### PR TITLE
[issue resolved] Trickbot config dumped on CAPEv2 host: python3.6.9 , guest:python3.7.2

### DIFF
--- a/lib/cuckoo/common/cape_utils.py
+++ b/lib/cuckoo/common/cape_utils.py
@@ -126,7 +126,6 @@ def convert(data):
 
 def static_config_parsers(yara_hit, file_data, cape_config):
     # Process CAPE Yara hits
-
         cape_name = yara_hit.replace('_', ' ')
         parser_loaded = False
         # Attempt to import a parser for the hit
@@ -138,7 +137,9 @@ def static_config_parsers(yara_hit, file_data, cape_config):
         if cape_name and HAS_MWCP and cape_name in malware_parsers:
             try:
                 reporter = mwcp.Reporter()
+                
                 reporter.run_parser(malware_parsers[cape_name], data=file_data)
+
                 if reporter.errors == []:
                     log.info("CAPE: Imported DC3-MWCP parser %s", cape_name)
                     parser_loaded = True
@@ -170,18 +171,20 @@ def static_config_parsers(yara_hit, file_data, cape_config):
                             log.info("CAPE: DC3-MWCP parser: %s", line.split(': ')[1])
                 reporter._Reporter__cleanup()
                 del reporter
-            except (ImportError, IndexError) as e:
+            except (ImportError, IndexError, TypeError) as e: # add TypeError
                 log.error(e)
 
             if not parser_loaded and cape_name in malware_parsers:
                 parser_loaded = True
                 try:
-                    cape_config = malware_parsers[cape_name].config(file_data)
-                    if isinstance(cape_config, list):
-                        for (key, value) in cape_config[0].items():
+                    cape_configraw = malware_parsers[cape_name].config(file_data) # changed from cape_config to cape_configraw because of avoiding overridden. duplicated value name.
+                    if isinstance(cape_configraw, list):
+                        for (key, value) in cape_configraw[0].items():
+                            if isinstance(value, map): value = list(value) #python3 map object returns iterator by default, not list and not serializeable in JSON.
                             cape_config["cape_config"].update({key: [value]})
-                    elif isinstance(cape_config, dict):
-                        for (key, value) in cape_config.items():
+                    elif isinstance(cape_configraw, dict):
+                        for (key, value) in cape_configraw.items():
+                            if isinstance(value, map): value = list(value) #python3 map object returns iterator by default, not list and not serializeable in JSON.
                             cape_config["cape_config"].update({key: [value]})
                 except Exception as e:
                     log.error("CAPE: parsing error with %s: %s", cape_name, e)

--- a/lib/cuckoo/common/cape_utils.py
+++ b/lib/cuckoo/common/cape_utils.py
@@ -171,20 +171,23 @@ def static_config_parsers(yara_hit, file_data, cape_config):
                             log.info("CAPE: DC3-MWCP parser: %s", line.split(': ')[1])
                 reporter._Reporter__cleanup()
                 del reporter
-            except (ImportError, IndexError, TypeError) as e: # add TypeError
+            except (ImportError, IndexError, TypeError) as e:
                 log.error(e)
 
             if not parser_loaded and cape_name in malware_parsers:
                 parser_loaded = True
                 try:
-                    cape_configraw = malware_parsers[cape_name].config(file_data) # changed from cape_config to cape_configraw because of avoiding overridden. duplicated value name.
+                    #changed from cape_config to cape_configraw because of avoiding overridden. duplicated value name.
+                    cape_configraw = malware_parsers[cape_name].config(file_data)
                     if isinstance(cape_configraw, list):
                         for (key, value) in cape_configraw[0].items():
-                            if isinstance(value, map): value = list(value) #python3 map object returns iterator by default, not list and not serializeable in JSON.
+                            #python3 map object returns iterator by default, not list and not serializeable in JSON.
+                            if isinstance(value, map): value = list(value)
                             cape_config["cape_config"].update({key: [value]})
                     elif isinstance(cape_configraw, dict):
                         for (key, value) in cape_configraw.items():
-                            if isinstance(value, map): value = list(value) #python3 map object returns iterator by default, not list and not serializeable in JSON.
+                            #python3 map object returns iterator by default, not list and not serializeable in JSON.
+                            if isinstance(value, map): value = list(value)
                             cape_config["cape_config"].update({key: [value]})
                 except Exception as e:
                     log.error("CAPE: parsing error with %s: %s", cape_name, e)

--- a/modules/processing/CAPE.py
+++ b/modules/processing/CAPE.py
@@ -72,7 +72,6 @@ UPX                  = 0x1000
 
 log = logging.getLogger(__name__)
 
-
 code_mapping = {
     PLUGX_PAYLOAD: "PlugX Payload",
     EVILGRAB_PAYLOAD: "EvilGrab Payload",
@@ -418,7 +417,6 @@ class CAPE(Processing):
 
         # Process CAPE Yara hits
         for hit in file_info["cape_yara"]:
-            log.info("LOADed CAPE.py IN process_file CAPE Yara hit! %s"%hit)
             # Check to see if file is packed with UPX
             if hit["name"] == "UPX":
                 log.info("CAPE: Found UPX Packed sample - attempting to unpack")
@@ -456,9 +454,9 @@ class CAPE(Processing):
         if cape_name:
             if "cape_config" in cape_config and "cape_name" not in cape_config:
                 cape_config["cape_name"] = format(cape_name)
-            if not "cape" in self.results:
+            if not "detections" in self.results:
                 if cape_name != "UPX":
-                    self.results["cape"] = cape_name
+                    self.results["detections"] = cape_name
 
         # Remove duplicate payloads from web ui
         for cape_file in CAPE_output:
@@ -522,7 +520,6 @@ class CAPE(Processing):
                 raise CuckooProcessingError("Sample file doesn't exist: \"%s\"" % self.file_path)
 
         self.process_file(self.file_path, CAPE_output, False, meta.get(self.file_path, {}))
-        log.info("cape_config %s"%cape_config)
         if "cape_config" in cape_config:
             CAPE_output.append(cape_config)
         

--- a/modules/processing/CAPE.py
+++ b/modules/processing/CAPE.py
@@ -72,6 +72,7 @@ UPX                  = 0x1000
 
 log = logging.getLogger(__name__)
 
+
 code_mapping = {
     PLUGX_PAYLOAD: "PlugX Payload",
     EVILGRAB_PAYLOAD: "EvilGrab Payload",
@@ -417,6 +418,7 @@ class CAPE(Processing):
 
         # Process CAPE Yara hits
         for hit in file_info["cape_yara"]:
+            log.info("LOADed CAPE.py IN process_file CAPE Yara hit! %s"%hit)
             # Check to see if file is packed with UPX
             if hit["name"] == "UPX":
                 log.info("CAPE: Found UPX Packed sample - attempting to unpack")
@@ -454,9 +456,9 @@ class CAPE(Processing):
         if cape_name:
             if "cape_config" in cape_config and "cape_name" not in cape_config:
                 cape_config["cape_name"] = format(cape_name)
-            if not "detections" in self.results:
+            if not "cape" in self.results:
                 if cape_name != "UPX":
-                    self.results["detections"] = cape_name
+                    self.results["cape"] = cape_name
 
         # Remove duplicate payloads from web ui
         for cape_file in CAPE_output:
@@ -520,7 +522,8 @@ class CAPE(Processing):
                 raise CuckooProcessingError("Sample file doesn't exist: \"%s\"" % self.file_path)
 
         self.process_file(self.file_path, CAPE_output, False, meta.get(self.file_path, {}))
+        log.info("cape_config %s"%cape_config)
         if "cape_config" in cape_config:
             CAPE_output.append(cape_config)
-
+        
         return CAPE_output

--- a/modules/processing/parsers/CAPE/TrickBot.py
+++ b/modules/processing/parsers/CAPE/TrickBot.py
@@ -165,9 +165,9 @@ def config(data):
             tag = child.tag
 
         if tag == 'autorun':
-            val = (map(lambda x: x.items(), child.getchildren()))
+            val = list(map(lambda x: x.items(), child.getchildren()))
         elif tag == 'servs':
-            val = (map(lambda x: x.text, child.getchildren()))
+            val = list(map(lambda x: x.text, child.getchildren()))
         else:
             val = child.text
 

--- a/modules/processing/parsers/CAPE/TrickBot.py
+++ b/modules/processing/parsers/CAPE/TrickBot.py
@@ -165,7 +165,7 @@ def config(data):
             tag = child.tag
 
         if tag == 'autorun':
-            val = str(map(lambda x: x.items(), child.getchildren()))
+            val = (map(lambda x: x.items(), child.getchildren()))
         elif tag == 'servs':
             val = (map(lambda x: x.text, child.getchildren()))
         else:


### PR DESCRIPTION
Hi 

I rewrote the CAPE parser specification to extract the Trickbot config from the process dump memory in order to run on CAPEv2 python environment (e.g host: python3.6.9 , guest:python 3.7.2).

Malware config dumping from "procdump_path" had been enabled on this commit of today.
https://github.com/kevoreilly/CAPEv2/commit/75b987a2a45c0dacc1de9120682c4d07c59eab51
CAPE.py
`                        #else:
                        else:
                            # We set append_file to False as we don't wan't to include
                            # the files by default in the CAPE tab
                            #self.process_file(file_path, CAPE_output, False)
                            self.process_file(file_path, CAPE_output, False)`


Thus my code is just for adjusting my purpose to python3 env.

Best Regards,
Tatsuya