### PR TITLE
Fix race conditions in Proxmox and our module

### DIFF
--- a/modules/machinery/proxmox.py
+++ b/modules/machinery/proxmox.py
@@ -27,8 +27,6 @@ class Proxmox(Machinery):
     """Manage Proxmox sandboxes."""
     def __init__(self):
         super(Proxmox, self).__init__()
-        self.node = None
-        self.vm = None
         self.timeout = int(cfg.timeouts.vm_state)
 
     def _initialize_check(self):
@@ -46,7 +44,7 @@ class Proxmox(Machinery):
         super(Proxmox, self)._initialize_check()
 
     def find_vm(self, label):
-        """Find a VM in the Proxmox cluster and remember its node and vm proxy
+        """Find a VM in the Proxmox cluster and return its node and vm proxy
         objects for extraction of additional data by other methods.
 
         @param label: the label of the VM to be compared to the VM's name in
@@ -74,46 +72,61 @@ class Proxmox(Machinery):
                 vm = hv.__getattr__(str(vm["vmid"]))
 
                 # remember various request proxies for subsequent actions
-                self.node = node
-                self.vm = vm
-                return
+                return vm, node
 
         raise CuckooMachineError("Not found")
 
-    def wait_for_task(self, taskid):
+    def wait_for_task(self, taskid, label, vm, node):
         """Wait for long-running Proxmox task to finish.
-
-        Only to be called after successfully having called find_vm() or having
-        otherwise initialised the Proxmox node object to work against.
 
         @param taskid: id of Proxmox task to wait for
         @raise CuckooMachineError: if task status cannot be determined."""
-        if not self.node:
-            raise CuckcooMachineError(
-                "BUG: Target Proxmox node not initialized.")
-
         elapsed = 0
         while elapsed < self.timeout:
             try:
-                task = self.node.tasks(taskid).status.get()
+                task = node.tasks(taskid).status.get()
             except ResourceException as e:
                 raise CuckooMachineError("Error getting status of task "
                                          "%s: %s" % (taskid, e))
 
-            if task["status"] == "stopped":
-                return task
+            # extract operation name from task status for display
+            operation = task["type"]
+            if operation.startswith("qm"):
+                operation = operation[2:]
 
-            log.debug("Waiting for task %s to finish: %s", taskid, task)
-            time.sleep(1)
-            elapsed += 1
+            if task["status"] != "stopped":
+                log.debug("%s: Waiting for operation %s (%s) to finish",
+                          label, operation, taskid)
+                time.sleep(1)
+                elapsed += 1
+                continue
 
+            # VMs sometimes remain locked for some seconds after a task
+            # completed. They will get stuck in that state if another operation
+            # is attempted. So query the current VM status to extract the lock
+            # status.
+            try:
+                status = vm.status.current.get()
+            except ResourceException as e:
+                raise CuckooMachineError("Couldn't get status: %s" % e)
+
+            if "lock" in status:
+                log.debug("%s: Task finished but VM still locked", label)
+                if status["lock"] != operation:
+                    log.warning("%s: Task finished but VM locked by different "
+                                "operation: %s", label, operation)
+                time.sleep(1)
+                elapsed += 1
+                continue
+
+            # task is really, really done
+            return task
+
+        # timeout expired
         return None
 
-    def find_snapshot(self, label):
+    def find_snapshot(self, label, vm):
         """Find a specific or the most current snapshot of a VM.
-
-        Only to be called after successfully having called find_vm() or having
-        otherwise initialised the VM object to work against.
 
         @param label: VM label for additional parameter retrieval
         @raise CuckooMachineError: if snapshots cannot be enumerated."""
@@ -123,15 +136,12 @@ class Proxmox(Machinery):
         if snapshot:
             return snapshot
 
-        if not self.vm:
-            raise CuckcooMachineError("BUG: Target VM not initialized.")
-
         # heuristically determine the most recent snapshot if no snapshot name
         # is explicitly configured.
-        log.debug("No snapshot configured for VM %s, determining most recent "
-                  "one", label)
+        log.debug("%s: No snapshot configured, determining most recent one",
+                  label)
         try:
-            snapshots = self.vm.snapshot.get()
+            snapshots = vm.snapshot.get()
         except ResourceException as e:
             raise CuckooMachineError("Error enumerating snapshots: %s" % e)
 
@@ -148,7 +158,7 @@ class Proxmox(Machinery):
 
         return snapshot
 
-    def rollback(self, label):
+    def rollback(self, label, vm, node):
         """Roll back a VM's status to a statically configured or the most recent
         snapshot.
 
@@ -157,19 +167,18 @@ class Proxmox(Machinery):
         @raise CuckooMachineError: if snapshot cannot be found, reverting the
                                    machine to the snapshot cannot be triggered
                                    or times out or fails for another reason."""
-
-        snapshot = self.find_snapshot(label)
+        snapshot = self.find_snapshot(label, vm)
         if not snapshot:
             raise CuckooMachineError("No snapshot found - check config")
 
         try:
-            log.debug("Reverting VM %s to snapshot %s", label, snapshot)
-            taskid = self.vm.snapshot(snapshot).rollback.post()
+            log.debug("%s: Reverting to snapshot %s", label, snapshot)
+            taskid = vm.snapshot(snapshot).rollback.post()
         except ResourceException as e:
             raise CuckooMachineError("Couldn't trigger rollback to "
                                      "snapshot %s: %s" % (snapshot, e))
 
-        task = self.wait_for_task(taskid)
+        task = self.wait_for_task(taskid, label, vm, node)
         if not task:
             raise CuckooMachineError("Timeout expired while rolling back to "
                                      "snapshot %s" % snapshot)
@@ -187,25 +196,26 @@ class Proxmox(Machinery):
                                    machine to the snapshot or starting the VM
                                    cannot be triggered or times out or fails
                                    for another reason."""
-        self.find_vm(label)
-        self.rollback(label)
+        vm, node = self.find_vm(label)
+        self.rollback(label, vm, node)
 
         try:
-            status = self.vm.status.current.get()
+            status = vm.status.current.get()
         except ResourceException as e:
             raise CuckooMachineError("Couldn't get status: %s" % e)
 
         if status["status"] == "running":
-            log.debug("VM already running after rollback, no need to start it")
+            log.debug("%s: Already running after rollback, no need to start "
+                      "it", label)
             return
 
         try:
-            log.debug("Starting VM %s", label)
-            taskid = self.vm.status.start.post()
+            log.debug("%s: Starting VM", label)
+            taskid = vm.status.start.post()
         except ResourceException as e:
             raise CuckooMachineError("Couldn't trigger start: %s" % e)
 
-        task = self.wait_for_task(taskid)
+        task = self.wait_for_task(taskid, label, vm, node)
         if not task:
             raise CuckooMachineError("Timeout expired while starting")
         if task["exitstatus"] != "OK":
@@ -218,15 +228,15 @@ class Proxmox(Machinery):
         @raise CuckooMachineError: if VM cannot be found or stopping it cannot
                                    be triggered or times out or fails for
                                    another reason."""
-        self.find_vm(label)
+        vm, node = self.find_vm(label)
 
         try:
-            log.debug("Stopping VM %s", label)
-            taskid = self.vm.status.stop.post()
+            log.debug("%s: Stopping VM", label)
+            taskid = vm.status.stop.post()
         except ResourceException as e:
             raise CuckooMachineError("Couldn't trigger stop: %s" % e)
 
-        task = self.wait_for_task(taskid)
+        task = self.wait_for_task(taskid, label, vm, node)
         if not task:
             raise CuckooMachineError("Timeout expired while stopping")
         if task["exitstatus"] != "OK":


### PR DESCRIPTION
Hi,

here's the latest changes from my PR against cuckoo (cuckoosandbox/cuckoo#2723), tested and found to be working with current master. Thanks for adding it here! :)

VMs sometimes remain locked for some seconds after a task completed.
They will get stuck in that state if another operation is attempted. So
query the current VM status to extract the lock status to continue
waiting for it to disappear.

Also, our machinery module was carrying internal state which got
corrupted under load. Switch to local variables throughout.
