### PR TITLE
added aws code

### DIFF
--- a/conf/aws.conf
+++ b/conf/aws.conf
@@ -1,0 +1,136 @@
+[aws]
+
+# All data in here is default, change it for your needs.
+# follow this link to set up the AWS cluster https://github.com/CheckPointSW/Cuckoo-AWS
+# this can be done for free using free tire
+
+# Specify the AWS Region (for example, us-west-1)
+region_name = us-west-2
+
+# Specify the Availability Zone(for example, us-west-1a) to create a new volume (used at machine's restoration).
+availability_zone = us-west-2a
+
+# Access keys consist of two parts: an access key ID (for example, AKIAIOSFODNN7EXAMPLE)
+# and a secret access key (for example, wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY).
+# To create access keys for your AWS account root user, you must use the AWS Management Console.
+aws_access_key_id =
+aws_secret_access_key =
+
+# Specify a comma-separated list of available machines to be used.
+# Each machine will be represented by the instance-id (for example, i-05f07711c635f817f).
+# For each specified instance-id you have to define a dedicated section containing the details
+# on the respective machine. (E.g. i-05f07711c635f817f,i-04d465547cba1af5e)
+# For better performance, it is recommended to leave this empty and set autoscale = yes.
+machines = i-0abcd12346778a
+
+
+# Default network interface.
+interface = eth0
+
+# To improve the performance, running_machines_gap is number of machines that are ready to perform a task (up and running).
+# running_machines_gap is the size of a pool which contains machines that were already started in advance.
+# Whenever a machine from the pool starts a task, the machinery will start another new machine.
+# In a scenario where all the list of machines are occupied, and autoscale mode is on, the machinery will instantly
+# scale up by creating new machines.
+# Thus, there will always be a constant number of ready machines for the user's requests.
+# It is recommended to set this value to 1 and above.
+running_machines_gap = 1
+
+# In a scenario where all the configured machines are occupied, the machinery will instantly scale up by creating
+# new machines and adding them to the Cuckoo internal database (DB). The new machines will be terminated after use.
+# The user can choose to prepare any number of machines, but does not have to (if autoscale in on).
+[autoscale]
+
+# Enable auto-scale in cuckoo(by setting autoscale = yes). recommended for better performance.
+autoscale = no
+
+# Specify the maximum number of online machines that was created as a result of auto-scale operation.
+# Once reaching that limit, cuckoo will create a new machine only if another was terminated.
+# This limit prevents a situation of creating machine beyond the subnet capacity.
+dynamic_machines_limit = 10
+
+# Specify the Amazon Machine Image (AMI). It required to launch a new instance.
+# You should create an image from the guest machine.
+image_id =
+
+# Specify the machine's instance type(for example, t2.small)
+instance_type = t2.medium
+
+# Specify the subnet id where the machines will be placed
+subnet_id =
+
+# Specify a comma-separated list of security groups IDs that will be associated with the machines.
+# On the Cuckoo default settings ,the security groups must allow tcp ports 2042,8000 and 8090 on the inbound.
+security_groups =
+
+# Specify the operating system platform used by the new machine
+# [windows/darwin/linux].
+platform = windows
+
+# Default network interface.
+interface =
+
+# Mostly unused for now. Please don't fill it out.
+options =
+
+# (Optional) Set your own tags. These are comma separated and help to identify
+# specific VMs. You can run samples on VMs with tag you require.
+tags =
+
+# Specify the IP of the Result Server, as your virtual machine sees it.
+# It should be the nest ip address.
+resultserver_ip =
+
+# Specify a port number to bind the result server on.
+resultserver_port = 2042
+
+
+# This section is just a template for one pre-configured machine, if you choose to use it.
+# For better performance, it is best to leave it blank and let the auto-scaling to control the machines.
+
+[i-0abcd12346778a]
+# Specify the label name.
+# Label would be the instance-id of the current machine as specified in your AWS account.
+label = i-0abcd12346778a
+
+# Specify the operating system platform used by current machine
+# [windows/darwin/linux].
+platform = windows
+
+# Specify the IP address of the current virtual machine. Make sure that the
+# IP address is valid and that the host machine is able to reach it. If not,
+# the analysis will fail.
+ip = 172.3.3.4
+
+# Specify the snapshot-id to use. it is used when creating a new volume when restoring a machine.
+# You should create a snapshot from the guest machine.
+snapshot = snap-0abcdefghtc875
+
+# (Optional) Specify the name of the network interface that should be used
+# when dumping network traffic from this machine with tcpdump. If specified,
+# overrides the default interface specified above.
+# Example (eth0 is the interface name):
+interface = eth0
+
+# (Optional) Specify the IP of the Result Server, as your virtual machine sees it.
+# The Result Server will always bind to the address and port specified in cuckoo.conf,
+# however you could set up your virtual network to use NAT/PAT, so you can specify here
+# the IP address for the Result Server as your machine sees it. If you don't specify an
+# address here, the machine will use the default value from cuckoo.conf.
+# NOTE: if you set this option you have to set result server IP to 0.0.0.0 in cuckoo.conf.
+# Example:
+resultserver_ip = 172.3.3.4
+
+# (Optional) Specify the port for the Result Server, as your virtual machine sees it.
+# The Result Server will always bind to the address and port specified in cuckoo.conf,
+# however you could set up your virtual network to use NAT/PAT, so you can specify here
+# the port for the Result Server as your machine sees it. If you don't specify a port
+# here, the machine will use the default value from cuckoo.conf.
+resultserver_port =
+
+# (Optional) Set your own tags. These are comma separated and help to identify
+# specific VMs. You can run samples on VMs with tag you require.
+#tags =
+
+# Mostly unused for now. Please don't fill it out.
+#options =

--- a/modules/machinery/aws.py
+++ b/modules/machinery/aws.py
@@ -1,0 +1,384 @@
+from __future__ import absolute_import
+
+import logging
+import time
+import boto3
+
+from lib.cuckoo.common.abstracts import Machinery
+from lib.cuckoo.common.config import Config
+from lib.cuckoo.common.exceptions import CuckooCriticalError
+from lib.cuckoo.common.exceptions import CuckooMachineError
+
+logging.getLogger("boto3").setLevel(logging.CRITICAL)
+logging.getLogger("botocore").setLevel(logging.CRITICAL)
+log = logging.getLogger(__name__)
+
+class AWS(Machinery):
+    """Virtualization layer for AWS."""
+
+    # VM states.
+    PENDING = "pending"
+    STOPPING = "stopping"
+    RUNNING = "running"
+    POWEROFF = "poweroff"
+    ERROR = "machete"
+
+    AUTOSCALE_CUCKOO = "AUTOSCALE_CUCKOO"
+
+    def __init__(self):
+        super(AWS, self).__init__()
+
+    """override Machinery method"""
+
+    def _initialize_check(self):
+        """
+        Looking for all EC2 machines that match aws.conf and load them into EC2_MACHINES dictionary.
+        """
+        self.ec2_machines = {}
+        self.dynamic_machines_sequence = 0
+        self.dynamic_machines_count = 0
+        log.info("connecting to AWS:{}".format(self.options.aws.region_name))
+        self.ec2_resource = boto3.resource(
+            "ec2", region_name=self.options.aws.region_name, aws_access_key_id=self.options.aws.aws_access_key_id,
+            aws_secret_access_key=self.options.aws.aws_secret_access_key)
+
+        # Iterate over all instances with tag that has a key of AUTOSCALE_CUCKOO
+        for instance in self.ec2_resource.instances.filter(Filters=[{"Name": "instance-state-name",
+                                                                     "Values": ["running", "stopped", "stopping"]}]):
+            if self._is_autoscaled(instance):
+                log.info("Terminating autoscaled instance %s" % instance.id)
+                instance.terminate()
+
+        instance_ids = self._list()
+        machines = self.machines()
+        for machine in machines:
+            if machine.label not in instance_ids:
+                continue
+            self.ec2_machines[machine.label] = self.ec2_resource.Instance(machine.label)
+            if self._status(machine.label) != AWS.POWEROFF:
+                self.stop(label=machine.label)
+
+        self._start_or_create_machines()
+
+    def _start_next_machines(self, num_of_machines_to_start):
+        """
+        pull from DB the next machines in queue and starts them
+        the whole idea is to prepare x machines on, so once a task will arrive - the machine will be ready with windows
+        already launched.
+        :param num_of_machines_to_start: how many machines(first in queue) will be started
+        """
+        for machine in self.db.get_available_machines():
+            if num_of_machines_to_start <= 0:
+                break
+            if self._status(machine.label) in [AWS.POWEROFF, AWS.STOPPING]:
+                self.ec2_machines[machine.label].start()  # not using self.start() to avoid _wait_ method
+                num_of_machines_to_start -= 1
+
+    def _delete_machine_form_db(self, label):
+        """
+        cuckoo's DB class does not implement machine deletion, so we made one here
+        :param label: the machine label
+        """
+        session = self.db.Session()
+        try:
+            from lib.cuckoo.core.database import Machine
+            machine = session.query(Machine).filter_by(label=label).first()
+            if machine:
+                session.delete(machine)
+                session.commit()
+        except SQLAlchemyError as e:
+            log.debug("Database error removing machine: {0}".format(e))
+            session.rollback()
+            return
+        finally:
+            session.close()
+
+    def _allocate_new_machine(self):
+        """
+        allocating/creating new EC2 instance(autoscale option)
+        """
+        # read configuration file
+        machinery_options = self.options.get("aws")
+        autoscale_options = self.options.get("autoscale")
+        # If configured, use specific network interface for this
+        # machine, else use the default value.
+        interface = autoscale_options["interface"] if autoscale_options.get("interface") else machinery_options.get(
+            "interface")
+        resultserver_ip = autoscale_options["resultserver_ip"] if autoscale_options.get("resultserver_ip") else Config(
+            "cuckoo:resultserver:ip")
+        if autoscale_options.get("resultserver_port"):
+            resultserver_port = autoscale_options["resultserver_port"]
+        else:
+            # The ResultServer port might have been dynamically changed,
+            # get it from the ResultServer singleton. Also avoid import
+            # recursion issues by importing ResultServer here.
+            from lib.cuckoo.core.resultserver import ResultServer
+            resultserver_port = ResultServer().port
+
+        log.info("All machines are busy, allocating new machine")
+        self.dynamic_machines_sequence += 1
+        self.dynamic_machines_count += 1
+        new_machine_name = "cuckoo_autoscale_%03d" % self.dynamic_machines_sequence
+        instance = self._create_instance(
+            tags=[{"Key": "Name", "Value": new_machine_name},
+                  {"Key": self.AUTOSCALE_CUCKOO, "Value": "True"}]
+        )
+        if instance is None:
+            return False
+
+        self.ec2_machines[instance.id] = instance
+        #  sets "new_machine" object in configuration object to avoid raising an exception
+        setattr(self.options, new_machine_name, {})
+        # add machine to DB
+        self.db.add_machine(
+            name=new_machine_name,
+            label=instance.id,
+            ip=instance.private_ip_address,
+            platform=autoscale_options["platform"],
+            options=autoscale_options["options"],
+            tags=autoscale_options["tags"],
+            interface=interface,
+            snapshot=None,
+            resultserver_ip=resultserver_ip,
+            resultserver_port=resultserver_port
+        )
+        return True
+
+    """override Machinery method"""
+
+    def acquire(self, machine_id=None, platform=None, tags=None):
+        """
+        override Machinery method to utilize the auto scale option
+        """
+        base_class_return_value = super(AWS, self).acquire(machine_id, platform, tags)
+        self._start_or_create_machines()  # prepare another machine
+        return base_class_return_value
+
+    def _start_or_create_machines(self):
+        """
+        checks if x(according to "gap" in aws config) machines can be immediately started.
+        If autoscale is enabled and less then x can be started - > create new instances to complete the gap
+        :return:
+        """
+
+        # read configuration file
+        machinery_options = self.options.get("aws")
+        autoscale_options = self.options.get("autoscale")
+
+        current_available_machines = self.db.count_machines_available()
+        running_machines_gap = machinery_options.get("running_machines_gap", 0)
+        dynamic_machines_limit = autoscale_options["dynamic_machines_limit"]
+
+        self._start_next_machines(num_of_machines_to_start=min(current_available_machines, running_machines_gap))
+        #  if no sufficient machines left  -> launch a new machines
+        while autoscale_options["autoscale"] and current_available_machines < running_machines_gap:
+            if self.dynamic_machines_count >= dynamic_machines_limit:
+                log.debug("Reached dynamic machines limit - %d machines" % dynamic_machines_limit)
+                break
+            if not self._allocate_new_machine():
+                break
+            current_available_machines += 1
+
+    """override Machinery method"""
+
+    def _list(self):
+        """
+        :return: A list of all instance ids under the AWS account
+        """
+        instances = self.ec2_resource.instances.filter(Filters=[{"Name": "instance-state-name",
+                                                                 "Values": ["running", "stopped", "stopping"]}])
+        return [instance.id for instance in instances]
+
+    """override Machinery method"""
+
+    def _status(self, label):
+        """
+        Gets current status of a vm.
+        @param label: virtual machine label.
+        @return: status string.
+        """
+        try:
+            self.ec2_machines[label].reload()
+            state = self.ec2_machines[label].state["Name"]
+            if state == "running":
+                status = AWS.RUNNING
+            elif state == "stopped":
+                status = AWS.POWEROFF
+            elif state == "pending":
+                status = AWS.PENDING
+            elif state == "stopping":
+                status = AWS.STOPPING
+            elif state in ["shutting-down", "terminated"]:
+                status = AWS.ERROR
+            else:
+                status = AWS.ERROR
+            log.info("instance state: {}".format(status))
+            return status
+        except Exception as e:
+            log.exception("can't retrieve the status: {}".format(e))
+            return AWS.ERROR
+
+    """override Machinery method"""
+
+    def start(self, label, task):
+        """
+        Start a virtual machine.
+        @param label: virtual machine label.
+        @param task: task object.
+        @raise CuckooMachineError: if unable to start.
+        """
+        log.debug("Starting vm {}".format(label))
+
+        if not self._is_autoscaled(self.ec2_machines[label]):
+            self.ec2_machines[label].start()
+            self._wait_status(label, AWS.RUNNING)
+
+    """override Machinery method"""
+
+    def stop(self, label):
+        """
+        Stops a virtual machine.
+        If the machine has initialized from autoscaled component, then terminate it.
+        @param label: virtual machine label.
+        @raise CuckooMachineError: if unable to stop.
+        """
+        log.debug("Stopping vm %s" % label)
+
+        status = self._status(label)
+
+        if status == AWS.POWEROFF:
+            raise CuckooMachineError(
+                "Trying to stop an already stopped VM: %s" % label
+            )
+
+        if self._is_autoscaled(self.ec2_machines[label]):
+            self.ec2_machines[label].terminate()
+            self._delete_machine_form_db(label)
+            self.dynamic_machines_count -= 1
+        else:
+            self.ec2_machines[label].stop(Force=True)
+            self._wait_status(label, AWS.POWEROFF)
+            self._restore(label)
+
+    """override Machinery method"""
+
+    def release(self, label=None):
+        """
+        we override it to have the ability to run start_or_create_machines() after unlocking the last machine
+        Release a machine.
+        @param label: machine label.
+        """
+        super(AWS, self).release(label)
+        self._start_or_create_machines()
+
+    def _create_instance(self, tags):
+        """
+        create a new instance
+        :param tags: tags to attach to instance
+        :return: the instance id
+        """
+
+        autoscale_options = self.options.get("autoscale")
+        response = self.ec2_resource.create_instances(
+            BlockDeviceMappings=[
+                {"DeviceName": "/dev/sda1", "Ebs": {"DeleteOnTermination": True, "VolumeType": "gp2"}}],
+            ImageId=autoscale_options["image_id"],
+            InstanceType=autoscale_options["instance_type"],
+            MaxCount=1,
+            MinCount=1,
+            NetworkInterfaces=[{
+                "DeviceIndex": 0,
+                "SubnetId": autoscale_options["subnet_id"],
+                "Groups": autoscale_options["security_groups"],
+            }],
+            TagSpecifications=[{"ResourceType": "instance", "Tags": tags}])
+        new_instance = response[0]
+        new_instance.modify_attribute(SourceDestCheck={'Value': False})
+        log.debug("Created %s\n%s", new_instance.id, repr(response))
+        return new_instance
+
+    def _is_autoscaled(self, instance):
+        """
+        checks if the instance has a tag that indicates that it was created as a result of autoscaling
+        :param instance: instance object
+        :return: true if the instance in "autoscaled"
+        """
+        if instance.tags:
+            for tag in instance.tags:
+                if tag.get("Key") == self.AUTOSCALE_CUCKOO:
+                    return True
+        return False
+
+    def _restore(self, label):
+        """
+        restore the instance according to the configured snapshot(aws.conf)
+        This method detaches and deletes the current volume, then creates a new one and attaches it.
+        :param label: machine label
+        """
+        log.info("restoring machine: {}".format(label))
+        vm_info = self.db.view_machine_by_label(label)
+        snap_id = vm_info.snapshot
+        instance = self.ec2_machines[label]
+        state = self._status(label)
+        if state != AWS.POWEROFF:
+            raise CuckooMachineError(
+                 "Instance '%s' state '%s' is not poweroff" % (label, state)
+            )
+        volumes = list(instance.volumes.all())
+        if len(volumes) != 1:
+            raise CuckooMachineError(
+                "Instance '%s' has wrong number of volumes %d" % (label, len(volumes))
+            )
+        old_volume = volumes[0]
+
+        log.debug("Detaching %s", old_volume.id)
+        resp = instance.detach_volume(VolumeId=old_volume.id, Force=True)
+        log.debug('response: {}'.format(resp))
+        while True:
+            old_volume.reload()
+            if old_volume.state != 'in-use':
+                break
+            time.sleep(1)
+
+        log.debug("Old volume %s in state %s", old_volume.id, old_volume.state)
+        if old_volume.state != 'available':
+            raise CuckooMachineError(
+                "Old volume turned into state %s instead of 'available'" % old_volume.state
+            )
+        log.debug('Deleting old volume')
+        volume_type = old_volume.volume_type
+        old_volume.delete()
+
+        log.debug("Creating new volume")
+        new_volume = self.ec2_resource.create_volume(
+            SnapshotId=snap_id,
+            AvailabilityZone=instance.placement['AvailabilityZone'],
+            VolumeType=volume_type)
+        log.debug("Created new volume %s", new_volume.id)
+        while True:
+            new_volume.reload()
+            if new_volume.state != 'creating':
+                break
+            time.sleep(1)
+        log.debug("new volume %s in state %s", new_volume.id, new_volume.state)
+        if new_volume.state != 'available':
+            state = new_volume.state
+            new_volume.delete()
+            raise CuckooMachineError(
+                "New volume turned into state %s instead of 'available'" % state
+            )
+
+        log.debug('Attaching new volume')
+        resp = instance.attach_volume(VolumeId=new_volume.id, Device="/dev/sda1")
+        log.debug('response {}'.format(resp))
+        while True:
+            new_volume.reload()
+            if new_volume.state != 'available':
+                break
+            time.sleep(1)
+        log.debug("new volume %s in state %s", new_volume.id, new_volume.state)
+        if new_volume.state != 'in-use':
+            new_volume.delete()
+            raise CuckooMachineError(
+                 "New volume turned into state %s instead of 'in-use'" % old_volume.state
+            )

--- a/modules/machinery/aws.py
+++ b/modules/machinery/aws.py
@@ -220,11 +220,10 @@ class AWS(Machinery):
 
     """override Machinery method"""
 
-    def start(self, label, task):
+    def start(self, label):
         """
         Start a virtual machine.
         @param label: virtual machine label.
-        @param task: task object.
         @raise CuckooMachineError: if unable to start.
         """
         log.debug("Starting vm {}".format(label))


### PR DESCRIPTION
Added AWS conf file as well as aws.py code for machinery. To test or set this up:

``` 
1. Edit ".cuckoo/conf/cuckoo.conf"
   machinery = aws
   [resultserver] ip = <the private IP of this machine>
2. Edit ".cuckoo/conf/aws.conf" according to the instructions in the file
```
• It is recommended to run guest VMs on 64-bit Windows 7. Create a guest Windows 7 64 bit VM and import this into AWS using the following guide: VM to AMI using this manual. https://docs.aws.amazon.com/vm-import/latest/userguide/vmimport-image-import.html

• Launch a new Windows 7 instance to set up the guest

• Install Python and Pillow library https://cuckoo.sh/docs/installation/guest/requirements.html

• Disable Windows Firewall and the Automatic Updates https://cuckoo.sh/docs/installation/guest/network.html

• Install Cuckoo agent https://cuckoo.sh/docs/installation/guest/agent.html

• For malware network analysis, each guest should have the Nest as their default route

• Save this instance as a new image(AMI). This action will also create a new snapshot(snapshot-id can be found under the AMI details.) Add this snap-shot ID to the aws.conf as shown in the code.

Reference to: #219 


