### PR TITLE
Fix Regular Expression injection

### DIFF
--- a/web/analysis/views.py
+++ b/web/analysis/views.py
@@ -916,7 +916,7 @@ def search_behavior(request, task_id):
 
         query = query.strip()
 
-        query = re.compile(query)
+        query = re.compile(re.escape(query))
 
         # Fetch anaylsis report
         if enabledconf["mongodb"]:


### PR DESCRIPTION
The fact of not sanitizing user input appended to a regular expression may lead to a `Regular Expression Denial of Service` by an attacker crafting a regular expression taking too much to load, or simply change the behaviour of the program.

Vulnerable code:

https://github.com/kevoreilly/CAPEv2/blob/ad9d702cd5f358ff34da26f5f3e10b6a4f004320/web/analysis/views.py#L919

References:

[OWASP ReDoS](https://owasp.org/www-community/attacks/Regular_expression_Denial_of_Service_-_ReDoS)