### PR TITLE
Rename option `logging` to `log_rotation`

### DIFF
--- a/conf/cuckoo.conf
+++ b/conf/cuckoo.conf
@@ -155,10 +155,10 @@ critical = 60
 # shutting down a vm. Default is 300 seconds.
 vm_state = 300
 
-[logging]
-# Allows to activate log rotate for cuckoo.log and process.log
+[log_rotation]
+# Activate log rotation for cuckoo.log and process.log.
 enabled = on
-# Keep 30 days logs
+# Keep 30 days of log history (default is 7).
 backup_count = 30
 
 [tmpfs]

--- a/lib/cuckoo/core/startup.py
+++ b/lib/cuckoo/core/startup.py
@@ -168,8 +168,8 @@ def init_logging():
     """Initializes logging."""
     formatter = logging.Formatter("%(asctime)s [%(name)s] %(levelname)s: %(message)s")
 
-    if cuckoo.logging.enabled:
-        days = cuckoo.logging.backup_count or 7
+    if cuckoo.log_rotation.enabled:
+        days = cuckoo.log_rotation.backup_count or 7
         fh = logging.handlers.TimedRotatingFileHandler(os.path.join(CUCKOO_ROOT, "log", "cuckoo.log"), when="midnight", backupCount=int(days))
     else:
         fh = logging.handlers.WatchedFileHandler(os.path.join(CUCKOO_ROOT, "log", "cuckoo.log"))

--- a/utils/process.py
+++ b/utils/process.py
@@ -166,8 +166,8 @@ def init_logging(auto=False, tid=0, debug=False):
         if not os.path.exists(os.path.join(CUCKOO_ROOT, "log")):
             os.makedirs(os.path.join(CUCKOO_ROOT, "log"))
         if auto:
-            if cfg.logging.enabled:
-                days = cfg.logging.backup_count or 7
+            if cfg.log_rotation.enabled:
+                days = cfg.log_rotation.backup_count or 7
                 fh = logging.handlers.TimedRotatingFileHandler(
                     os.path.join(CUCKOO_ROOT, "log", "process.log"), when="midnight", backupCount=int(days)
                 )


### PR DESCRIPTION
The current name feels confusing, as the options in this section don't affect logging itself, but rather the log rotation.