### PR TITLE
Resolve TypeError in retention reporting module.

### DIFF
--- a/modules/reporting/retention.py
+++ b/modules/reporting/retention.py
@@ -53,7 +53,7 @@ def delete_mongo_data(curtask, tid):
     # TODO: Class-ify this or make it a function in utils, some code reuse
     # between this/process.py/django view
     analyses = results_db.analysis.find({"info.id": int(tid)})
-    if analyses.count > 0:
+    if analyses.count() > 0:
         for analysis in analyses:
             for process in analysis.get("behavior", {}).get("processes", []):
                 for call in process["calls"]:


### PR DESCRIPTION
This PR resolves the following generated exception from the retention reporting module:
```

[lib.cuckoo.core.plugins] ERROR: Failed to run the reporting module "Retention":
Traceback (most recent call last):
  File "/opt/CAPEv2/utils/../lib/cuckoo/core/plugins.py", line 783, in process
    current.run(self.results)
  File "/opt/CAPEv2/utils/../modules/reporting/retention.py", line 193, in run
    delete_mongo_data(curtask, lastTask)
  File "/opt/CAPEv2/utils/../modules/reporting/retention.py", line 56, in delete_mongo_data
    if analyses.count > 0:
TypeError: '>' not supported between instances of 'method' and 'int'
```