### PR TITLE
Updated Zloader parser

### DIFF
--- a/modules/processing/parsers/mwcp/Zloader.py
+++ b/modules/processing/parsers/mwcp/Zloader.py
@@ -31,7 +31,7 @@ rule Zloader
         cape_type = "Zloader Payload"
     strings:
         $rc4_init = {31 [1-3] 66 C7 8? 00 01 00 00 00 00 90 90 [0-5] 8? [5-90] 00 01 00 00 [0-15] (74|75)}
-        $decrypt_conf = {83 C4 04 84 C0 74 5? E8 [4] E8 [4] E8 [4] E8 [4] ?8 [4] ?8 [4] ?8}
+        $decrypt_conf = {e8 ?? ?? ?? ?? e8 ?? ?? ?? ?? e8 ?? ?? ?? ?? e8 ?? ?? ?? ?? 68 ?? ?? ?? ?? 68 ?? ?? ?? ?? e8 ?? ?? ?? ?? 83 c4 08 e8 ?? ?? ?? ??}
     condition:
         uint16(0) == 0x5A4D and any of them
 }
@@ -66,11 +66,8 @@ class Zloader(Parser):
                 continue
             for item in match.strings:
                 if '$decrypt_conf' in item[1]:
-                    decrypt_conf = int(item[0])+28
+                    decrypt_conf = int(item[0])+21
         va = struct.unpack("I",filebuf[decrypt_conf:decrypt_conf+4])[0]
-        while va > 0x100000:
-            decrypt_conf += 5
-            va = struct.unpack("I",filebuf[decrypt_conf:decrypt_conf+4])[0]
         key = string_from_offset(filebuf, pe.get_offset_from_rva(va-image_base))
         data_offset = pe.get_offset_from_rva(struct.unpack("I",filebuf[decrypt_conf+5:decrypt_conf+9])[0]-image_base)
         enc_data = filebuf[data_offset:].split(b"\0\0")[0]


### PR DESCRIPTION
While analyzing a Zloader email campaign from February for a blog post (<https://www.hornetsecurity.com/en/threat-research/zloader-email-campaign-using-mhtml-to-download-and-decrypt-xls/>) we noticed the Zloader parser did not work on the Zloader samples. We therefore updated the parser.

Tested and confirmed working (both for current and older samples (for which the parser also worked pre-change)) against (at least) the following Zloader samples:

- <https://bazaar.abuse.ch/sample/d20f5e6ff3b8af7d2adb395d2fc57b5c35343fc7b17865ccbbc66b66711a3b4c/> (first seen 2021-03-13)
- <https://bazaar.abuse.ch/sample/67773bd7bf1720493b3dd438a8d2959412dd9a4381a646d3e7278e73e18e102d/> (first seen 2021-03-01)
- <https://bazaar.abuse.ch/sample/d56060acb8115119810ae3aca151e94cbe5e2459dd405c8f010ced5a25c8548a/> (first seen 2021-01-20)
- <https://bazaar.abuse.ch/sample/35466f0c22f220890b932e59f9a21032712e8260343d13ad4c0d9560db3b638f/> (first seen 2020-12-08)

So should be good, but feel free to adapt or reject the pull request as you see fit.

Thank you for all the hard work on CAPE!
