### PR TITLE
make lowered, normalized search terms explicit

### DIFF
--- a/lib/cuckoo/common/web_utils.py
+++ b/lib/cuckoo/common/web_utils.py
@@ -843,6 +843,8 @@ normalized_lower_terms = (
     "sha3",
     "sha256",
     "sha512",
+    "ip",
+    "domain",
 )
 
 # ToDo verify if still working

--- a/lib/cuckoo/common/web_utils.py
+++ b/lib/cuckoo/common/web_utils.py
@@ -845,6 +845,10 @@ normalized_lower_terms = (
     "sha512",
     "ip",
     "domain",
+    "ja3_hash",
+    "dhash",
+    "iconhash",
+    "imphash",
 )
 
 # ToDo verify if still working

--- a/lib/cuckoo/common/web_utils.py
+++ b/lib/cuckoo/common/web_utils.py
@@ -836,6 +836,15 @@ search_term_map = {
     "dhash": "static.pe.icon_dhash",
 }
 
+# search terms that will be forwarded to mongodb in a lowered normalized form
+normalized_lower_terms = (
+    "md5",
+    "sha1",
+    "sha3",
+    "sha256",
+    "sha512",
+)
+
 # ToDo verify if still working
 def perform_ttps_search(value):
     if repconf.mongodb.enabled and len(value) == 5 and value.upper().startswith("T") and value[1:].isdigit():
@@ -853,7 +862,7 @@ def perform_search(term, value):
         return es.search(index=fullidx, doc_type="analysis", q="%s" % value, sort="task_id:desc", size=numhits)["hits"]["hits"]
 
     query_val = False
-    if term in ("md5", "sha1", "sha3", "sha256", "sha512"):
+    if term in normalized_lower_terms:
         query_val = value.lower()
     elif term in ("surisid", "id"):
         try:


### PR DESCRIPTION
There's a few special search terms (md5, sha1, etc.) previously sent to MongoDB in their natural form. Most terms default to [using a regex](https://github.com/kevoreilly/CAPEv2/blob/090c879c2c6dc8c59d2cbe10124be029a49307d0/lib/cuckoo/common/web_utils.py#L883). 

This PR pulls the lowered normalized search terms into `normalized_lower_terms`, and lets the following search terms skip the regex filter:
- md5
- sha1
- sha3
- sha256
- sha512
- ip
- domain
- ja3_hash
- dhash
- iconhash
- imphash