### PR TITLE
Resolve static extraction fails if sha256 exists

### DIFF
--- a/lib/cuckoo/common/cape_utils.py
+++ b/lib/cuckoo/common/cape_utils.py
@@ -390,13 +390,16 @@ def static_config_parsers(yara_hit, file_data):
 def static_config_lookup(file_path, sha256=False):
     if not sha256:
         sha256 = hashlib.sha256(open(file_path, "rb").read()).hexdigest()
-    cape_tasks = results_db.analysis.find_one(
+    document_dict = results_db.analysis.find_one(
         {"target.file.sha256": sha256}, {"CAPE.configs": 1, "info.id": 1, "_id": 0}, sort=[("_id", pymongo.DESCENDING)]
     )
-    if not cape_tasks:
+
+    if not document_dict:
         return
-    for task in cape_tasks.get("CAPE", {}).get("configs", []) or []:
-        return task["info"]
+
+    has_config = document_dict.get("CAPE", {}).get("configs", [])
+    if has_config:
+        return document_dict["info"]
 
 
 def static_extraction(path):


### PR DESCRIPTION
Resolves issue where static extraction fails if sha256 exists. The find_one method returns a dict and not a list.