### PR TITLE
put lower bounds on cryptography dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ flor
 Pebble
 bson
 pymisp
-cryptography
+cryptography>=3.1
 requests[security]
 pyOpenSSL
 pefile


### PR DESCRIPTION
Follow-up to PR #301, set minimum version of cryptography to 3.1 to get support for [load_der_pkcs7_certificates](https://cryptography.io/en/latest/hazmat/primitives/asymmetric/serialization.html#cryptography.hazmat.primitives.serialization.pkcs7.load_der_pkcs7_certificates).

Without 3.1 or higher, the certificate extraction may crash with attribute errors:
```
AttributeError: 'Backend' object has no attribute 'load_der_pkcs7_certificates'
```