### PR TITLE
settings.py: reload secret_key import fixed

### DIFF
--- a/web/web/settings.py
+++ b/web/web/settings.py
@@ -120,7 +120,7 @@ except ImportError:
         key_file.write('SECRET_KEY = "{0}"'.format(key))
 
     # Reload key.
-    from secret_key import *
+    from .secret_key import *
 
 try:
     from captcha.fields import ReCaptchaField


### PR DESCRIPTION
Import for secret_key reload should be relative - same as initial import.
Bug prevents running some `python3 manage.py` commands on fresh install.
Currently first time command is executed it creates secret_key.py if missing but fails with (re)loading it (due to wrong import). After first failure next commands work fine (file already exist imported with first attempt).