### PR TITLE
add helper function and creation script for network_dga_fraunhofer sig

### DIFF
--- a/cuckoo.pyproj
+++ b/cuckoo.pyproj
@@ -409,6 +409,7 @@
     <Compile Include="lib\cuckoo\common\defines.py" />
     <Compile Include="lib\cuckoo\common\dns.py" />
     <Compile Include="lib\cuckoo\common\exceptions.py" />
+    <Compile Include="lib\cuckoo\common\fraunhofer_helper.py" />
     <Compile Include="lib\cuckoo\common\irc.py" />
     <Compile Include="lib\cuckoo\common\logo.py" />
     <Compile Include="lib\cuckoo\common\logtbl.py" />

--- a/lib/cuckoo/common/fraunhofer_helper.py
+++ b/lib/cuckoo/common/fraunhofer_helper.py
@@ -1,0 +1,28 @@
+# Copyright (C) 2020 King-Konsto
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import json
+import gzip
+
+from lib.cuckoo.common.constants import CUCKOO_ROOT
+
+def get_dga_lookup_dict():
+    dga_lookup_path = os.path.join(CUCKOO_ROOT, "data", "dga_lookup_dict.json.gz")
+    if os.path.exists(dga_lookup_path):
+        with gzip.GzipFile(dga_lookup_path, "r") as fin:
+            return json.loads(fin.read().decode("utf-8"))
+
+    return {}

--- a/utils/create_bloom.py
+++ b/utils/create_bloom.py
@@ -1,0 +1,110 @@
+# Copyright (C) 2020 King-Konsto
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import gzip
+import json
+import logging
+import os
+import requests
+import sys
+
+try:
+    from flor import BloomFilter
+    HAVE_FLOR = True
+except ImportError:
+    HAVE_FLOR = False
+
+from lib.cuckoo.common.constants import CUCKOO_ROOT
+
+
+API_URL = "https://dgarchive.caad.fkie.fraunhofer.de/today/1"
+API_USER = ""
+API_PW = ""
+
+if __name__ == "__main__":
+    logging.getLogger().setLevel(logging.DEBUG)
+    if not HAVE_FLOR:
+        logging.error("Python library 'flor' is not installed")
+        sys.exit(-1)
+
+    logging.info("Starting bloomfilter generation script")
+    session = requests.Session()
+    session.auth = (API_USER, API_PW)
+
+    if not (API_URL and API_USER and API_PW and session):
+        logging.error("Please put your credentials into API_USER, API_PW and API_URL")
+        sys.exit(-1)
+
+    # 1. call API and get json dict containing active DGA domains and DGA families
+    # endpoint /today/1 means today, yesterday and tomorrow (today +/- 1)
+    logging.info("Fetching data from Fraunhofer API")
+    response = session.get(API_URL)
+    if not response:
+        logging.error("Fraunhofer DGA API call malformed or credentials invalid")
+        sys.exit(-1)
+
+    if response.status_code != 200:
+        logging.error("Error while querying Fraunhofer DGA API: %s", response.status_code)
+        sys.exit(-1)
+
+    dga_json = response.json()
+    if not dga_json:
+        logging.error("API response could not be transformed into json dict")
+        sys.exit(-1)
+
+    # 2. create empty bloomfilter
+    logging.info("Creating bloomfilter and DGA dict")
+    bloom = BloomFilter(n=1000000, p=0.0001)
+
+    # 3. insert DGA domains from json dict into bloomfilter and create dict for family lookup
+    dga_lookup_dict = {}
+    first_entry = False
+    test_domain = None
+    test_family = None
+    for family, domain_list in dga_json.items():
+        if not first_entry:
+            test_domain = domain_list[0]
+            test_family = family
+            first_entry = True
+        for domain in domain_list:
+            # insert domain into bloomfilter
+            if not domain.lower().encode("utf8") in bloom:
+                bloom.add(domain.lower().encode("utf8"))
+
+            # insert into family/domain lookup table
+            dga_lookup_dict[domain] = family
+
+    # test with first DGA domain/family pair that should be present in the bloomfilter and the dga_dict
+    if not (first_entry and test_domain and test_family):
+        logging.error("Unknown error while creating bloomfilter and DGA dict")
+        sys.exit(-1)
+    if test_domain.lower().encode("utf8") in bloom and dga_lookup_dict.get(test_domain.lower(), "") == test_family:
+        logging.info("%s (%s)", test_domain, test_family)
+        logging.info("Bloomfilter and DGA dict successfully created")
+    else:
+        logging.error("Unknown error while creating bloomfilter and DGA dict")
+        sys.exit(-1)
+
+    # 5. write bloomfilter and dga dict to a file so that the sandbox can use it in the python signature
+    logging.info("Write bloomfilter and dga dict to files")
+    bloom_path = os.path.join(CUCKOO_ROOT, "data",  "dga.bloom")
+    with open(bloom_path, "wb") as f:
+        bloom.write(f)
+
+    lookup_path = os.path.join(CUCKOO_ROOT, "data", "dga_lookup_dict.json.gz")
+    with gzip.GzipFile(lookup_path, "w") as fout:
+        fout.write(json.dumps(dga_lookup_dict).encode("utf8"))
+
+    logging.info("Successfully generated bloomfilter and dga dict file")

--- a/utils/create_bloom.py
+++ b/utils/create_bloom.py
@@ -25,6 +25,7 @@ try:
     HAVE_FLOR = True
 except ImportError:
     HAVE_FLOR = False
+    logging.error("Python library 'flor' is not installed -> pip3 install flor")
 
 from lib.cuckoo.common.constants import CUCKOO_ROOT
 
@@ -36,7 +37,7 @@ API_PW = ""
 if __name__ == "__main__":
     logging.getLogger().setLevel(logging.DEBUG)
     if not HAVE_FLOR:
-        logging.error("Python library 'flor' is not installed")
+        logging.error("Python library 'flor' is not installed -> pip3 install flor")
         sys.exit(-1)
 
     logging.info("Starting bloomfilter generation script")


### PR DESCRIPTION
This signature detects the likely usage of Domain Generation algorithms by
matching all dns requests of a sandbox run against a pre-built bloomfilter.
The bloomfilter contains the active DGA domains from today, tomorrow and
yesterday and is based on the intelligence of the Fraunhofer DGArchive.

The check against the bloomfilter is really quick. Only if we have hits
we'll proceed and match the DGA domain to its DGA/malware family by
performing a dict lookup that is preloaded in memory.

The bloomfilter and the lookup dict are created by the create_bloom.py
script of the CAPEv2 repository and placed within the /data folder of
the community repository. The update process can be performed
manually via running the script on the local machine before
signature push/pull or via cronjob task.

Relies on PR in the community repo: https://github.com/kevoreilly/community/pull/117

* Bloomfilter library: https://github.com/DCSO/flor
* Fraunhofer DGArchive: https://dgarchive.caad.fkie.fraunhofer.de/welcome/