### PR TITLE
Add signature for CAPE having extracted config

### DIFF
--- a/modules/signatures/cape_extracted.py
+++ b/modules/signatures/cape_extracted.py
@@ -40,3 +40,23 @@ class CAPEExtractedContent(Signature):
                     self.data.append({process: yara[0].get("name")})
 
         return ret
+
+class CAPEExtractedConfig(Signature):
+    name = "cape_extracted_config"
+    description = "CAPE has extracted a malware configuration"
+    severity = 3
+    categories = ["malware"]
+    authors = ["Kevin Ross"]
+    minimum = "1.3"
+    evented = True
+
+    def run(self):
+        ret = False
+        for cape in self.results.get("CAPE", []) or []:
+            capeconfig = cape.get("cape_config", "")
+            malwarename = cape.get("cape_name", "")
+            if capeconfig and malwarename:
+                self.data.append({"extracted_config": malwarename})
+                ret = True
+
+        return ret


### PR DESCRIPTION
This is more to highlight that a config is there and also to more easily identify cases where it might have stopped extracting the config if not looking at the CAPE tab.

![image](https://user-images.githubusercontent.com/2414517/94323572-42d64900-ff8e-11ea-9135-896c26779dec.png)

![image](https://user-images.githubusercontent.com/2414517/94323600-584b7300-ff8e-11ea-8bdb-2944b8db7efa.png)
