### PR TITLE
[chg] handle case where inetsim traffic is not correctly recorded by tcpdump

### DIFF
--- a/modules/auxiliary/sniffer.py
+++ b/modules/auxiliary/sniffer.py
@@ -141,7 +141,7 @@ class Sniffer(Auxiliary):
         )
 
         # TODO fix this, temp fix to not get all that noise
-        pargs.extend(["and", "not", "(", "dst", "host", resultserver_ip, "and", "src", "host", host, ")"])
+        #pargs.extend(["and", "not", "(", "dst", "host", resultserver_ip, "and", "src", "host", host, ")"])
 
         if remote and bpf:
             pargs.extend(["and", "("] + bpf.split(" ") + [")"])


### PR DESCRIPTION
Probably the original _tcpdump_ filter is fine in the case InetSIM is running on a separated VM (not sure about the noise part ...), nevertheless if it listens on the same _resultserver_ip_ , only DNS traffic is recorded and all the rest (http/https/etc.) is left out.

From here the issues we have with no recorded HTTP sessions (under the _Network_ tab in the report and in the _json_ export) when an analysis was started with InetSIM vs TOR vs Dirty line