### PR TITLE
Improving the linux sandbox

### DIFF
--- a/analyzer/linux/lib/core/packages.py
+++ b/analyzer/linux/lib/core/packages.py
@@ -166,7 +166,7 @@ class Package(object):
         log.info(cmd)
         self.proc = subprocess.Popen(cmd, env={"XAUTHORITY": "/root/.Xauthority", "DISPLAY": ":0"}, stderr=subprocess.PIPE, shell=True)
 
-        while "systemtap_module_init() returned 0" not in self.proc.stderr.readline():
+        while "systemtap_module_init() returned 0" not in self.proc.stderr.readline().decode():
             # log.debug(self.proc.stderr.readline())
             pass
 

--- a/analyzer/linux/modules/auxiliary/stap.py
+++ b/analyzer/linux/modules/auxiliary/stap.py
@@ -37,6 +37,8 @@ class STAP(Auxiliary):
             path = path_cfg
         elif os.path.exists("/root/.cuckoo") and has_stap("/root/.cuckoo"):
             path = has_stap("/root/.cuckoo")
+        elif os.path.exists("/root/.cape") and has_stap("/root/.cape"):
+            path = has_stap("root/.cape")
         else:
             log.warning("Could not find STAP LKM, aborting systemtap analysis.")
             return False
@@ -46,6 +48,9 @@ class STAP(Auxiliary):
 
         while "systemtap_module_init() returned 0" not in self.proc.stderr.readline().decode("utf8"):
             pass
+
+        self.proc.terminate()
+        self.proc.wait()
 
         stap_stop = time.time()
         log.info("STAP aux module startup took %.2f seconds" % (stap_stop - stap_start))

--- a/docs/book/src/installation/guest/linux.rst
+++ b/docs/book/src/installation/guest/linux.rst
@@ -33,6 +33,20 @@ with your user. You also have script in utils/linux_mktaps.sh**
 Preparing x32/x64 Ubuntu 17.10 Linux guests
 ===========================================
 
+Install support files dependencies::
+
+    $ sudo apt update
+    $ sudo apt install python3-pip
+    $ pip3 install pyinotify
+    $ pip3 install pillow       # optional
+    $ pip3 install pyscreenshot # optional
+
+(For x64 architectures) Install python3 32 bits::
+
+    $ sudo dpkg --add-architecture i386
+    $ sudo apt update
+    $ sudo apt install python3:i386
+	
 Ensure the agent automatically starts. The easiest way is to add it to crontab::
 
     $ sudo crontab -e
@@ -96,6 +110,15 @@ Disable NTP inside of the VM::
 
     $ sudo timedatectl set-ntp off
 
+Disable auto-update for noise reduction::
+
+    $ sudo tee /etc/apt/apt.conf.d/20auto-upgrades << EOF
+      APT::Periodic::Update-Package-Lists "0";
+      APT::Periodic::Unattended-Upgrade "0";
+    EOF
+	
+If needed, kill the unattended-upgrade process using htop or ps + kill.
+	
 Optional - preinstalled remove software and configurations::
 
     $ sudo apt-get purge update-notifier update-manager update-manager-core ubuntu-release-upgrader-core


### PR DESCRIPTION
I know that linux is a work in progress. I hope I didn't misunderstand the original code.
 
I tried to improve the original documentation and modify the stap module according to the doc instructions. I kept the original .cuckoo folder to avoid breaking existing sandboxes. 

I encountered an issue where the staprun in packages.py would not run because the stap_.ko file was already used by the unstopped subprocess in stap.py. I did not really understand why staprun was run twice. But I fixed this issue by killing the stap.py subprocess after it reached the "systemtap_module_init() returned 0".