### PR TITLE
fix SystemRoot typo

### DIFF
--- a/analyzer/windows/modules/packages/python.py
+++ b/analyzer/windows/modules/packages/python.py
@@ -11,7 +11,7 @@ class Python(Package):
 
     PATHS = [
         ("HomeDrive", "Python*", "python.exe"),
-        ("SYSTEMROOT", "py.exe")
+        ("SystemRoot", "py.exe")
     ]
 
     def start(self, path):


### PR DESCRIPTION
The Package class checks for "SystemRoot" not "SYSTEMROOT"