### PR TITLE
fixed update capa-rules

### DIFF
--- a/utils/community.py
+++ b/utils/community.py
@@ -3,6 +3,7 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
+import shutil
 import os
 import sys
 import zipfile
@@ -28,6 +29,8 @@ def flare_capa_rules():
         http = urllib3.PoolManager()
         data = http.request("GET", "https://github.com/fireeye/capa-rules/archive/master.zip").data
         dest_folder = os.path.join(CUCKOO_ROOT, "data")
+        shutil.rmtree((os.path.join(dest_folder, "capa-rules-master")), ignore_errors=True)
+        shutil.rmtree((os.path.join(dest_folder, "capa-rules")), ignore_errors=True)
         zipfile.ZipFile(BytesIO(data)).extractall(path=dest_folder)
         os.rename(os.path.join(dest_folder, "capa-rules-master"), os.path.join(dest_folder, "capa-rules"))
         print("[+] FLARE CAPA rules installed")
@@ -153,6 +156,7 @@ def main():
 
     if args.capa_rules:
         flare_capa_rules()
+        return
 
     if not enabled:
         print(colors.red("You need to enable a category!\n"))
@@ -167,3 +171,4 @@ if __name__ == "__main__":
         main()
     except KeyboardInterrupt:
         pass
+


### PR DESCRIPTION
Hi, 
The update of the Capa-Rules via community.py -cr did not work for me. 

1) Errno 39] Directory not empty: '/opt/CAPEv2/data/capa-rules-master' -> '/opt/CAPEv2/data/capa-rules

![Screenshot from 2020-12-07 11-37-04](https://user-images.githubusercontent.com/35531629/101348327-63baf480-3883-11eb-8aed-97ef364acf9f.png)

-> I decided to delete the old directorys to replace them with new ones.

2)  Always get the help function although the function was successful

-> return after flare_capa_rules() in the if-statement

There is surely a more beautiful solution, but works for me atm. Feel free to merge if you agree. 
Have a nice day

Claudio