### PR TITLE
Logging fixed to avoid TypeError

### DIFF
--- a/conf/cuckoo.conf
+++ b/conf/cuckoo.conf
@@ -150,7 +150,7 @@ vm_state = 300
 # Allows to activate log rotate for cuckoo.log and process.log
 enabled = on
 # Keep 30 days logs
-backupCount = 30
+backup_count = 30
 
 [ramfs]
 # only if you using volatility for conf extraction

--- a/lib/cuckoo/core/startup.py
+++ b/lib/cuckoo/core/startup.py
@@ -120,7 +120,7 @@ def init_logging():
     formatter = logging.Formatter("%(asctime)s [%(name)s] %(levelname)s: %(message)s")
 
     if cuckoo.logging.enabled:
-        days = cuckoo.logging.backupCount
+        days = cuckoo.logging.backup_count
         fh = logging.handlers.TimedRotatingFileHandler(os.path.join(CUCKOO_ROOT, "log", "cuckoo.log"), when="midnight", backupCount=days)
     else:
         fh = logging.handlers.WatchedFileHandler(os.path.join(CUCKOO_ROOT, "log", "cuckoo.log"))

--- a/modules/reporting/compressresults.py
+++ b/modules/reporting/compressresults.py
@@ -31,12 +31,20 @@ class CompressResults(Report):
 
         for keyword in ("CAPE", "procdump"):
             if keyword in results:
-                cape_json = json.dumps(results[keyword]).encode('utf8')
-                compressed_data = zlib.compress(cape_json)
-                results[keyword] = Binary(compressed_data)
-
+                try:
+                    cape_json = json.dumps(results[keyword]).encode('utf8')
+                    compressed_data = zlib.compress(cape_json)
+                    results[keyword] = Binary(compressed_data)
+                except UnicodeDecodeError as e:
+                    log.warn("Failed to compress {} result: {}".format(
+                        keyword, e.reason))
         # compress behaviour analysis (enhanced & summary)
-        for keyword in ("enhanced"):
-            if keyword in results["behavior"]:
-                compressed_behavior_enhanced = zlib.compress(JSONEncoder().encode(results["behavior"][keyword]).encode('utf8'))
-                results["behavior"][keyword] = Binary(compressed_behavior_enhanced)
+        if "enhanced" in results["behavior"]:
+            try:
+                compressed_behavior_enhanced = zlib.compress(
+                    JSONEncoder().encode(results["behavior"]["enhanced"]).encode('utf8'))
+                results["behavior"]["enhanced"] = Binary(
+                    compressed_behavior_enhanced)
+            except UnicodeDecodeError as e:
+                log.warn(
+                    "Failed to compress Enhanced Behaviour: {}".format(e.reason))

--- a/utils/process.py
+++ b/utils/process.py
@@ -155,7 +155,7 @@ def init_logging(auto=False, tid=0, debug=False):
         os.makedirs(os.path.join(CUCKOO_ROOT, "log"))
     if auto:
         if cfg.logging.enabled:
-            days = cfg.logging.backupCount
+            days = cfg.logging.backup_count
             fh = logging.handlers.TimedRotatingFileHandler(os.path.join(CUCKOO_ROOT, "log", "process.log"), when="midnight", backupCount=days)
         else:
             fh = logging.handlers.WatchedFileHandler(os.path.join(CUCKOO_ROOT, "log", "process.log"))


### PR DESCRIPTION
Those parameters cause this exception due to capital letter on backupCount variable.
--- Logging error ---
Traceback (most recent call last):
  File "/usr/lib/python3.6/logging/handlers.py", line 72, in emit
    self.doRollover()
  File "/usr/lib/python3.6/logging/handlers.py", line 397, in doRollover
    if self.backupCount > 0:
TypeError: '>' not supported between instances of 'NoneType' and 'int'
