### PR TITLE
Update zip.py

### DIFF
--- a/analyzer/windows/modules/packages/zip.py
+++ b/analyzer/windows/modules/packages/zip.py
@@ -49,6 +49,17 @@ class Zip(Package):
 
         # Extraction.
         with ZipFile(zip_path, "r") as archive:
+
+            # Check if the archive is encrypted
+            for zip_info in archive.infolist():
+                is_encrypted = zip_info.flag_bits & 0x1
+                # If encrypted and the user didn't provide a password 
+                # set to default value
+                if is_encrypted and password == b"":
+                    log.debug("Achive is encrypted and user did not provide a password, using default value: infected")
+                    password = b"infected"
+                # Else, either password stays as user specified or archive is not encrypted
+                    
             try:
                 archive.extractall(path=extract_path, pwd=password)
             except BadZipfile:
@@ -102,7 +113,7 @@ class Zip(Package):
         root = os.environ["TEMP"]
         password = self.options.get("password")
         if password is None:
-            password = b""
+            password = b"infected"
         exe_regex = re.compile('(\.exe|\.dll|\.scr|\.msi|\.bat|\.lnk|\.js|\.jse|\.vbs|\.vbe|\.wsf)$',flags=re.IGNORECASE)
         zipinfos = self.get_infos(path)
         self.extract_zip(path, root, password, 0)

--- a/analyzer/windows/modules/packages/zip.py
+++ b/analyzer/windows/modules/packages/zip.py
@@ -113,7 +113,7 @@ class Zip(Package):
         root = os.environ["TEMP"]
         password = self.options.get("password")
         if password is None:
-            password = b"infected"
+            password = b""
         exe_regex = re.compile('(\.exe|\.dll|\.scr|\.msi|\.bat|\.lnk|\.js|\.jse|\.vbs|\.vbe|\.wsf)$',flags=re.IGNORECASE)
         zipinfos = self.get_infos(path)
         self.extract_zip(path, root, password, 0)

--- a/analyzer/windows/modules/packages/zip.py
+++ b/analyzer/windows/modules/packages/zip.py
@@ -28,7 +28,7 @@ class Zip(Package):
              ("SystemRoot", "sysnative", "WindowsPowerShell", "v1.0", "powershell.exe"),
              ("SystemRoot", "system32", "xpsrchvw.exe"),
             ]
-    def extract_zip(self, zip_path, extract_path, password=b"intefected", recursion_depth=1):
+    def extract_zip(self, zip_path, extract_path, password=b"infected", recursion_depth=1):
         """Extracts a nested ZIP file.
         @param zip_path: ZIP path
         @param extract_path: where to extract
@@ -101,6 +101,8 @@ class Zip(Package):
     def start(self, path):
         root = os.environ["TEMP"]
         password = self.options.get("password")
+        if password is None:
+            password = b""
         exe_regex = re.compile('(\.exe|\.dll|\.scr|\.msi|\.bat|\.lnk|\.js|\.jse|\.vbs|\.vbe|\.wsf)$',flags=re.IGNORECASE)
         zipinfos = self.get_infos(path)
         self.extract_zip(path, root, password, 0)


### PR DESCRIPTION
- Typo in predefined password: "intefected" rather than "infected"

- If password is not specified in CAPE arguments, password variable is type None, which causes exception on line 48 when we use the .encode() function. Proposed solution is to set the password to blank string if none is specified.

You could also set the value to an empty string when the arguments are created... but I don't know that area of the code!