### PR TITLE
Resolve KeyError while using /api/ w/ dist.py

### DIFF
--- a/utils/api.py
+++ b/utils/api.py
@@ -709,9 +709,9 @@ def machines_list():
 
     machines = db.list_machines()
 
-    response["machines"] = []
+    response["data"] = []
     for row in machines:
-        response["machines"].append(row.to_dict())
+        response["data"].append(row.to_dict())
 
     return jsonize(response)
 

--- a/utils/dist.py
+++ b/utils/dist.py
@@ -131,7 +131,7 @@ def node_fetch_tasks(status, url, ht_user, ht_pass, action="fetch", since=0):
 def node_list_machines(url, ht_user, ht_pass):
     try:
         r = requests.get(os.path.join(url, "machines", "list"), params={"username": ht_user, "password": ht_pass}, verify=False)
-        for machine in r.json()["machines"]:
+        for machine in r.json()["data"]:
             yield Machine(name=machine["name"], platform=machine["platform"], tags=machine["tags"])
     except Exception as e:
         abort(404, message="Invalid Cuckoo node (%s): %s" % (url, e))


### PR DESCRIPTION
This pull request resolves a KeyError exception while using dist.py w/ /api/.  Also included change to update the deprecated api.py as well.

**Issue:**

When trying to register a new node w/ the webui API the following is returned:
`{"message": "Invalid Cuckoo node (http://<MASTER_IP>:8000/api/): 'machines'"}`

This is a KeyError exception as the response does not have the key "machines" but rather has the key "data".

**Steps to reproduce:**

1. Ensure that dist.py is running.
2. Run the following command to register a node:
`curl http://localhost:9003/node -F name=master -F url=http://<MASTER_IP>:8000/api/`
