### PR TITLE
fixed UnboundLocalError: local variable os ...

### DIFF
--- a/modules/machinery/kvmremote.py
+++ b/modules/machinery/kvmremote.py
@@ -7,6 +7,7 @@ import subprocess
 import xml.etree.ElementTree as ET
 import libvirt
 import logging
+import os
 
 from lib.cuckoo.common.abstracts import LibVirtMachinery
 from lib.cuckoo.common.exceptions import CuckooMachineError, CuckooCriticalError
@@ -97,7 +98,6 @@ class KVMRemote(LibVirtMachinery):
             try:
                 from subprocess import DEVNULL  # py3k
             except ImportError:
-                import os
                 DEVNULL = open(os.devnull, 'wb')
 
             # this triggers local dump


### PR DESCRIPTION
Fixed error  
Traceback (most recent call last):
  File "/opt/CAPEv2/modules/machinery/kvmremote.py", line 129, in dump_memory
    if not os.path.isfile(path):
UnboundLocalError: local variable 'os' referenced before assignment