### PR TITLE
tarfile in python 3.8 requires BytesIO 

### DIFF
--- a/web/api/views.py
+++ b/web/api/views.py
@@ -19,7 +19,7 @@ from django.shortcuts import render, redirect
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_safe
 from ratelimit.decorators import ratelimit
-from io import StringIO
+from io import BytesIO
 from bson.objectid import ObjectId
 from django.contrib.auth.decorators import login_required
 
@@ -1329,7 +1329,7 @@ def tasks_report(request, task_id, report_format="json"):
             return jsonize(resp, response=True)
 
         fname = "%s_reports.tar.bz2" % task_id
-        s = StringIO()
+        s = BytesIO()
         tar = tarfile.open(name=fname, fileobj=s, mode="w:bz2")
         for rep in os.listdir(srcdir):
             tar.add(os.path.join(srcdir, rep), arcname=rep)
@@ -1342,7 +1342,7 @@ def tasks_report(request, task_id, report_format="json"):
     elif report_format.lower() in bz_formats:
         bzf = bz_formats[report_format.lower()]
         srcdir = os.path.join(CUCKOO_ROOT, "storage", "analyses", "%d" % task_id)
-        s = StringIO()
+        s = BytesWarning()
 
         # By default go for bz2 encoded tar files (for legacy reasons.)
         # tarmode = tar_formats.get("tar", "w:bz2")
@@ -1621,7 +1621,7 @@ def tasks_screenshot(request, task_id, screenshot="all"):
 
     if screenshot == "all":
         fname = "%s_screenshots.tar.bz2" % task_id
-        s = StringIO()
+        s = BytesIO()
         tar = tarfile.open(fileobj=s, mode="w:bz2")
         for shot in os.listdir(srcdir):
             tar.add(os.path.join(srcdir, shot), arcname=shot)
@@ -1696,7 +1696,7 @@ def tasks_dropped(request, task_id):
 
     else:
         fname = "%s_dropped.tar.bz2" % task_id
-        s = StringIO()
+        s = BytesIO()
         tar = tarfile.open(fileobj=s, mode="w:bz2")
         for dirfile in os.listdir(srcdir):
             tar.add(os.path.join(srcdir, dirfile), arcname=dirfile)
@@ -1846,7 +1846,7 @@ def tasks_procmemory(request, task_id, pid="all"):
             return jsonize(resp, response=True)
 
         fname = "%s_procdumps.tar.bz2" % task_id
-        s = StringIO()
+        s = BytesIO()
         tar = tarfile.open(fileobj=s, mode="w:bz2")
         for memdump in os.listdir(srcdir):
             tar.add(os.path.join(srcdir, memdump), arcname=memdump)
@@ -1859,7 +1859,7 @@ def tasks_procmemory(request, task_id, pid="all"):
         if os.path.exists(srcfile):
             if apiconf.taskprocmemory.get("compress"):
                 fname = srcfile.split("/")[-1]
-                s = StringIO()
+                s = BytesIO()
                 tar = tarfile.open(fileobj=s, mode="w:bz2")
                 tar.add(srcfile, arcname=fname)
                 tar.close()


### PR DESCRIPTION
Hey there, report download endpoints are failing under Ubuntu 20.04's Python 3.8. PRing a patch to switch from StringIO to BytesIO. 