### PR TITLE
Create parallax.yar

### DIFF
--- a/data/yara/CAPE/parallax.yar
+++ b/data/yara/CAPE/parallax.yar
@@ -1,0 +1,22 @@
+rule Parallax
+{
+meta:
+	description = "Identifies Parallax RAT."
+	author = "@bartblaze"
+	date = "2020-09"
+	tlp = "White"
+
+strings:
+	$ = ".DeleteFile(Wscript.ScriptFullName)" ascii wide
+	$ = ".DeleteFolder" ascii wide fullword
+	$ = ".FileExists" ascii wide fullword
+	$ = "= CreateObject" ascii wide fullword
+	$ = "Clipboard Start" ascii wide fullword
+	$ = "UN.vbs" ascii wide fullword
+	$ = "[Alt +" ascii wide fullword
+	$ = "[Clipboard End]" ascii wide fullword
+	$ = "[Ctrl +" ascii wide fullword
+
+condition:
+	3 of them
+}


### PR DESCRIPTION
Adding the parallax yara rule from @bartblaze here, it has a match on this [Injected PE Image: 32-bit executable](https://www.capesandbox.com/analysis/108604/#) :)

![image](https://user-images.githubusercontent.com/49360849/102713338-9cc87f80-42ed-11eb-9494-a7baabb9ba04.png)

