### PR TITLE
decode shellcode strings from bytes to strings

### DIFF
--- a/web/api/views.py
+++ b/web/api/views.py
@@ -1163,6 +1163,9 @@ def tasks_iocs(request, task_id, detail=None):
         if data["target"]["category"] == "file":
             del data["target"]["file"]["path"]
             del data["target"]["file"]["guest_paths"]
+            for x in data["target"]["file"]["yara"]:
+                for i in range(0, len(x["strings"])):
+                    x["strings"][i] = x["strings"][i].hex(' 
 
     data["network"] = {}
     if "network" in list(buf.keys()) and buf["network"]:

--- a/web/api/views.py
+++ b/web/api/views.py
@@ -1165,7 +1165,7 @@ def tasks_iocs(request, task_id, detail=None):
             del data["target"]["file"]["guest_paths"]
             for x in data["target"]["file"]["yara"]:
                 for i in range(0, len(x["strings"])):
-                    x["strings"][i] = x["strings"][i].hex(' 
+                    x["strings"][i] = x["strings"][i].hex('  ')
 
     data["network"] = {}
     if "network" in list(buf.keys()) and buf["network"]:


### PR DESCRIPTION
I've spotted the problem when there are a shellcode strings, when using API get iocs:
"File "/usr/lib/python3.8/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type bytes is not JSON serializable
"
So, here's a solution.