### PR TITLE
Enable reboot of physical machine after analysis without Fog agent

### DIFF
--- a/agent/agent.py
+++ b/agent/agent.py
@@ -33,6 +33,7 @@ if sys.maxsize > 2 ** 32:
 AGENT_VERSION = "0.11"
 AGENT_FEATURES = [
     "execpy",
+    "execute",
     "pinning",
     "logs",
     "largefile",

--- a/modules/machinery/physical.py
+++ b/modules/machinery/physical.py
@@ -138,6 +138,13 @@ class Physical(Machinery):
                                  "wol": 'true'}).encode('utf8')
 
                     r_deploy = requests.post("http://" + self.options.fog.hostname + "/fog/host/" + hostID + "/task", headers=headers, data=payload)
+                    
+                    try:
+                        requests.post("http://{0}:{1}".format(machine.ip, CUCKOO_GUEST_PORT) + "/execute", data={"command" : "shutdown -r -f -t 0"})
+                    except:
+                        # The reboot will start immediately which may kill our socket so we just ignore this exception
+                        log.debug("Socket killed from analysis machine due to reboot")
+
 
         # We are waiting until we are able to connect to the agent again since we dont know how long it will take to restore the machine
         while not self.isTaskigDone(hostID):


### PR DESCRIPTION
Fog agent on physical machines can't be reached after an analysis since WMI gets restarted during an analysis which does not restart the fog agent. It therefor possibly makes sense to enable the route "execute" in agent.py and directly issue the command

shutdown -r -f -t 0

through modules/machinery/physical.py after an analysis has finished. Code has been tested locally