### PR TITLE
Clean up f-strings and logging in analyzer and admin folder

### DIFF
--- a/admin/admin.py
+++ b/admin/admin.py
@@ -181,7 +181,7 @@ def execute_command_on_all(remote_command):
             _, ssh_stdout, _ = ssh.exec_command(remote_command)
             ssh_out = ssh_stdout.read().decode("utf-8").strip()
             if "Active: active (running)" in ssh_out and "systemctl status" not in remote_command:
-                log.info("[+] Service " + green("restarted successfully and is UP"))
+                log.info("[+] Service %s", green("restarted successfully and is UP"))
             else:
                 if ssh_out:
                     log.info(green(f"[+] {server} - {ssh_out}"))

--- a/analyzer/linux/analyzer.py
+++ b/analyzer/linux/analyzer.py
@@ -79,7 +79,7 @@ class Analyzer:
             # Set virtual machine clock.
             clock = datetime.datetime.strptime(self.config.clock, "%Y%m%dT%H:%M:%S")
             # Setting date and time.
-            os.system('date -s "{0}"'.format(clock.strftime("%y-%m-%d %H:%M:%S")))
+            os.system(f'date -s "{clock.strftime("%y-%m-%d %H:%M:%S")}"')
 
         # We update the target according to its category. If it's a file, then
         # we store the path.
@@ -99,7 +99,7 @@ class Analyzer:
         dump_files()
 
         # Hell yeah.
-        log.info("Analysis completed.")
+        log.info("Analysis completed")
         return True
 
     def run(self):
@@ -115,7 +115,7 @@ class Analyzer:
         # one automatically.
         """
         if not self.config.package:
-            log.debug("No analysis package specified, trying to detect it automagically.")
+            log.debug("No analysis package specified, trying to detect it automagically")
 
             if self.config.category == "file":
                 package = "generic"
@@ -125,24 +125,22 @@ class Analyzer:
             # If we weren't able to automatically determine the proper package,
             # we need to abort the analysis.
             if not package:
-                raise CuckooError("No valid package available for file "
-                                  "type: {0}".format(self.config.file_type))
+                raise CuckooError(f"No valid package available for file type: {self.config.file_type}")
 
-            log.info("Automatically selected analysis package \"%s\"", package)
+            log.info('Automatically selected analysis package "%s"', package)
         # Otherwise just select the specified package.
         else:
             package = self.config.package
 
         # Generate the package path.
-        package_name = "modules.packages.%s" % package
+        package_name = f"modules.packages.{package}"
 
         # Try to import the analysis package.
         try:
             __import__(package_name, globals(), locals(), ["dummy"], 0)
         # If it fails, we need to abort the analysis.
         except ImportError:
-            raise CuckooError("Unable to import package \"{0}\", does "
-                              "not exist.".format(package_name))
+            raise CuckooError('Unable to import package "{package_name}", does not exist')
 
         # Initialize the package parent abstract.
         Package()
@@ -151,8 +149,7 @@ class Analyzer:
         try:
             package_class = Package.__subclasses__()[0]
         except IndexError as e:
-            raise CuckooError("Unable to select package class "
-                              "(package={0}): {1}".format(package_name, e))
+            raise CuckooError(f"Unable to select package class (package={package_name}): {e}")
         """
         if self.config.package:
             suggestion = self.config.package
@@ -180,7 +177,7 @@ class Analyzer:
         pack = package_class(self.target, **kwargs)
         # Initialize Auxiliary modules
         Auxiliary()
-        prefix = auxiliary.__name__ + "."
+        prefix = f"{auxiliary.__name__}."
         for loader, name, ispkg in pkgutil.iter_modules(auxiliary.__path__, prefix):
             if ispkg:
                 continue
@@ -189,7 +186,7 @@ class Analyzer:
             try:
                 __import__(name, globals(), locals(), ["dummy"], 0)
             except ImportError as e:
-                log.warning("Unable to import the auxiliary module " '"%s": %s', name, e)
+                log.warning('Unable to import the auxiliary module "%s": %s', name, e)
 
         # Walk through the available auxiliary modules.
         aux_enabled, aux_avail = [], []
@@ -217,13 +214,11 @@ class Analyzer:
             # pids = pack.start(self.target)
             pids = pack.start()
         except NotImplementedError:
-            raise CuckooError('The package "{0}" doesn\'t contain a run ' "function.".format(package_class))
+            raise CuckooError(f'The package "{package_class}" doesn\'t contain a run function')
         except CuckooPackageError as e:
-            raise CuckooError('The package "{0}" start function raised an ' "error: {1}".format(package_class, e))
+            raise CuckooError(f'The package "{package_class}" start function raised an error: {e}')
         except Exception as e:
-            raise CuckooError(
-                'The package "{0}" start function encountered ' "an unhandled exception: " "{1}".format(package_class, e)
-            )
+            raise CuckooError(f'The package "{package_class}" start function encountered an unhandled exception: {e}')
 
         # If the analysis package returned a list of process IDs, we add them
         # to the list of monitored processes and enable the process monitor.
@@ -235,13 +230,13 @@ class Analyzer:
         # where the package isn't enabling any behavioral analysis), we don't
         # enable the process monitor.
         else:
-            log.info("No process IDs returned by the package, running " "for the full timeout.")
+            log.info("No process IDs returned by the package, running for the full timeout")
             pid_check = False
 
         # Check in the options if the user toggled the timeout enforce. If so,
         # we need to override pid_check and disable process monitor.
         if self.config.enforce_timeout:
-            log.info("Enabled timeout enforce, running for the full timeout.")
+            log.info("Enabled timeout enforce, running for the full timeout")
             pid_check = False
 
         time_counter = 0
@@ -249,7 +244,7 @@ class Analyzer:
         while True:
             time_counter += 1
             if time_counter > int(self.config.timeout):
-                log.info("Analysis timeout hit, terminating analysis.")
+                log.info("Analysis timeout hit, terminating analysis")
                 break
 
             try:
@@ -272,7 +267,7 @@ class Analyzer:
                     # If none of the monitored processes are still alive, we
                     # can terminate the analysis.
                     if not PROCESS_LIST:
-                        log.info("Process list is empty, " "terminating analysis.")
+                        log.info("Process list is empty, terminating analysis")
                         break
 
                     # Update the list of monitored processes available to the
@@ -286,14 +281,14 @@ class Analyzer:
                     # returns False, it means that it requested the analysis
                     # to be terminate.
                     if not pack.check():
-                        log.info("The analysis package requested the " "termination of the analysis.")
+                        log.info("The analysis package requested the termination of the analysis")
                         break
 
                 # If the check() function of the package raised some exception
                 # we don't care, we can still proceed with the analysis but we
                 # throw a warning.
                 except Exception as e:
-                    log.warning('The package "%s" check function raised ' "an exception: %s", package_class, e)
+                    log.warning('The package "%s" check function raised an exception: %s', package_class, e)
             except Exception as e:
                 log.exception("The PID watching loop raised an exception: %s", e)
             finally:
@@ -305,7 +300,7 @@ class Analyzer:
             # final operations through the finish() function.
             pack.finish()
         except Exception as e:
-            log.warning('The package "%s" finish function raised an ' "exception: %s", package_class, e)
+            log.warning('The package "%s" finish function raised an exception: %s', package_class, e)
 
         try:
             # Upload files the package created to files in the results folder
@@ -314,7 +309,7 @@ class Analyzer:
                 for package in package_files:
                     upload_to_host(package[0], os.path.join("files", package[1]))
         except Exception as e:
-            log.warning('The package "%s" package_files function raised an ' "exception: %s", package_class, e)
+            log.warning('The package "%s" package_files function raised an exception: %s', package_class, e)
 
         # Terminate the Auxiliary modules.
         for aux in sorted(aux_enabled, key=lambda x: x.priority):
@@ -328,7 +323,7 @@ class Analyzer:
         if self.config.terminate_processes:
             # Try to terminate remaining active processes. We do this to make sure
             # that we clean up remaining open handles (sockets, files, etc.).
-            log.info("Terminating remaining processes before shutdown.")
+            log.info("Terminating remaining processes before shutdown")
 
             for pid in PROCESS_LIST:
                 proc = Process(pid=pid)
@@ -345,7 +340,7 @@ class Analyzer:
             except (NotImplementedError, AttributeError):
                 continue
             except Exception as e:
-                log.warning("Exception running finish callback of auxiliary " "module %s: %s", aux.__class__.__name__, e)
+                log.warning("Exception running finish callback of auxiliary module %s: %s", aux.__class__.__name__, e)
 
         # Let's invoke the completion procedure.
         self.complete()
@@ -381,7 +376,7 @@ if __name__ == "__main__":
         if len(log.handlers):
             log.exception(error_exc)
         else:
-            sys.stderr.write("{0}\n".format(error_exc))
+            sys.stderr.write(f"{error_exc}\n")
 
     # Once the analysis is completed or terminated for any reason, we report
     # back to the agent, notifying that it can report back to the host.

--- a/analyzer/linux/lib/api/process.py
+++ b/analyzer/linux/lib/api/process.py
@@ -21,7 +21,7 @@ class Process:
         self.pid = pid
 
     def is_alive(self):
-        if not os.path.exists("/proc/%u" % self.pid):
+        if not os.path.exists(f"/proc/{self.pid}"):
             return False
         status = self.get_proc_status()
         if not status:
@@ -35,11 +35,11 @@ class Process:
 
     def get_proc_status(self):
         try:
-            status = open("/proc/%u/status" % self.pid).readlines()
+            status = open(f"/proc/{self.pid}/status").readlines()
             status_values = dict((i[0], i[1]) for i in [j.strip().split(None, 1) for j in status])
             return status_values
         except Exception:
-            log.critical("could not get process status for pid %u", self.pid)
+            log.critical("Could not get process status for pid %s", self.pid)
         return {}
 
     def execute(self, cmd):

--- a/analyzer/linux/lib/common/abstracts.py
+++ b/analyzer/linux/lib/common/abstracts.py
@@ -41,7 +41,7 @@ class Package(object):
         """
         p = Process()
         if not p.execute(cmd):
-            raise CuckooPackageError("Unable to execute the initial process, " "analysis aborted.")
+            raise CuckooPackageError("Unable to execute the initial process, analysis aborted")
 
         return p.pid
 

--- a/analyzer/linux/lib/common/apicalls.py
+++ b/analyzer/linux/lib/common/apicalls.py
@@ -14,7 +14,6 @@ log = logging.getLogger(__name__)
 
 
 def apicalls(target, **kwargs):
-    """ """
     if not target:
         raise Exception("Invalid target for apicalls()")
 
@@ -50,20 +49,19 @@ def _stap_command_line(target, **kwargs):
     # cmd += ["-o"]
     # cmd += ["stap.log"]
     # cmd += [path]
-    cmd = "sudo staprun -vv -o stap.log " + path
+    cmd = f"sudo staprun -vv -o stap.log {path}"
 
     run_as_root = kwargs.get("run_as_root", False)
 
+    target_cmd = f'"{target}"'
     if "args" in kwargs:
-        target_cmd = '"%s %s"' % (target, " ".join(kwargs["args"]))
-    else:
-        target_cmd = '"%s"' % (target)
+        target_cmd += f'" {" ".join(kwargs["args"])}"'
 
     # When we don't want to run the target as root, we have to drop privileges
     # with `sudo -u current_user` right before calling the target.
     # if not run_as_root:
-    #    target_cmd = '"sudo -u %s %s"' % (getuser(), target_cmd)
-    #    cmd += "-DSUDO=1"
+    #    target_cmd = f'"sudo -u {getuser()} {target_cmd}"'
+    #    cmd += " -DSUDO=1"
     # cmd += ["-c", target_cmd]
-    cmd += " -c " + target_cmd
+    cmd += f" -c {target_cmd}"
     return cmd

--- a/analyzer/linux/lib/common/results.py
+++ b/analyzer/linux/lib/common/results.py
@@ -18,7 +18,7 @@ BUFSIZE = 1024 * 1024
 def upload_to_host(file_path, dump_path, pids=[], metadata="", category=""):
     nc = infd = None
     if not os.path.exists(file_path):
-        log.warning("File not exist: {}".format(file_path))
+        log.warning("File not exist: %s", file_path)
         return
 
     try:
@@ -27,12 +27,12 @@ def upload_to_host(file_path, dump_path, pids=[], metadata="", category=""):
         nc.init(dump_path, file_path, pids, metadata, category)
         infd = open(file_path, "rb")  # rb
         buf = infd.read(BUFSIZE)
-        log.info("Uploading file {} to host -> {}".format(file_path, dump_path))
+        log.info("Uploading file %s to host -> %s", file_path, dump_path)
         while buf:
             nc.send(buf, retry=True)
             buf = infd.read(BUFSIZE)
     except Exception as e:
-        log.error("Exception uploading file {0} to host: {1}".format(file_path, e), exc_info=True)
+        log.error("Exception uploading file %s to host: %s", file_path, e, exc_info=True)
     finally:
         if infd:
             infd.close()
@@ -74,9 +74,9 @@ class NetlogConnection(object):
                 self.connect()
                 self.send(data, retry=False)
             else:
-                print(("Unhandled exception in NetlogConnection:", str(e)))
+                print(f"Unhandled exception in NetlogConnection: {e}")
         except Exception as e:
-            log.error(("Unhandled exception in NetlogConnection:", str(e)))
+            log.error("Unhandled exception in NetlogConnection: %s", e)
             # We really have nowhere to log this, if the netlog connection
             # does not work, we can assume that any logging won't work either.
             # So we just fail silently.

--- a/analyzer/linux/lib/core/packages.py
+++ b/analyzer/linux/lib/core/packages.py
@@ -29,7 +29,7 @@ def choose_package_class(file_type=None, file_name="", suggestion=None):
             log.info(file_name)
             name = "generic"
 
-    full_name = "modules.packages.%s" % name
+    full_name = f"modules.packages.{name}"
     try:
         # FIXME(rodionovd):
         # I couldn't figure out how to make __import__ import anything from
@@ -39,11 +39,11 @@ def choose_package_class(file_type=None, file_name="", suggestion=None):
         # from this module and then try to figure out the required member class
         module = __import__(full_name, globals(), locals(), ["*"])
     except ImportError:
-        raise Exception('Unable to import package "{0}": it does not ' "exist.".format(name))
+        raise Exception(f'Unable to import package "{name}": it does not exist')
     try:
         pkg_class = _found_target_class(module, name)
     except IndexError as err:
-        raise Exception("Unable to select package class (package={0}): " "{1}".format(full_name, err))
+        raise Exception(f"Unable to select package class (package={full_name}): {err}")
     return pkg_class
 
 
@@ -81,7 +81,7 @@ class Package(object):
 
     def __init__(self, target, **kwargs):
         if not target:
-            raise Exception("Package(): `target` and `host` arguments are required")
+            raise Exception("Package(): 'target' and 'host' arguments are required")
 
         self.target = target
         # Any analysis options?
@@ -133,7 +133,7 @@ class Package(object):
             self.apicalls_analysis()
             return self.proc.pid
         else:
-            raise Exception("Unsupported analysis method. Try `apicalls`.")
+            raise Exception("Unsupported analysis method. Try 'apicalls'")
         """
 
     def check(self):
@@ -177,14 +177,14 @@ class Package(object):
             pass
 
         stap_stop = time.time()
-        log.info("Process startup took %.2f seconds" % (stap_stop - stap_start))
+        log.info("Process startup took %.2f seconds", stap_stop - stap_start)
         return True
 
     def normal_analysis(self):
         kwargs = {"args": self.args, "timeout": self.timeout, "run_as_root": self.run_as_root}
 
         # cmd = apicalls(self.target, **kwargs)
-        cmd = "%s %s" % (self.target, " ".join(kwargs["args"]))
+        cmd = f"{self.target} {' '.join(kwargs['args'])}"
         stap_start = time.time()
         self.proc = subprocess.Popen(
             cmd, env={"XAUTHORITY": "/root/.Xauthority", "DISPLAY": ":0"}, stderr=subprocess.PIPE, shell=True
@@ -193,7 +193,7 @@ class Package(object):
         log.debug(self.proc.stderr.readline())
 
         stap_stop = time.time()
-        log.info("Process startup took %.2f seconds" % (stap_stop - stap_start))
+        log.info("Process startup took %.2f seconds", stap_stop - stap_start)
         return True
 
     @staticmethod
@@ -209,9 +209,9 @@ class Package(object):
         log.info("Package requested stop")
         try:
             r = self.proc.poll()
-            log.debug("stap subprocess retval %r", r)
+            log.debug("stap subprocess retval %d", r)
             self.proc.kill()
-            # subprocess.check_call(["sudo","kill", str(self.proc.pid)])
+            # subprocess.check_call(["sudo", "kill", str(self.proc.pid)])
             waitpid(self.proc.pid, 0)
             self._upload_file("stap.log", "logs/all.stap")
         except Exception as e:

--- a/analyzer/linux/modules/auxiliary/filecollector.py
+++ b/analyzer/linux/modules/auxiliary/filecollector.py
@@ -88,9 +88,9 @@ class FileCollector(Auxiliary, Thread):
         ]
 
         for filename in os.listdir("/"):
-            if os.path.isdir("/" + filename) and filename not in ignore:
-                log.info("FileCollector trying to watch dir %s" % (filename))
-                watch_this = os.path.abspath("/" + filename)
+            if os.path.isdir(f"/{filename}") and filename not in ignore:
+                log.info("FileCollector trying to watch dir %s", filename)
+                watch_this = os.path.abspath(f"/{filename}")
                 self.watch_manager.add_watch(watch_this, flags, rec=True, auto_add=True)
 
         log.info("FileCollector setup complete")
@@ -119,7 +119,7 @@ class FileCollector(Auxiliary, Thread):
                     return
 
                 if event.pathname.startswith("/tmp/#"):
-                    # log.info("skipping wierd file %s", event.pathname)
+                    # log.info("Skipping wierd file %s", event.pathname)
                     return
 
                 if not os.path.isfile(event.pathname):
@@ -131,11 +131,11 @@ class FileCollector(Auxiliary, Thread):
 
                 for x in range(0, 1):
                     try:
-                        # log.info("trying to collect file %s", event.pathname)
+                        # log.info("Trying to collect file %s", event.pathname)
                         sha256 = hash_file(hashlib.sha256, event.pathname)
-                        filename = "%s_%s" % (sha256[:16], os.path.basename(event.pathname))
+                        filename = f"{sha256[:16]}_{os.path.basename(event.pathname)}"
                         if filename in self.uploadedHashes:
-                            # log.info("already collected file %s", event.pathname)
+                            # log.info("Already collected file %s", event.pathname)
                             return
                         upload_path = os.path.join("files", filename)
                         upload_to_host(event.pathname, upload_path)
@@ -144,13 +144,13 @@ class FileCollector(Auxiliary, Thread):
                     except Exception as e:
                         log.info('Error dumping file from path "%s": %s', event.pathname, e)
 
-                    # log.info("retrying %s", event.pathname)
+                    # log.info("Retrying %s", event.pathname)
                     time.sleep(1)
 
             except Exception as e:
                 log.error("Exception processing event %s", e)
 
-        _method_name.__name__ = "process_{}".format(method)
+        _method_name.__name__ = f"process_{method}"
         setattr(cls, _method_name.__name__, _method_name)
 
 

--- a/analyzer/linux/modules/auxiliary/human.py
+++ b/analyzer/linux/modules/auxiliary/human.py
@@ -53,7 +53,7 @@ def destroyOfficeWindows(window):
             ("libreoffice", "libreoffice-impress"),
             ("win", "Xpdf"),
         ]:
-            log.debug("Destroying: %s" % w.get_wm_class()[1])
+            log.debug("Destroying: %s", w.get_wm_class()[1])
             w.destroy()
         destroyOfficeWindows(w)
 

--- a/analyzer/linux/modules/auxiliary/screenshots.py
+++ b/analyzer/linux/modules/auxiliary/screenshots.py
@@ -50,7 +50,7 @@ class Screenshots(Auxiliary, Thread):
         @return: operation status.
         """
         if not Screenshot().have_pil():
-            log.warning("Python Image Library is not installed, " "screenshots are disabled")
+            log.warning("Python Image Library is not installed, screenshots are disabled")
             return False
 
         img_counter = 0
@@ -77,7 +77,7 @@ class Screenshots(Auxiliary, Thread):
 
             # now upload to host from the StringIO
             nf = NetlogFile()
-            nf.init("shots/%s.jpg" % str(img_counter).rjust(4, "0"))
+            nf.init(f"shots/{str(img_counter).rjust(4, '0')}.jpg")
             for chunk in tmpio:
                 nf.sock.send(chunk)
             nf.close()

--- a/analyzer/linux/modules/auxiliary/stap.py
+++ b/analyzer/linux/modules/auxiliary/stap.py
@@ -40,7 +40,7 @@ class STAP(Auxiliary):
         elif os.path.exists("/root/.cape") and has_stap("/root/.cape"):
             path = has_stap("root/.cape")
         else:
-            log.warning("Could not find STAP LKM, aborting systemtap analysis.")
+            log.warning("Could not find STAP LKM, aborting systemtap analysis")
             return False
 
         stap_start = time.time()
@@ -64,13 +64,13 @@ class STAP(Auxiliary):
         self.proc.wait()
 
         stap_stop = time.time()
-        log.info("STAP aux module startup took %.2f seconds" % (stap_stop - stap_start))
+        log.info("STAP aux module startup took %.2f seconds", stap_stop - stap_start)
         return True
 
     def stop(self):
         try:
             r = self.proc.poll()
-            log.debug("stap subprocess retval %r", r)
+            log.debug("stap subprocess retval %d", r)
             self.proc.kill()
         except Exception as e:
             log.warning("Exception killing stap: %s", e)

--- a/analyzer/linux/modules/packages/doc.py
+++ b/analyzer/linux/modules/packages/doc.py
@@ -11,6 +11,6 @@ class Doc(Package):
     """LibreOffice document."""
 
     def prepare(self):
-        system('/bin/chmod +x "%s"' % self.target)
+        system(f'/bin/chmod +x "{self.target}"')
         self.args = [self.target] + self.args
         self.target = "/usr/bin/libreoffice --writer"

--- a/analyzer/linux/modules/packages/generic.py
+++ b/analyzer/linux/modules/packages/generic.py
@@ -13,6 +13,6 @@ class Generic(Package):
     def prepare(self):
         # Make sure that our target is executable
         # /usr/bin/open will handle it
-        system('/bin/chmod +x "%s"' % self.target)
+        system(f'/bin/chmod +x "{self.target}"')
         self.args = [self.target] + self.args
         self.target = "sh -c"

--- a/analyzer/linux/modules/packages/pdf.py
+++ b/analyzer/linux/modules/packages/pdf.py
@@ -11,6 +11,6 @@ class Pdf(Package):
     """Bash shell script analysys package."""
 
     def prepare(self):
-        system('/bin/chmod +x "%s"' % self.target)
+        system(f'/bin/chmod +x "{self.target}"')
         self.args = [self.target] + self.args
         self.target = "/usr/bin/xpdf"

--- a/analyzer/linux/modules/packages/perl.py
+++ b/analyzer/linux/modules/packages/perl.py
@@ -13,4 +13,4 @@ class Perl(Package):
     def prepare(self):
         # Make sure that our target is executable
         # /usr/bin/open will handle it
-        system('/bin/chmod +x "%s"' % self.target)
+        system(f'/bin/chmod +x "{self.target}"')

--- a/analyzer/linux/modules/packages/wget.py
+++ b/analyzer/linux/modules/packages/wget.py
@@ -25,7 +25,7 @@ class Wget(Package):
     def prepare(self):
         # todo use random tempfile
         # ToDo random name
-        ret = system('wget "%s" -O /tmp/file_malwr --no-check-certificate' % self.target)
+        ret = system(f'wget "{self.target}" -O /tmp/file_malwr --no-check-certificate')
         log.info(ret)
         # py3 permission
         chmod("/tmp/file_malwr", 0o755)

--- a/analyzer/linux/modules/packages/zip.py
+++ b/analyzer/linux/modules/packages/zip.py
@@ -23,7 +23,7 @@ class Zip(Package):
         password = self.options.get("password")
         files = self._extract(self.target, password)
         if not files or len(files) == 0:
-            raise Exception("Invalid (or empty) zip archive: %s" % self.target)
+            raise Exception(f"Invalid (or empty) zip archive: {self.target}")
         # Look for a file to analyse
         target_name = self.options.get("file")
         if not target_name:
@@ -47,9 +47,9 @@ class Zip(Package):
         pkg_class = choose_package_class(file_info, target_name)
 
         if not pkg_class:
-            raise Exception("Unable to detect analysis package for the file %s" % target_name)
+            raise Exception(f"Unable to detect analysis package for the file {target_name}")
         else:
-            log.info('Analysing file "%s" using package "%s"', target_name, str(pkg_class))
+            log.info('Analysing file "%s" using package "%s"', target_name, pkg_class)
 
         kwargs = {"options": self.options, "timeout": self.timeout}
         # We'll forward start() method invocation to the proper package later
@@ -73,7 +73,7 @@ class Zip(Package):
         with ZipFile(archive_path, "r") as archive:
             try:
                 archive.extractall(path=extract_path, pwd=password)
-                log.info("extractall")
+                log.info("Extracted all")
             except BadZipfile:
                 raise Exception("Invalid Zip file")
             # Try to extract it again, but with a default password
@@ -81,7 +81,7 @@ class Zip(Package):
                 try:
                     archive.extractall(path=extract_path, pwd="infected")
                 except RuntimeError as err:
-                    raise Exception("Unable to extract Zip file: %s" % err)
+                    raise Exception(f"Unable to extract Zip file: {err}")
             finally:
                 self._extract_nested_archives(archive, extract_path, password)
         return archive.namelist()
@@ -106,10 +106,7 @@ def _prepare_archive_at_path(filename):
         return None
     # Test if zip file contains a file named as itself
     if _is_overwritten(filename):
-        log.debug(
-            "ZIP file contains a file with the same name, original is \
-        going to be overwrite"
-        )
+        log.debug("ZIP file contains a file with the same name, original is going to be overwritten")
         # In this case we just change the file name
         new_zip_path = filename + _random_extension()
         move(filename, new_zip_path)
@@ -127,7 +124,7 @@ def _is_overwritten(zip_path):
 
 
 def _random_extension(length=5):
-    return "." + "".join(SystemRandom().choice(ascii_letters) for _ in range(length))
+    return f".{''.join(SystemRandom().choice(ascii_letters) for _ in range(length))}"
 
 
 def _fileinfo(target):

--- a/analyzer/windows/analyzer.py
+++ b/analyzer/windows/analyzer.py
@@ -122,12 +122,12 @@ def add_protected_path(name):
 
 def upload_files(folder):
     """Create a copy of the given file path."""
-    log_folder = PATHS["root"] + "\\" + folder
+    log_folder = f"{PATHS['root']}\\{folder}"
     try:
         if os.path.exists(log_folder):
-            log.info('Uploading files at path "%s" ', log_folder)
+            log.info('Uploading files at path "%s"', log_folder)
         else:
-            log.warning('Folder at path "%s" does not exist, skip.', log_folder)
+            log.warning('Folder at path "%s" does not exist, skipping', log_folder)
             return
     except IOError as e:
         log.warning('Unable to access folder at path "%s": %s', log_folder, e)
@@ -181,8 +181,8 @@ class Analyzer:
         """Return \\\\.\\PIPE on Windows XP and \\??\\PIPE elsewhere."""
         version = sys.getwindowsversion()
         if version.major == 5 and version.minor == 1:
-            return "\\\\.\\PIPE\\" + name
-        return "\\??\\PIPE\\" + name
+            return f"\\\\.\\PIPE\\{name}"
+        return f"\\??\\PIPE\\{name}"
 
     def pids_from_process_name_list(self, namelist):
         proclist = []
@@ -306,9 +306,9 @@ class Analyzer:
 
         # Report missed injections
         for pid in INJECT_LIST:
-            log.warning("Monitor injection attempted but failed for process %d.", pid)
+            log.warning("Monitor injection attempted but failed for process %d", pid)
 
-        log.info("Analysis completed.")
+        log.info("Analysis completed")
 
     def get_completion_key(self):
         if hasattr(self.config, "completion_key"):
@@ -334,7 +334,7 @@ class Analyzer:
         # If no analysis package was specified at submission, we try to select
         # one automatically.
         if not self.config.package:
-            log.debug("No analysis package specified, trying to detect " "it automagically.")
+            log.debug("No analysis package specified, trying to detect it automagically")
 
             # If the analysis target is a file, we choose the package according
             # to the file format.
@@ -348,23 +348,23 @@ class Analyzer:
             # If we weren't able to automatically determine the proper package,
             # we need to abort the analysis.
             if not package:
-                raise CuckooError("No valid package available for file " "type: {0}".format(self.config.file_type))
+                raise CuckooError(f"No valid package available for file type: {self.config.file_type}")
 
             log.info('Automatically selected analysis package "%s"', package)
         # Otherwise just select the specified package.
         else:
             package = self.config.package
-            log.info('Analysis package "%s" has been specified.', package)
+            log.info('Analysis package "%s" has been specified', package)
         # Generate the package path.
-        package_name = "modules.packages.%s" % package
+        package_name = f"modules.packages.{package}"
         # Try to import the analysis package.
         try:
             log.debug('Importing analysis package "%s"...', package)
             __import__(package_name, globals(), locals(), ["dummy"])
-            # log.debug('Imported analysis package "%s".', package)
+            # log.debug('Imported analysis package "%s"', package)
         # If it fails, we need to abort the analysis.
         except ImportError:
-            raise CuckooError('Unable to import package "{0}", does ' "not exist.".format(package_name))
+            raise CuckooError(f'Unable to import package "{package_name}", does not exist')
         except Exception as e:
             log.exception(e)
         # Initialize the package parent abstract.
@@ -373,14 +373,14 @@ class Analyzer:
         try:
             package_class = Package.__subclasses__()[0]
         except IndexError as e:
-            raise CuckooError("Unable to select package class " "(package={0}): {1}".format(package_name, e))
+            raise CuckooError(f"Unable to select package class (package={package_name}): {e}")
         except Exception as e:
             log.exception(e)
 
         # Initialize the analysis package.
         log.debug('Initializing analysis package "%s"...', package)
         self.package = package_class(self.options, self.config)
-        # log.debug('Initialized analysis package "%s".', package)
+        # log.debug('Initialized analysis package "%s"', package)
 
         # Move the sample to the current working directory as provided by the
         # task - one is able to override the starting path of the sample.
@@ -437,7 +437,7 @@ class Analyzer:
 
         # Initialize Auxiliary modules
         Auxiliary()
-        prefix = auxiliary.__name__ + "."
+        prefix = f"{auxiliary.__name__}."
 
         # disable_screens = True
         # if "disable_screens" in self.options and self.options["disable_screens"] == "0":
@@ -450,9 +450,9 @@ class Analyzer:
             try:
                 log.debug('Importing auxiliary module "%s"...', name)
                 __import__(name, globals(), locals(), ["dummy"])
-                # log.debug('Imported auxiliary module "%s".', name)
+                # log.debug('Imported auxiliary module "%s"', name)
             except ImportError as e:
-                log.warning("Unable to import the auxiliary module " '"%s": %s', name, e)
+                log.warning('Unable to import the auxiliary module "%s": %s', name, e)
         # Walk through the available auxiliary modules.
         aux_avail = []
 
@@ -463,7 +463,7 @@ class Analyzer:
             try:
                 log.debug('Initializing auxiliary module "%s"...', module.__name__)
                 aux = module(self.options, self.config)
-                # log.debug('Initialized auxiliary module "%s".', module.__name__)
+                # log.debug('Initialized auxiliary module "%s"', module.__name__)
                 aux_avail.append(aux)
                 # log.debug('Trying to start auxiliary module "%s"...', module.__name__)
                 aux.start()
@@ -513,13 +513,11 @@ class Analyzer:
         try:
             pids = self.package.start(self.target)
         except NotImplementedError:
-            raise CuckooError('The package "{0}" doesn\'t contain a start ' "function.".format(package_name))
+            raise CuckooError('The package "{package_name}" doesn\'t contain a start function')
         except CuckooPackageError as e:
-            raise CuckooError('The package "{0}" start function raised an ' "error: {1}".format(package_name, e))
+            raise CuckooError(f'The package "{package_name}" start function raised an error: {e}')
         except Exception as e:
-            raise CuckooError(
-                'The package "{0}" start function encountered ' "an unhandled exception: " "{1}".format(package_name, e)
-            )
+            raise CuckooError(f'The package "{package_name}" start function encountered an unhandled exception: {e}')
 
         # If the analysis package returned a list of process IDs, we add them
         # to the list of monitored processes and enable the process monitor.
@@ -531,13 +529,13 @@ class Analyzer:
         # where the package isn't enabling any behavioral analysis), we don't
         # enable the process monitor.
         else:
-            log.info("No process IDs returned by the package, running for the full timeout.")
+            log.info("No process IDs returned by the package, running for the full timeout")
             pid_check = False
 
         # Check in the options if the user toggled the timeout enforce. If so,
         # we need to override pid_check and disable process monitor.
         if self.config.enforce_timeout:
-            log.info("Enabled timeout enforce, running for the full timeout.")
+            log.info("Enabled timeout enforce, running for the full timeout")
             pid_check = False
 
         time_start = timeit.default_timer()
@@ -548,7 +546,7 @@ class Analyzer:
         while self.do_run:
             self.time_counter = timeit.default_timer() - time_start
             if self.time_counter >= int(self.config.timeout):
-                log.info("Analysis timeout hit, terminating analysis.")
+                log.info("Analysis timeout hit, terminating analysis")
                 ANALYSIS_TIMED_OUT = True
                 break
 
@@ -556,7 +554,7 @@ class Analyzer:
             # operating on the list of monitored processes. Therefore we
             # cannot proceed with the checks until the lock is released.
             if self.process_lock.locked():
-                log.info("we are locked")
+                log.info("Process lock is locked")
                 KERNEL32.Sleep(1000)
                 continue
 
@@ -575,7 +573,7 @@ class Analyzer:
                                     except Exception as e:
                                         log.error(e, exc_info=True)
                                 else:
-                                    log.info("procdump not enabled")
+                                    log.info("Procdump not enabled")
                                 log.info("Process with pid %s appears to have terminated", pid)
                                 if pid in self.process_list.pids:
                                     self.process_list.remove_pid(pid)
@@ -586,7 +584,7 @@ class Analyzer:
                             not self.LASTINJECT_TIME or (timeit.default_timer() >= (self.LASTINJECT_TIME + 15))  # Add 15 seconds
                         ):
                             if emptytime and (timeit.default_timer() >= (emptytime + 5)):  # Add 5 seconds
-                                log.info("Process list is empty, terminating analysis.")
+                                log.info("Process list is empty, terminating analysis")
                                 break
                             elif not emptytime:
                                 emptytime = timeit.default_timer()
@@ -604,14 +602,14 @@ class Analyzer:
                     # returns False, it means that it requested the analysis
                     # to be terminate.
                     if not self.package.check():
-                        log.info("The analysis package requested the " "termination of the analysis.")
+                        log.info("The analysis package requested the termination of the analysis")
                         break
 
                 # If the check() function of the package raised some exception
                 # we don't care, we can still proceed with the analysis but we
                 # throw a warning.
                 except Exception as e:
-                    log.warning('The package "%s" check function raised ' "an exception: %s", package_name, e)
+                    log.warning('The package "%s" check function raised an exception: %s', package_name, e)
             finally:
                 # Zzz.
                 KERNEL32.Sleep(1000)
@@ -624,14 +622,14 @@ class Analyzer:
                     try:
                         proc.set_terminate_event()
                     except Exception:
-                        log.error("Unable to set terminate event for process %d.", proc.pid)
+                        log.error("Unable to set terminate event for process %d", proc.pid)
                         continue
-                    log.info("Terminate event set for process %d.", proc.pid)
+                    log.info("Terminate event set for process %d", proc.pid)
                 if self.config.terminate_processes:
                     # Try to terminate remaining active processes.
                     # (This setting may render full system memory dumps less useful!)
                     if proc.is_alive() and not pid in self.CRITICAL_PROCESS_LIST and not proc.is_critical():
-                        log.info("Terminating process %d before shutdown.", proc.pid)
+                        log.info("Terminating process %d before shutdown", proc.pid)
                         proc_counter = 0
                         while proc.is_alive():
                             if proc_counter > 5:
@@ -639,24 +637,24 @@ class Analyzer:
                                     proc.terminate()
                                 except Exception:
                                     continue
-                            log.info("Waiting for process %d to exit.", proc.pid)
+                            log.info("Waiting for process %d to exit", proc.pid)
                             KERNEL32.Sleep(1000)
                             proc_counter += 1
 
         # Create the shutdown mutex.
         KERNEL32.CreateMutexA(None, False, SHUTDOWN_MUTEX)
-        log.info("Created shutdown mutex.")
+        log.info("Created shutdown mutex")
         # since the various processes poll for the existence of the mutex, sleep
         # for a second to ensure they see it before they're terminated
         KERNEL32.Sleep(1000)
 
-        log.info("Shutting down package.")
+        log.info("Shutting down package")
         try:
             # Before shutting down the analysis, the package can perform some
             # final operations through the finish() function.
             self.package.finish()
         except Exception as e:
-            log.warning('The package "%s" finish function raised an ' "exception: %s", package_name, e)
+            log.warning('The package "%s" finish function raised an exception: %s', package_name, e)
 
         try:
             # Upload files the package created to package_files in the
@@ -664,9 +662,9 @@ class Analyzer:
             for path, name in self.package.package_files() or []:
                 upload_to_host(path, os.path.join("package_files", name))
         except Exception as e:
-            log.warning('The package "%s" package_files function raised an ' "exception: %s", package_name, e)
+            log.warning('The package "%s" package_files function raised an exception: %s', package_name, e)
 
-        log.info("Stopping auxiliary modules.")
+        log.info("Stopping auxiliary modules")
         # Terminate the Auxiliary modules.
         for aux in AUX_ENABLED:
             if not hasattr(aux, "stop"):
@@ -686,9 +684,9 @@ class Analyzer:
             except (NotImplementedError, AttributeError):
                 continue
             except Exception as e:
-                log.warning("Exception running finish callback of auxiliary " "module %s: %s", aux.__class__.__name__, e)
+                log.warning("Exception running finish callback of auxiliary module %s: %s", aux.__class__.__name__, e)
 
-        log.info("Shutting down pipe server and dumping dropped files.")
+        log.info("Shutting down pipe server and dumping dropped files")
 
         return True
 
@@ -732,7 +730,7 @@ class Files(object):
 
         if pid not in self.files[filepath.lower()]:
             self.files[filepath.lower()].append(pid)
-            verbose and log.info("Added pid %s for %r", pid, filepath)
+            verbose and log.info("Added pid %s for %s", pid, filepath)
 
             # PROCESS_LIST.append(int(pid))
             add_pid_to_aux_modules(int(pid))
@@ -749,7 +747,7 @@ class Files(object):
     def dump_file(self, filepath, metadata="", pids=False, ppids=False, category="files"):
         """Dump a file to the host."""
         if not os.path.isfile(filepath):
-            log.warning("File at path %r does not exist, skip.", filepath)
+            log.warning("File at path %s does not exist, skipping", filepath)
             return False
 
         duplicated = False
@@ -773,7 +771,7 @@ class Files(object):
 
         if category == "memory":
             if pids:
-                upload_path = os.path.join(category, "{}.dmp".format(pids[0]))
+                upload_path = os.path.join(category, f"{pids[0]}.dmp")
             else:
                 pids = [os.path.basename(filepath).split(".")[0]]
                 upload_path = os.path.join(category, os.path.basename(filepath))
@@ -892,13 +890,12 @@ class CommandPipeHandler(object):
     def _handle_loaded(self, data):
         """The monitor has loaded into a particular process."""
         if not data:
-            log.warning("Received loaded command with incorrect parameters, " "skipping it.")
+            log.warning("Received loaded command with incorrect parameters, skipping it")
             return
 
         # pid, track = data.split(b",")
         # if not pid.isdigit() or not track.isdigit():
-        #    log.warning("Received loaded command with incorrect parameters, "
-        #                "skipping it.")
+        #    log.warning("Received loaded command with incorrect parameters, skipping it")
         #    return
 
         self.analyzer.process_lock.acquire()
@@ -943,7 +940,7 @@ class CommandPipeHandler(object):
         self.analyzer.process_lock.release()
 
     def _handle_kerror(self, error_msg):
-        log.error("Error : %s", str(error_msg))
+        log.error("Error : %s", error_msg)
 
     # if a new driver has been loaded, we stop the analysis
     def _handle_ksubvert(self, data):
@@ -1066,7 +1063,7 @@ class CommandPipeHandler(object):
             si.dwFlags = 1
             # SW_HIDE
             si.wShowWindow = 0
-            subprocess.call("sc config " + servname.decode("utf-8") + " type= own", startupinfo=si)
+            subprocess.call(f"sc config {servname.decode('utf-8')} type= own", startupinfo=si)
             log.info('Announced starting service "%s"', servname)
             if not self.analyzer.MONITORED_SERVICES:
                 # Inject into services.exe so we can monitor service creation
@@ -1084,7 +1081,7 @@ class CommandPipeHandler(object):
                     KERNEL32.Sleep(1000)
                     self.analyzer.MONITORED_SERVICES = True
                 else:
-                    log.error("Unable to monitor service %s" % (servname))
+                    log.error("Unable to monitor service %s", servname)
 
     def _handle_resume(self, data):
         # RESUME:2560,3728'
@@ -1129,7 +1126,7 @@ class CommandPipeHandler(object):
 
         if process_id in (self.analyzer.pid, self.analyzer.ppid):
             if process_id not in self.ignore_list["pid"]:
-                log.warning("Received request to inject Cuckoo processes, " "skipping it.")
+                log.warning("Received request to inject Cuckoo processes, skipping it")
                 self.ignore_list["pid"].append(process_id)
             self.analyzer.process_lock.release()
             return
@@ -1141,7 +1138,9 @@ class CommandPipeHandler(object):
             # This pid is already on the notrack list, move it to the
             # list of tracked pids.
             if not self.analyzer.process_list.has_pid(process_id, notrack=False):
-                log.debug("Received request to inject pid=%d. It was already " "on our notrack list, moving it to the track list.")
+                log.debug(
+                    "Received request to inject pid=%d. It was already on our notrack list, moving it to the track list", process_id
+                )
 
                 self.analyzer.process_list.remove_pid(process_id)
                 self.analyzer.process_list.add_pid(process_id)
@@ -1174,7 +1173,7 @@ class CommandPipeHandler(object):
             else:
                 proc.inject(injectmode=INJECT_CREATEREMOTETHREAD, interest=filepath, nosleepskip=True)
 
-            log.info("Injected into process with pid %s and name %r", proc.pid, filename)
+            log.info("Injected into process with pid %s and name %s", proc.pid, filename)
 
     def _handle_process(self, data):
         """Request for injection into a process."""
@@ -1240,12 +1239,12 @@ class CommandPipeHandler(object):
         """Request for injection into a process using APC."""
         # Parse the process and thread identifier.
         if not data or data.count(b",") != 2:
-            log.warning("Received PROCESS2 command from monitor with an " "incorrect argument.")
+            log.warning("Received PROCESS2 command from monitor with an incorrect argument")
             return
 
         pid, tid, mode = data.split(b",")
         if not pid.isdigit() or not tid.isdigit() or not mode.isdigit():
-            log.warning("Received PROCESS2 command from monitor with an " "incorrect argument.")
+            log.warning("Received PROCESS2 command from monitor with an incorrect argument")
             return
 
         return self._inject_process(int(pid), int(tid), int(mode))
@@ -1304,16 +1303,16 @@ class CommandPipeHandler(object):
 
     def _handle_dumpreqs(self, data):
         if not data.isdigit():
-            log.warning("Received DUMPREQS command with an incorrect argument %r.", data)
+            log.warning("Received DUMPREQS command with an incorrect argument %s", data)
             return
         pid = int(data)
         if pid not in self.tracked:
-            log.warning("Received DUMPREQS command but there are no reqs for pid %d.", pid)
+            log.warning("Received DUMPREQS command but there are no reqs for pid %d", pid)
             return
 
         dumpreqs = self.tracked[pid].get("dumpreq", [])
         for addr, length in dumpreqs:
-            log.debug("tracked dump req (%r, %r, %r)", pid, addr, length)
+            log.debug("Tracked dump req (%d, %s, %s)", pid, addr, length)
 
             if not addr or not length:
                 continue
@@ -1342,7 +1341,7 @@ class CommandPipeHandler(object):
     def dispatch(self, data):
         response = "NOPE"
         if not data or b":" not in data:
-            log.critical("Unknown command received from the monitor: %r", data.strip())
+            log.critical("Unknown command received from the monitor: %s", data.strip())
         else:
             # Backwards compatibility (old syntax is, e.g., "FILE_NEW:" vs the
             # new syntax, e.g., "1234:FILE_NEW:").
@@ -1352,15 +1351,15 @@ class CommandPipeHandler(object):
             # if command not in (b"DEBUG", b"INFO"):
             #    log.info((command, arguments, "dispatch"))
             self.pid = None
-            fn = getattr(self, "_handle_%s" % command.lower().decode("utf-8"), None)
+            fn = getattr(self, f"_handle_{command.lower().decode()}", None)
             if not fn:
-                log.critical("Unknown command received from the monitor: %r", data.strip())
+                log.critical("Unknown command received from the monitor: %s", data.strip())
             else:
                 try:
                     response = fn(arguments)
                 except Exception as e:
                     log.error(e, exc_info=True)
-                    log.exception("Pipe command handler exception occurred (command " "%s args %r).", command, arguments)
+                    log.exception("Pipe command handler exception occurred (command %s args %s)", command, arguments)
 
         return response
 
@@ -1410,7 +1409,7 @@ if __name__ == "__main__":
         if len(log.handlers):
             log.exception(error_exc)
         else:
-            sys.stderr.write("{0}\n".format(error_exc))
+            sys.stderr.write(f"{error_exc}\n")
 
     # Once the analysis is completed or terminated for any reason, we report
     # back to the agent, notifying that it can report back to the host.
@@ -1422,7 +1421,7 @@ if __name__ == "__main__":
             complete_excp = traceback.format_exc()
             data["status"] = "exception"
             if "description" in data:
-                data["description"] += "%s\n%s" % (data["description"], complete_excp)
+                data["description"] += f"{data['description']}\n{complete_excp}"
             else:
                 data["description"] = complete_excp
         try:

--- a/analyzer/windows/lib/api/process.py
+++ b/analyzer/windows/lib/api/process.py
@@ -64,9 +64,7 @@ def get_referrer_url(interest):
     vedstr = b"0CCEQfj" + base64.urlsafe_b64encode(random_string(random.randint(5, 8) * 3).encode("utf-8"))
     eistr = base64.urlsafe_b64encode(random_string(12).encode("utf-8"))
     usgstr = b"AFQj" + base64.urlsafe_b64encode(random_string(12).encode("utf-8"))
-    referrer = "http://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd={0}&ved={1}&url={2}&ei={3}&usg={4}".format(
-        itemidx, vedstr, escapedurl, eistr, usgstr
-    )
+    referrer = f"http://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd={itemidx}&ved={vedstr}&url={escapedurl}&ei={eistr}&usg={usgstr}"
     return referrer
 
 
@@ -189,9 +187,7 @@ class Process:
         return True
 
     def is_critical(self):
-        """Determines if process is 'critical' or not, so we can prevent
-        terminating it
-        """
+        """Determines if process is 'critical' or not, so we can prevent terminating it"""
         if not self.h_process:
             self.open()
 
@@ -277,32 +273,30 @@ class Process:
             "[MiniFilter.DriverFiles]\r\n"
             "%DriverName%.sys\r\n"
             "[SourceDisksFiles]\r\n"
-            "{driver_name}.sys = 1,,\r\n"
+            f"{driver_name}.sys = 1,,\r\n"
             "[SourceDisksNames]\r\n"
             "1 = %DiskId1%,,,\r\n"
             "[Strings]\r\n"
-            'Prov = "{random_string8}"\r\n'
-            'ServiceDescription = "{random_string12}"\r\n'
-            'ServiceName = "{service_name}"\r\n'
-            'DriverName = "{driver_name}"\r\n'
-            'DiskId1 = "{service_name} Device Installation Disk"\r\n'
-            'DefaultInstance = "{service_name} Instance"\r\n'
-            'Instance1.Name = "{service_name} Instance"\r\n'
+            f'Prov = "{random_string(8)}"\r\n'
+            f'ServiceDescription = "{random_string(12)}"\r\n'
+            f'ServiceName = "{service_name}"\r\n'
+            f'DriverName = "{driver_name}"\r\n'
+            f'DiskId1 = "{service_name} Device Installation Disk"\r\n'
+            f'DefaultInstance = "{service_name} Instance"\r\n'
+            f'Instance1.Name = "{service_name} Instance"\r\n'
             'Instance1.Altitude = "370050"\r\n'
             "Instance1.Flags = 0x0"
-        ).format(
-            service_name=service_name, driver_name=driver_name, random_string8=random_string(8), random_string12=random_string(12)
         )
 
-        new_inf = os.path.join(os.getcwd(), "dll", "{0}.inf".format(service_name))
-        new_sys = os.path.join(os.getcwd(), "dll", "{0}.sys".format(driver_name))
+        new_inf = os.path.join(os.getcwd(), "dll", f"{service_name}.inf")
+        new_sys = os.path.join(os.getcwd(), "dll", f"{driver_name}.sys")
         copy(sys_file, new_sys)
-        new_exe = os.path.join(os.getcwd(), "dll", "{0}.exe".format(exe_name))
+        new_exe = os.path.join(os.getcwd(), "dll", f"{exe_name}.exe")
         copy(exe_file, new_exe)
-        log.info("[-] Driver name : " + new_sys)
-        log.info("[-] Inf name : " + new_inf)
-        log.info("[-] Application name : " + new_exe)
-        log.info("[-] Service : " + service_name)
+        log.info("[-] Driver name : %s", new_sys)
+        log.info("[-] Inf name : %s", new_inf)
+        log.info("[-] Application name : %s", new_exe)
+        log.info("[-] Service : %s", service_name)
 
         fh = open(new_inf, "w")
         fh.write(inf_data)
@@ -313,8 +307,8 @@ class Process:
             wow64 = c_ulong(0)
             KERNEL32.Wow64DisableWow64FsRedirection(byref(wow64))
 
-        os.system('cmd /c "rundll32 setupapi.dll, InstallHinfSection DefaultInstall 132 ' + new_inf + '"')
-        os.system("net start " + service_name)
+        os.system(f'cmd /c "rundll32 setupapi.dll, InstallHinfSection DefaultInstall 132 {new_inf}"')
+        os.system(f"net start {service_name}")
 
         si = STARTUPINFO()
         si.cb = sizeof(si)
@@ -325,16 +319,16 @@ class Process:
         if not ldp:
             if os_is_64bit:
                 KERNEL32.Wow64RevertWow64FsRedirection(wow64)
-            log.error("Failed starting " + exe_name + ".exe.")
+            log.error("Failed starting %s.exe", exe_name)
             return False
 
-        config_path = os.path.join(os.getenv("TEMP"), "%s.ini" % self.pid)
+        config_path = os.path.join(os.getenv("TEMP"), f"{self.pid}.ini")
         with open(config_path, "w") as config:
             cfg = Config("analysis.conf")
 
-            config.write("host-ip={0}\n".format(cfg.ip))
-            config.write("host-port={0}\n".format(cfg.port))
-            config.write("pipe={0}\n".format(PIPE))
+            config.write(f"host-ip={cfg.ip}\n")
+            config.write(f"host-port={cfg.port}\n")
+            config.write(f"pipe={PIPE}\n")
 
         log.info("Sending startup information")
         hFile = KERNEL32.CreateFileW(PATH_KERNEL_DRIVER, GENERIC_READ | GENERIC_WRITE, 0, None, OPEN_EXISTING, 0, None)
@@ -354,31 +348,18 @@ class Process:
             flag = KERNEL32.Process32First(snapshot, byref(proc_info))
             while flag:
                 if proc_info.sz_exeFile == "VBoxService.exe":
-                    log.info("VBoxService.exe found !")
+                    log.info("VBoxService.exe found!")
                     pid_vboxservice = proc_info.th32ProcessID
                     flag = 0
                 elif proc_info.sz_exeFile == "VBoxTray.exe":
                     pid_vboxtray = proc_info.th32ProcessID
-                    log.info("VBoxTray.exe found !")
+                    log.info("VBoxTray.exe found!")
                     flag = 0
                 flag = KERNEL32.Process32Next(snapshot, byref(proc_info))
             bytes_returned = c_ulong(0)
-            msg = (
-                str(self.pid)
-                + "_"
-                + str(ppid)
-                + "_"
-                + str(os.getpid())
-                + "_"
-                + str(pi.dwProcessId)
-                + "_"
-                + str(pid_vboxservice)
-                + "_"
-                + str(pid_vboxtray)
-                + "\0"
-            )
+            msg = f"{self.pid}_{ppid}_{os.getpid()}_{pi.dwProcessId}_{pid_vboxservice}_{pid_vboxtray}\0"
             KERNEL32.DeviceIoControl(hFile, IOCTL_PID, msg, len(msg), None, 0, byref(bytes_returned), None)
-            msg = os.getcwd() + "\0"
+            msg = f"{os.getcwd()}\0"
             KERNEL32.DeviceIoControl(
                 hFile, IOCTL_CUCKOO_PATH, str(msg, "utf-8"), len(str(msg, "utf-8")), None, 0, byref(bytes_returned), None
             )
@@ -395,7 +376,7 @@ class Process:
         @return: operation status.
         """
         if not os.access(path, os.X_OK):
-            log.error('Unable to access file at path "%s", ' "execution aborted", path)
+            log.error('Unable to access file at path "%s", execution aborted', path)
             return False
 
         startup_info = STARTUPINFO()
@@ -406,7 +387,7 @@ class Process:
         startup_info.wShowWindow = 1
         process_info = PROCESS_INFORMATION()
 
-        arguments = '"' + path + '" '
+        arguments = f'"{path}" '
         if args:
             arguments += args
 
@@ -424,13 +405,13 @@ class Process:
             self.h_process = process_info.hProcess
             self.thread_id = process_info.dwThreadId
             self.h_thread = process_info.hThread
-            log.info('Successfully executed process from path "%s" with ' 'arguments "%s" with pid %d', path, args or "", self.pid)
+            log.info('Successfully executed process from path "%s" with arguments "%s" with pid %d', path, args or "", self.pid)
             if kernel_analysis:
                 return self.kernel_analyze()
             return True
         else:
             log.error(
-                'Failed to execute process from path "%s" with ' 'arguments "%s" (Error: %s)',
+                'Failed to execute process from path "%s" with arguments "%s" (Error: %s)',
                 path,
                 args,
                 get_error_string(KERNEL32.GetLastError()),
@@ -442,7 +423,7 @@ class Process:
         @return: operation status.
         """
         if not self.suspended:
-            log.warning("The process with pid %d was not suspended at creation" % self.pid)
+            log.warning("The process with pid %d was not suspended at creation", self.pid)
             return False
 
         if not self.h_thread:
@@ -493,10 +474,10 @@ class Process:
             self.open()
 
         if KERNEL32.TerminateProcess(self.h_process, 1):
-            log.info("Successfully terminated process with pid %d.", self.pid)
+            log.info("Successfully terminated process with pid %d", self.pid)
             return True
         else:
-            log.error("Failed to terminate process with pid %d.", self.pid)
+            log.error("Failed to terminate process with pid %d", self.pid)
             return False
 
     def is_64bit(self):
@@ -533,7 +514,7 @@ class Process:
 
     def write_monitor_config(self, interest=None, nosleepskip=False):
 
-        config_path = format(os.getcwd()) + "\\dll\\%s.ini" % self.pid
+        config_path = os.path.join(os.getcwd(), "dll", f"{self.pid}.ini")
         log.info("Monitor config for process %s: %s", self.pid, config_path)
 
         with open(config_path, "w", encoding="utf-8") as config:
@@ -546,30 +527,26 @@ class Process:
                 Process.process_num += 1
             firstproc = Process.process_num == 1
 
-            config.write("host-ip={0}\n".format(self.config.ip))
-            config.write("host-port={0}\n".format(self.config.port))
-            config.write("pipe={0}\n".format(PIPE))
-            config.write("logserver={0}\n".format(logserver_path))
-            config.write("results={0}\n".format(PATHS["root"]))
-            config.write("analyzer={0}\n".format(os.getcwd()))
-            config.write("pythonpath={0}\n".format(os.path.dirname(sys.executable)))
-            config.write("first-process={0}\n".format("1" if firstproc else "0"))
-            config.write("startup-time={0}\n".format(Process.startup_time))
-            config.write("file-of-interest={0}\n".format(interest))
-            config.write("shutdown-mutex={0}\n".format(SHUTDOWN_MUTEX))
-            config.write("terminate-event={0}{1}\n".format(TERMINATE_EVENT, self.pid))
+            config.write(f"host-ip={self.config.ip}\n")
+            config.write(f"host-port={self.config.port}\n")
+            config.write(f"pipe={PIPE}\n")
+            config.write(f"logserver={logserver_path}\n")
+            config.write(f"results={PATHS['root']}\n")
+            config.write(f"analyzer={os.getcwd()}\n")
+            config.write(f"pythonpath={os.path.dirname(sys.executable)}\n")
+            config.write(f"first-process={1 if firstproc else 0}\n")
+            config.write(f"startup-time={Process.startup_time}\n")
+            config.write(f"file-of-interest={interest}\n")
+            config.write(f"shutdown-mutex={SHUTDOWN_MUTEX}\n")
+            config.write(f"terminate-event={TERMINATE_EVENT}{self.pid}\n")
 
             if nosleepskip or (
-                "force-sleepskip" not in self.options
-                and len(interest) > 2
-                and interest[1] != ":"
-                and interest[0] != "\\"
-                and Process.process_num <= 2
+                "force-sleepskip" not in self.options and len(interest) > 2 and interest[:2] != "\\:" and Process.process_num <= 2
             ):
                 config.write("force-sleepskip=0\n")
 
             if "norefer" not in self.options and "referrer" not in self.options:
-                config.write("referrer={0}\n".format(get_referrer_url(interest)))
+                config.write(f"referrer={get_referrer_url(interest)}\n")
 
             server_options = [
                 "disable_cape",
@@ -585,7 +562,7 @@ class Process:
 
             for optname, option in self.options.items():
                 if optname not in server_options:
-                    config.write("{0}={1}\n".format(optname, option))
+                    config.write(f"{optname}={option}\n")
                     log.info("Option '%s' with value '%s' sent to monitor", optname, option)
 
     def inject(self, injectmode=INJECT_QUEUEUSERAPC, interest=None, nosleepskip=False):
@@ -604,7 +581,7 @@ class Process:
             thread_id = self.thread_id
 
         if not self.is_alive():
-            log.warning("The process with pid %s is not alive, " "injection aborted", self.pid)
+            log.warning("The process with pid %d is not alive, injection aborted", self.pid)
             return False
 
         if self.is_64bit():
@@ -620,18 +597,12 @@ class Process:
         dll = os.path.join(os.getcwd(), dll)
 
         if not os.path.exists(bin_name):
-            log.warning(
-                "Invalid loader path %s for injecting DLL in process " "with pid %d, injection aborted.", bin_name, self.pid
-            )
-            log.error(
-                "Please ensure the %s loader is in analyzer/windows/bin " "in order to analyze %s binaries.", bit_str, bit_str
-            )
+            log.warning("Invalid loader path %s for injecting DLL in process with pid %d, injection aborted", bin_name, self.pid)
+            log.error("Please ensure the %s loader is in analyzer/windows/bin in order to analyze %s binaries", bit_str, bit_str)
             return False
 
         if not os.path.exists(dll):
-            log.warning(
-                "Invalid path %s for monitor DLL to be injected in process " "with pid %d, injection aborted.", dll, self.pid
-            )
+            log.warning("Invalid path %s for monitor DLL to be injected in process with pid %d, injection aborted", dll, self.pid)
             return False
 
         self.write_monitor_config(interest, nosleepskip)
@@ -654,7 +625,7 @@ class Process:
                 return True
 
         except Exception as e:
-            log.error(("process", e))
+            log.error("Error running process: %s", e)
             return False
 
     def upload_memdump(self):
@@ -665,14 +636,15 @@ class Process:
             log.warning("No valid pid specified, memory dump cannot be uploaded")
             return False
 
-        file_path = os.path.join(PATHS["memory"], "{0}.dmp".format(self.pid))
+        file_path = os.path.join(PATHS["memory"], f"{self.pid}.dmp")
         try:
-            file_path = os.path.join(PATHS["memory"], "{0}.dmp".format(self.pid))
-            upload_to_host(file_path, os.path.join("memory", "{0}.dmp".format(self.pid)), category="memory")
+            file_path = os.path.join(PATHS["memory"], f"{self.pid}.dmp")
+            upload_to_host(file_path, os.path.join("memory", f"{self.pid}.dmp"), category="memory")
         except Exception as e:
             print(e)
             log.error(e, exc_info=True)
-            log.error(os.path.join("memory", "{0}.dmp".format(self.pid)), file_path)
+            log.error(os.path.join("memory", f"{self.pid}.dmp"))
+            log.error(file_path)
         log.info("Memory dump of process %d uploaded", self.pid)
 
         return True
@@ -686,13 +658,12 @@ class Process:
             return False
 
         if not self.is_alive():
-            log.warning("The process with pid %d is not alive, memory " "dump aborted", self.pid)
+            log.warning("The process with pid %d is not alive, memory dump aborted", self.pid)
             return False
 
         bin_name = ""
         bit_str = ""
-        # file_path = os.path.join(PATHS["memory"], "{0}.dmp".format(self.pid))
-        file_path = os.path.join(PATHS["memory"], str(self.pid) + ".dmp")
+        file_path = os.path.join(PATHS["memory"], f"{self.pid}.dmp")
         if self.is_64bit():
             orig_bin_name = LOADER64_NAME
             bit_str = "64-bit"
@@ -711,19 +682,20 @@ class Process:
                 return False
         else:
             log.error(
-                "Please place the %s binary from cuckoomon into analyzer/windows/bin in order to analyze %s binaries.",
+                "Please place the %s binary from cuckoomon into analyzer/windows/bin in order to analyze %s binaries",
                 os.path.basename(bin_name),
                 bit_str,
             )
             return False
 
         try:
-            file_path = os.path.join(PATHS["memory"], str(self.pid) + ".dmp")
-            upload_to_host(file_path, os.path.join("memory", str(self.pid) + ".dmp"))
+            file_path = os.path.join(PATHS["memory"], f"{self.pid}.dmp")
+            upload_to_host(file_path, os.path.join("memory", f"{self.pid}.dmp"))
         except Exception as e:
             print(e)
             log.error(e, exc_info=True)
-            log.error(os.path.join("memory", "{0}.dmp".format(self.pid)), file_path)
+            log.error(os.path.join("memory", f"{self.pid}.dmp"))
+            log.error(file_path)
 
         log.info("Memory dump of process with pid %d completed", self.pid)
 

--- a/analyzer/windows/lib/api/utils.py
+++ b/analyzer/windows/lib/api/utils.py
@@ -43,7 +43,7 @@ class Utils:
             return False
 
     def cmd_wrapper(self, cmd):
-        # print("running command and waiting for it to finish %s" % (cmd))
+        # print(f"Running command and waiting for it to finish {cmd}")
         p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
         stdout, stderr = p.communicate()
         return (p.returncode, stdout, stderr)

--- a/analyzer/windows/lib/common/abstracts.py
+++ b/analyzer/windows/lib/common/abstracts.py
@@ -67,7 +67,7 @@ class Package(object):
             elif basedir == "HomeDrive":
                 # os.path.join() does not work well when giving just C:
                 # instead of C:\\, so we manually add the backslash.
-                homedrive = os.getenv("HomeDrive") + "\\"
+                homedrive = f"{os.getenv('HomeDrive')}\\"
                 yield os.path.join(homedrive, *path[1:])
             else:
                 yield os.path.join(*path)
@@ -81,7 +81,7 @@ class Package(object):
             if os.path.isfile(path):
                 return path
 
-        raise CuckooPackageError("Unable to find any %s executable." % application)
+        raise CuckooPackageError(f"Unable to find any {application} executable")
 
     def get_path_glob(self, application):
         """Search for the application in all available paths with glob support.
@@ -93,7 +93,7 @@ class Package(object):
                 if os.path.isfile(path):
                     return path
 
-        raise CuckooPackageError("Unable to find any %s executable." % application)
+        raise CuckooPackageError(f"Unable to find any {application} executable")
 
     def get_path_app_in_path(self, application):
         """Search for the application in all available paths.
@@ -107,7 +107,7 @@ class Package(object):
                 else:
                     return path
 
-        raise CuckooPackageError("Unable to find any %s executable." % application)
+        raise CuckooPackageError(f"Unable to find any {application} executable")
 
     def execute(self, path, args, interest):
         """Starts an executable for analysis.
@@ -124,7 +124,7 @@ class Package(object):
 
         p = Process(options=self.options, config=self.config)
         if not p.execute(path=path, args=args, suspended=suspended, kernel_analysis=kernel_analysis):
-            raise CuckooPackageError("Unable to execute the initial process, " "analysis aborted.")
+            raise CuckooPackageError("Unable to execute the initial process, analysis aborted")
 
         if free:
             return None
@@ -149,7 +149,7 @@ class Package(object):
 
         p = Process(options=self.options, config=self.config)
         if not p.execute(path=path, args=args, suspended=suspended, kernel_analysis=False):
-            raise CuckooPackageError("Unable to execute the initial process, " "analysis aborted.")
+            raise CuckooPackageError("Unable to execute the initial process, analysis aborted")
 
         is_64bit = p.is_64bit()
 

--- a/analyzer/windows/lib/common/constants.py
+++ b/analyzer/windows/lib/common/constants.py
@@ -18,11 +18,11 @@ PATHS = {
     "drop": os.path.join(ROOT, "drop"),
 }
 
-PIPE = "\\\\.\\PIPE\\" + random_string(6, 10)
-SHUTDOWN_MUTEX = "Global\\" + random_string(6, 10)
-TERMINATE_EVENT = "Global\\" + random_string(6, 10)
-CAPEMON32_NAME = "dll\\" + random_string(6, 8) + ".dll"
-CAPEMON64_NAME = "dll\\" + random_string(6, 8) + ".dll"
-LOADER32_NAME = "bin\\" + random_string(7, 7) + ".exe"
-LOADER64_NAME = "bin\\" + random_string(8, 8) + ".exe"
-LOGSERVER_PREFIX = "\\\\.\\PIPE\\" + random_string(8, 12)
+PIPE = f"\\\\.\\PIPE\\{random_string(6, 10)}"
+SHUTDOWN_MUTEX = f"Global\\{random_string(6, 10)}"
+TERMINATE_EVENT = f"Global\\{random_string(6, 10)}"
+CAPEMON32_NAME = f"dll\\{random_string(6, 8)}.dll"
+CAPEMON64_NAME = f"dll\\{random_string(6, 8)}.dll"
+LOADER32_NAME = f"bin\\{random_string(7)}.exe"
+LOADER64_NAME = f"bin\\{random_string(8)}.exe"
+LOGSERVER_PREFIX = f"\\\\.\\PIPE\\{random_string(8, 12)}"

--- a/analyzer/windows/lib/common/decode_vbe_jse.py
+++ b/analyzer/windows/lib/common/decode_vbe_jse.py
@@ -347,7 +347,7 @@ def DecodeVBEJSE(content, options):
 
 
 def Main():
-    oParser = optparse.OptionParser(usage="usage: %prog [options] [file]\n" + __description__, version="%prog " + __version__)
+    oParser = optparse.OptionParser(usage=f"usage: %prog [options] [file]\n{__description__}", version=f"%prog {__version__}")
     oParser.add_option("-m", "--man", action="store_true", default=False, help="Print manual")
     (options, args) = oParser.parse_args()
 

--- a/analyzer/windows/lib/common/errors.py
+++ b/analyzer/windows/lib/common/errors.py
@@ -384,6 +384,6 @@ def get_error_string(error_code):
     @return: error description if found.
     """
     if error_code in ERRORS:
-        return "%s (%s)" % (ERRORS[error_code]["description"], ERRORS[error_code]["name"])
+        return f"{ERRORS[error_code]['description']} ({ERRORS[error_code]['name']})"
     else:
         return str(error_code)

--- a/analyzer/windows/lib/common/results.py
+++ b/analyzer/windows/lib/common/results.py
@@ -23,12 +23,12 @@ def upload_to_host(file_path, dump_path, pids=[], ppids=[], metadata="", categor
     infd = None
     we_open = False
     if not os.path.exists(file_path):
-        log.warning("File {} doesn't exist anymore".format(file_path))
+        log.warning("File %s doesn't exist anymore", file_path)
         return
     file_size = Path(file_path).stat().st_size
-    log.info(f"File {file_path} size is {file_size}, Max size: {config.upload_max_size}")
+    log.info("File %s size is %d, Max size: %s", file_path, file_size, config.upload_max_size)
     if int(config.upload_max_size) < int(file_size) and config.do_upload_max_size is False:
-        log.warning("File {} size is too big: {}, ignoring".format(file_path, file_size))
+        log.warning("File %s size is too big: %d, ignoring", file_path, file_size)
         return
     try:
         nc = NetlogFile()
@@ -43,7 +43,7 @@ def upload_to_host(file_path, dump_path, pids=[], ppids=[], metadata="", categor
                 nc.send(buf, retry=True)
                 buf = infd.read(BUFSIZE)
     except Exception as e:
-        log.error("Exception uploading file {0} to host: {1}".format(file_path, e), exc_info=True)
+        log.error("Exception uploading file %s to host: %s", file_path, e, exc_info=True)
     finally:
         if infd and we_open:
             infd.close()
@@ -83,9 +83,9 @@ class NetlogConnection(object):
                 self.connect()
                 self.send(data, retry=False)
             else:
-                print(("Unhandled exception in NetlogConnection:", str(e)))
+                print(f"Unhandled exception in NetlogConnection: {e}")
         except Exception as e:
-            log.error(("Unhandled exception in NetlogConnection:", str(e)))
+            log.error("Unhandled exception in NetlogConnection: %s", e)
             # We really have nowhere to log this, if the netlog connection
             # does not work, we can assume that any logging won't work either.
             # So we just fail silently.

--- a/analyzer/windows/lib/core/log.py
+++ b/analyzer/windows/lib/core/log.py
@@ -61,7 +61,7 @@ class LogServerThread(Thread):
                 try:
                     data += buf.raw[: bytes_read.value]
                 except MemoryError:
-                    log.error("MemoryError just happend")
+                    log.error("MemoryError just occurred")
                     break
                 if success or KERNEL32.GetLastError() != ERROR_MORE_DATA:
                     break
@@ -118,7 +118,7 @@ class LogServer(object):
         )
 
         if h_pipe == INVALID_HANDLE_VALUE:
-            log.warning("Unable to create log server pipe.")
+            log.warning("Unable to create log server pipe")
             return False
 
         logserver = LogServerThread(h_pipe, result_ip, result_port)

--- a/analyzer/windows/lib/core/pipe.py
+++ b/analyzer/windows/lib/core/pipe.py
@@ -49,12 +49,12 @@ class PipeForwarder(threading.Thread):
         success = KERNEL32.ReadFile(self.pipe_handle, byref(pid), sizeof(pid), byref(bytes_read), None)
 
         if not success or bytes_read.value != sizeof(pid):
-            log.warning("Unable to read the process identifier of this log pipe instance.")
+            log.warning("Unable to read the process identifier of this log pipe instance")
             KERNEL32.CloseHandle(self.pipe_handle)
             return
 
         if self.active.get(pid.value):
-            log.warning("A second log pipe handler for an active process is " "being requested, denying request.")
+            log.warning("A second log pipe handler for an active process is being requested, denying request")
             KERNEL32.CloseHandle(self.pipe_handle)
             return
 
@@ -89,7 +89,7 @@ class PipeForwarder(threading.Thread):
             elif KERNEL32.GetLastError() == ERROR_BROKEN_PIPE:
                 break
             else:
-                log.warning("The log pipe handler has failed, last error %d.", KERNEL32.GetLastError())
+                log.warning("The log pipe handler has failed, last error %d", KERNEL32.GetLastError())
                 break
 
         if pid.value:
@@ -194,7 +194,7 @@ class PipeServer(threading.Thread):
                 )
 
             if pipe_handle == INVALID_HANDLE_VALUE:
-                log.warning("Error opening logging pipe server.")
+                log.warning("Error opening logging pipe server")
                 continue
 
             if KERNEL32.ConnectNamedPipe(pipe_handle, None) or KERNEL32.GetLastError() == ERROR_PIPE_CONNECTED:

--- a/analyzer/windows/lib/core/startup.py
+++ b/analyzer/windows/lib/core/startup.py
@@ -50,7 +50,7 @@ def disconnect_logger():
 
 def set_clock(clock, timeout):
     # Output key info to analysis log
-    log.info("Date set to: {0}, timeout set to: {1}".format(clock, timeout))
+    log.info("Date set to: %s, timeout set to: %s", clock, timeout)
 
     clock = datetime.strptime(clock, "%Y%m%dT%H:%M:%S")
     st = SYSTEMTIME()

--- a/analyzer/windows/modules/auxiliary/browser.py
+++ b/analyzer/windows/modules/auxiliary/browser.py
@@ -38,5 +38,5 @@ class Browser(Auxiliary, Thread):
                 ie = Process()
                 if not url:
                     url = "https://www.yahoo.com/"
-                ie.execute(path=iexplore, args='"' + url + '"', suspended=False)
+                ie.execute(path=iexplore, args=f'"{url}"', suspended=False)
                 ie.close()

--- a/analyzer/windows/modules/auxiliary/curtain.py
+++ b/analyzer/windows/modules/auxiliary/curtain.py
@@ -43,7 +43,7 @@ class Curtain(Thread, Auxiliary):
                 stdout=open("C:\\curtain.log", "w"),
             )
         except Exception as e:
-            log.error("Curtain - Error collecting PowerShell events - %s " % e)
+            log.error("Curtain - Error collecting PowerShell events - %s", e)
 
         # time.sleep(5)
 
@@ -60,7 +60,7 @@ class Curtain(Thread, Auxiliary):
                 startupinfo=self.startupinfo,
             )
         except Exception as e:
-            log.error("Curtain - Error clearing PowerShell events - %s" % e)
+            log.error("Curtain - Error clearing PowerShell events - %s", e)
 
     def run(self):
         if self.enabled:

--- a/analyzer/windows/modules/auxiliary/digisig.py
+++ b/analyzer/windows/modules/auxiliary/digisig.py
@@ -87,7 +87,7 @@ class DigiSig(Auxiliary):
         lastnum = "0"
         for item in signers:
             num = str(item.split(":")[0].count("-"))
-            signed = signType + " " + num
+            signed = f"{signType} {num}"
             if lastnum != num and buf:
                 self.json_data["signers"].append(buf)
                 buf = dict()
@@ -110,17 +110,17 @@ class DigiSig(Auxiliary):
 
         try:
             if self.config.category != "file":
-                log.debug("Skipping authenticode validation, analysis is not " "a file.")
+                log.debug("Skipping authenticode validation, analysis is not a file")
                 return True
 
             sign_path = os.path.join(os.getcwd(), "bin", "signtool.exe")
             if not os.path.exists(sign_path):
-                log.info("Skipping authenticode validation, signtool.exe was " "not found in bin/")
+                log.info("Skipping authenticode validation, signtool.exe was not found in bin/")
                 return True
 
-            log.debug("Checking for a digital signature.")
+            log.debug("Checking for a digital signature")
             file_path = os.path.join(os.environ["TEMP"] + os.sep, str(self.config.file_name))
-            cmd = '{0} verify /pa /v "{1}"'.format(sign_path, file_path)
+            cmd = f'{sign_path} verify /pa /v "{file_path}"'
             ret, out, err = util.cmd_wrapper(cmd)
             out = out.decode(locale.getpreferredencoding(), errors="ignore")
 
@@ -130,24 +130,24 @@ class DigiSig(Auxiliary):
                 self.jsonify("Certificate Chain", self.cert_build)
                 self.jsonify("Timestamp Chain", self.time_build)
                 self.json_data["valid"] = True
-                log.debug("File has a valid signature.")
+                log.debug("File has a valid signature")
             # Non-zero return, it didn't validate or exist
             else:
                 self.json_data["error"] = True
                 errmsg = b" ".join(b"".join(err.split(b":")[1:]).split())
                 self.json_data["error_desc"] = errmsg.decode("utf-8")
                 if b"file format cannot be verified" in err:
-                    log.debug("File format not recognized.")
+                    log.debug("File format not recognized")
                 elif b"No signature found" not in err:
-                    log.debug("File has an invalid signature.")
+                    log.debug("File has an invalid signature")
                     _ = self.parse_digisig(out)
                     self.jsonify("Certificate Chain", self.cert_build)
                     self.jsonify("Timestamp Chain", self.time_build)
                 else:
-                    log.debug("File is not signed.")
+                    log.debug("File is not signed")
 
             if self.json_data:
-                log.info("Uploading signature results to aux/{0}.json".format(self.__class__.__name__))
+                log.info("Uploading signature results to aux/%s.json", self.__class__.__name__)
                 upload = BytesIO()
                 upload.write(json.dumps(self.json_data, ensure_ascii=False).encode("utf-8"))
                 upload.seek(0)

--- a/analyzer/windows/modules/auxiliary/disguise.py
+++ b/analyzer/windows/modules/auxiliary/disguise.py
@@ -58,7 +58,7 @@ class Disguise(Auxiliary):
         """
         key = OpenKey(HKEY_LOCAL_MACHINE, "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion", 0, KEY_SET_VALUE)
 
-        value = "{0}-{1}-{2}-{3}".format(random_integer(5), random_integer(3), random_integer(7), random_integer(5))
+        value = f"{random_integer(5)}-{random_integer(3)}-{random_integer(7)}-{random_integer(5)}"
 
         SetValueEx(key, "ProductId", 0, REG_SZ, value)
         CloseKey(key)
@@ -95,17 +95,17 @@ class Disguise(Auxiliary):
         self._office_helper("Software\\Microsoft\\Office\\Common\\Security", "UFIControls", REG_DWORD, 1)
         for oVersion in installedVersions:
             for software in ("Word", "Excel", "PowerPoint", "Publisher", "Outlook"):
-                productPath = r"{0}\{1}\{2}".format(baseOfficeKeyPath, oVersion, software)
-                self._office_helper(productPath + "\\Common\\General", "ShownOptIn", REG_DWORD, 1)
-                self._office_helper(productPath + "\\Security", "VBAWarnings", REG_DWORD, 1)
-                self._office_helper(productPath + "\\Security", "AccessVBOM", REG_DWORD, 1)
-                self._office_helper(productPath + "\\Security", "DisableDDEServerLaunch", REG_DWORD, 0)
-                self._office_helper(productPath + "\\Security", "MarkInternalAsUnsafe", REG_DWORD, 0)
-                self._office_helper(productPath + "\\Security\\ProtectedView", "DisableAttachmentsInPV", REG_DWORD, 1)
-                self._office_helper(productPath + "\\Security\\ProtectedView", "DisableInternetFilesInPV", REG_DWORD, 1)
-                self._office_helper(productPath + "\\Security\\ProtectedView", "DisableUnsafeLocationsInPV", REG_DWORD, 1)
-                # self._office_helper("HKEY_CURRENT_USER\\Software\\Policies\\Microsoft\\Office\\{}\\{}\\Security".format(oVersion, software), "MarkInternalAsUnsafe", REG_DWORD, 0)
-                self._office_helper(productPath + "\\Security", "ExtensionHardening", 0)
+                productPath = rf"{baseOfficeKeyPath}\{oVersion}\{software}"
+                self._office_helper(f"{productPath}\\Common\\General", "ShownOptIn", REG_DWORD, 1)
+                self._office_helper(f"{productPath}\\Security", "VBAWarnings", REG_DWORD, 1)
+                self._office_helper(f"{productPath}\\Security", "AccessVBOM", REG_DWORD, 1)
+                self._office_helper(f"{productPath}\\Security", "DisableDDEServerLaunch", REG_DWORD, 0)
+                self._office_helper(f"{productPath}\\Security", "MarkInternalAsUnsafe", REG_DWORD, 0)
+                self._office_helper(f"{productPath}\\Security\\ProtectedView", "DisableAttachmentsInPV", REG_DWORD, 1)
+                self._office_helper(f"{productPath}\\Security\\ProtectedView", "DisableInternetFilesInPV", REG_DWORD, 1)
+                self._office_helper(f"{productPath}\\Security\\ProtectedView", "DisableUnsafeLocationsInPV", REG_DWORD, 1)
+                # self._office_helper(f"HKEY_CURRENT_USER\\Software\\Policies\\Microsoft\\Office\\{oVersion}\\{software}\\Security", "MarkInternalAsUnsafe", REG_DWORD, 0)
+                self._office_helper(f"{productPath}\\Security", "ExtensionHardening", 0)
 
     def set_office_mrus(self):
         """Adds randomized MRU's to Office software(s).
@@ -147,11 +147,11 @@ class Disguise(Auxiliary):
             for software in extensions:
                 values = list()
                 mruKeyPath = ""
-                productPath = r"{0}\{1}\{2}".format(baseOfficeKeyPath, oVersion, software)
+                productPath = rf"{baseOfficeKeyPath}\{oVersion}\{software}"
                 try:
                     productKey = OpenKey(HKEY_CURRENT_USER, productPath, 0, KEY_READ)
                     CloseKey(productKey)
-                    mruKeyPath = r"{0}\File MRU".format(productPath)
+                    mruKeyPath = rf"{productPath}\File MRU"
                     try:
                         mruKey = OpenKey(HKEY_CURRENT_USER, mruKeyPath, 0, KEY_READ)
                     except WindowsError:
@@ -176,16 +176,16 @@ class Disguise(Auxiliary):
                     for i in range(1, randint(10, 30)):
                         rString = random_string(minimum=11, charset="0123456789ABCDEF")
                         if i % 2:
-                            baseId = "T01D1C" + rString
+                            baseId = f"T01D1C{rString}"
                         else:
-                            baseId = "T01D1D" + rString
-                        setVal = "[F00000000][{0}][O00000000]*{1}{2}.{3}".format(
+                            baseId = f"T01D1D{rString}"
+                        setVal = f"[F00000000][{0}][O00000000]*{1}{2}.{3}".format(
                             baseId,
                             basePaths[randint(0, len(basePaths) - 1)],
                             random_string(minimum=3, maximum=15, charset="abcdefghijkLMNOPQURSTUVwxyz_0369"),
                             extensions[software][randint(0, len(extensions[software]) - 1)],
                         )
-                        name = "Item {0}".format(i)
+                        name = f"Item {i}"
                         SetValueEx(mruKey, name, 0, REG_SZ, setVal)
                     CloseKey(mruKey)
 
@@ -200,12 +200,12 @@ class Disguise(Auxiliary):
         try:
             # get netbios interface
             for path in ("CurrentControlSet", "ControlSet001", "ControlSet002"):
-                netbios_init = "System\\{}\\Services\\NetBT\\Parameters\\Interfaces\\".format(path)
+                netbios_init = f"System\\{path}\\Services\\NetBT\\Parameters\\Interfaces\\"
                 netbios = OpenKey(HKEY_LOCAL_MACHINE, netbios_init,0, KEY_READ)
                 for currentKey in xrange(0, QueryInfoKey(netbios)[0]):
                     subkey = EnumKey(netbios, currentKey)
                     if  subkey.startswith("Tcpip_"):
-                        sub_netbios = OpenKey(HKEY_LOCAL_MACHINE, netbios_init+"\\"+subkey, 0, KEY_SET_VALUE)
+                        sub_netbios = OpenKey(HKEY_LOCAL_MACHINE, f"{netbios_init}\\{subkey}", 0, KEY_SET_VALUE)
                         SetValueEx(sub_netbios, "NetbiosOptions", 0, REG_DWORD, 2)
                         CloseKey(sub_netbios)
                 CloseKey(netbios)
@@ -242,7 +242,7 @@ class Disguise(Auxiliary):
     def randomizeUUID(self):
         createdUUID = str(uuid4())
 
-        log.info("Disguising GUID to " + str(createdUUID))
+        log.info("Disguising GUID to %s", createdUUID)
         keyPath = "SOFTWARE\\Microsoft\\Cryptography"
 
         # Determing if the machine is 32 or 64 bit and open the registry key

--- a/analyzer/windows/modules/auxiliary/evtx.py
+++ b/analyzer/windows/modules/auxiliary/evtx.py
@@ -172,10 +172,10 @@ class Evtx(Thread, Auxiliary):
                         f'auditpol /set /subcategory:"{subcategory}"'
                         f'/success:{settings["success"]} /failure:{settings["failure"]}'
                     )
-                    log.debug(f"Enabling advanced logging -> {cmd}")
+                    log.debug("Enabling advanced logging -> %s", cmd)
                     os.system(cmd)
                 except Exception as err:
-                    log.error(f"Cannot enable advanced logging for subcategory {subcategory} - {err}")
+                    log.error("Cannot enable advanced logging for subcategory %s - %s", subcategory, err)
                     pass
 
     def collect_windows_logs(self):
@@ -188,21 +188,21 @@ class Evtx(Thread, Auxiliary):
             logs_folder = "C:/windows/Sysnative/winevt/Logs"
             os.listdir(logs_folder)
         except Exception:
-            logs_folder = "c:/Windows/System32/winevt/Logs"
+            logs_folder = "C:/Windows/System32/winevt/Logs"
 
         with zipfile.ZipFile(self.evtx_dump, "w", zipfile.ZIP_DEFLATED) as zip_obj:
             for evtx_file_name in os.listdir(logs_folder):
                 for selected_evtx in self.windows_logs:
-                    _selected_evtx = selected_evtx + ".evtx"
+                    _selected_evtx = f"{selected_evtx}.evtx"
                     if "/" in _selected_evtx:
                         _selected_evtx = "%4".join(_selected_evtx.split("/"))
                     if _selected_evtx == evtx_file_name:
                         full_path = os.path.join(logs_folder, evtx_file_name)
                         if os.path.exists(full_path):
-                            log.debug(f"Adding {full_path} to zip dump")
+                            log.debug("Adding %s to zip dump", full_path)
                             zip_obj.write(full_path, evtx_file_name)
 
-        log.debug(f"Uploading {self.evtx_dump} to host")
+        log.debug("Uploading %s to host", self.evtx_dump)
         upload_to_host(self.evtx_dump, f"evtx/{self.evtx_dump}", False)
 
     def wipe_windows_logs(self):
@@ -212,10 +212,10 @@ class Evtx(Thread, Auxiliary):
         try:
             for evtx_channel in self.windows_logs:
                 cmd = f"wevtutil cl {evtx_channel}"
-                log.debug(f"wiping {evtx_channel}")
+                log.debug("Wiping %s", evtx_channel)
                 os.system(cmd)
         except Exception as err:
-            log.error(f"module error - {err}")
+            log.error("Module error - %s", err)
             pass
 
     def run(self):

--- a/analyzer/windows/modules/auxiliary/human.py
+++ b/analyzer/windows/modules/auxiliary/human.py
@@ -244,7 +244,7 @@ def get_office_window(hwnd, lparam):
         USER32.GetWindowTextW(hwnd, text, 1024)
         if any([value in text.value for value in ("- Microsoft", "- Word", "- Excel", "- PowerPoint")]):
             # send ALT+F4 equivalent
-            log.info("Closing Office window.")
+            log.info("Closing Office window")
             USER32.SendNotifyMessageW(hwnd, WM_CLOSE, None, None)
             CLOSED_OFFICE = True
     return True

--- a/analyzer/windows/modules/auxiliary/screenshots.py
+++ b/analyzer/windows/modules/auxiliary/screenshots.py
@@ -50,7 +50,7 @@ class Screenshots(Auxiliary, Thread):
         @return: operation status.
         """
         if not Screenshot().have_pil():
-            log.warning("Python Image Library is not installed, " "screenshots are disabled")
+            log.warning("Python Image Library is not installed, screenshots are disabled")
             return False
 
         img_counter = 0
@@ -77,7 +77,7 @@ class Screenshots(Auxiliary, Thread):
 
             # now upload to host from the StringIO
             nf = NetlogFile()
-            nf.init("shots/%s.jpg" % str(img_counter).rjust(4, "0"))
+            nf.init(f"shots/{str(img_counter).rjust(4, '0')}.jpg")
             for chunk in tmpio:
                 nf.sock.send(chunk)
             nf.close()

--- a/analyzer/windows/modules/auxiliary/tlsdump.py
+++ b/analyzer/windows/modules/auxiliary/tlsdump.py
@@ -34,7 +34,7 @@ class TLSDumpMasterSecrets(Auxiliary):
                 flag = 0
             flag = KERNEL32.Process32Next(snapshot, byref(proc_info))
         if not pid:
-            log.warning("Unable to find lsass.exe process.")
+            log.warning("Unable to find lsass.exe process")
             return
         try:
             p = Process(options=self.options, config=self.config, pid=pid)
@@ -42,10 +42,10 @@ class TLSDumpMasterSecrets(Auxiliary):
             p.inject(injectmode=0, interest=filepath, nosleepskip=True)
         except CuckooError as e:
             if "process access denied" in e.message:
-                log.warning("You're not running the Agent as Administrator.")
+                log.warning("You're not running the Agent as Administrator")
             else:
                 log.warning(
-                    "An unknown error occurred while trying to inject into " "the lsass.exe process to dump TLS master secrets: %s",
+                    "An unknown error occurred while trying to inject into the lsass.exe process to dump TLS master secrets: %s",
                     e,
                 )
         del self.options["tlsdump"]

--- a/analyzer/windows/modules/packages/Shellcode-Unpacker.py
+++ b/analyzer/windows/modules/packages/Shellcode-Unpacker.py
@@ -25,7 +25,7 @@ class Shellcode_Unpacker(Package):
 
     def start(self, path):
         loaderpath = "bin\\loader.exe"
-        arguments = "shellcode " + path
+        arguments = f"shellcode {path}"
 
         # we need to move out of the analyzer directory
         # due to a check in monitor dll
@@ -33,7 +33,7 @@ class Shellcode_Unpacker(Package):
         newpath = os.path.join(basepath, os.path.basename(loaderpath))
         shutil.copy(loaderpath, newpath)
 
-        log.info("[-] newpath : " + newpath)
-        log.info("[-] arguments : " + arguments)
+        log.info("[-] newpath : %s", newpath)
+        log.info("[-] arguments : %s", arguments)
 
         return self.execute(newpath, arguments, newpath)

--- a/analyzer/windows/modules/packages/Shellcode.py
+++ b/analyzer/windows/modules/packages/Shellcode.py
@@ -21,9 +21,9 @@ class Shellcode(Package):
     def start(self, path):
         offset = self.options.get("offset")
         loaderpath = "bin\\loader.exe"
-        args = "shellcode " + path
+        args = f"shellcode {path}"
         if offset:
-            args += " {0}".format(offset)
+            args += f" {offset}"
         # we need to move out of the analyzer directory
         # due to a check in monitor dll
         basepath = os.path.dirname(path)

--- a/analyzer/windows/modules/packages/Shellcode_x64.py
+++ b/analyzer/windows/modules/packages/Shellcode_x64.py
@@ -21,9 +21,9 @@ class Shellcode_x64(Package):
     def start(self, path):
         offset = self.options.get("offset")
         loaderpath = "bin\\loader_x64.exe"
-        args = "shellcode " + path
+        args = f"shellcode {path}"
         if offset:
-            args += " {0}".format(offset)
+            args += f" {offset}"
         # we need to move out of the analyzer directory
         # due to a check in monitor dll
         basepath = os.path.dirname(path)

--- a/analyzer/windows/modules/packages/UPX.py
+++ b/analyzer/windows/modules/packages/UPX.py
@@ -29,7 +29,7 @@ class UPX(Package):
 
         # If the file doesn't have an extension, add .exe
         if "." not in os.path.basename(path):
-            new_path = path + ".exe"
+            new_path = f"{path}.exe"
             os.rename(path, new_path)
             path = new_path
 

--- a/analyzer/windows/modules/packages/UPX_dll.py
+++ b/analyzer/windows/modules/packages/UPX_dll.py
@@ -34,13 +34,13 @@ class UPX_dll(Package):
         # and rename it. This is needed for rundll32 to execute correctly.
         # See ticket #354 for details.
         if ext != ".dll":
-            new_path = path + ".dll"
+            new_path = f"{path}.dll"
             os.rename(path, new_path)
             path = new_path
 
-        args = "{0},{1}".format(path, function)
+        args = f"{path},{function}"
         if arguments:
-            args += " {0}".format(arguments)
+            args += f" {arguments}"
 
         if dllloader:
             newname = os.path.join(os.path.dirname(rundll32), dllloader)

--- a/analyzer/windows/modules/packages/Unpacker.py
+++ b/analyzer/windows/modules/packages/Unpacker.py
@@ -33,7 +33,7 @@ class Unpacker(Package):
         # an exception that will crash the app if it does
         # not find an extension on the main exe's filename
         if "." not in os.path.basename(path):
-            new_path = path + ".exe"
+            new_path = f"{path}.exe"
             os.rename(path, new_path)
             path = new_path
 

--- a/analyzer/windows/modules/packages/Unpacker_dll.py
+++ b/analyzer/windows/modules/packages/Unpacker_dll.py
@@ -35,13 +35,13 @@ class Unpacker_dll(Package):
         # and rename it. This is needed for rundll32 to execute correctly.
         # See ticket #354 for details.
         if ext != ".dll":
-            new_path = path + ".dll"
+            new_path = f"{path}.dll"
             os.rename(path, new_path)
             path = new_path
 
-        args = "{0},{1}".format(path, function)
+        args = f"{path},{function}"
         if arguments:
-            args += " {0}".format(arguments)
+            args += f" {arguments}"
 
         if dllloader:
             newname = os.path.join(os.path.dirname(rundll32), dllloader)

--- a/analyzer/windows/modules/packages/Unpacker_js.py
+++ b/analyzer/windows/modules/packages/Unpacker_js.py
@@ -25,14 +25,14 @@ class Unpacker_JS(Package):
 
     def start(self, path):
         wscript = self.get_path("wscript.exe")
-        args = '"%s"' % path
+        args = f'"{path}"'
         ext = os.path.splitext(path)[-1].lower()
         if ext != ".js" and ext != ".jse":
             if os.path.isfile(path) and "#@~^" in open(path, "rb").read(100):
-                os.rename(path, path + ".jse")
-                path = path + ".jse"
+                os.rename(path, f"{path}.jse")
+                path = f"{path}.jse"
             else:
-                os.rename(path, path + ".js")
-                path = path + ".js"
-        args = '"%s"' % path
+                os.rename(path, f"{path}.js")
+                path = f"{path}.js"
+        args = f'"{path}"'
         return self.execute(wscript, args, path)

--- a/analyzer/windows/modules/packages/Unpacker_ps1.py
+++ b/analyzer/windows/modules/packages/Unpacker_ps1.py
@@ -27,8 +27,8 @@ class PS1(Package):
         powershell = self.get_path_glob("PowerShell")
 
         if not path.endswith(".ps1"):
-            os.rename(path, path + ".ps1")
+            os.rename(path, f"{path}.ps1")
             path += ".ps1"
 
-        args = '-NoProfile -ExecutionPolicy bypass -File "{0}"'.format(path)
+        args = f'-NoProfile -ExecutionPolicy bypass -File "{path}"'
         return self.execute(powershell, args, path)

--- a/analyzer/windows/modules/packages/Unpacker_regsvr.py
+++ b/analyzer/windows/modules/packages/Unpacker_regsvr.py
@@ -34,12 +34,12 @@ class Unpacker_Regsvr(Package):
         # and rename it. This is needed for rundll32 to execute correctly.
         # See ticket #354 for details.
         if ext != ".dll":
-            new_path = path + ".dll"
+            new_path = f"{path}.dll"
             os.rename(path, new_path)
             path = new_path
 
         args = path
         if arguments:
-            args += " {0}".format(arguments)
+            args += f" {arguments}"
 
         return self.execute(regsvr32, args, path)

--- a/analyzer/windows/modules/packages/Unpacker_zip.py
+++ b/analyzer/windows/modules/packages/Unpacker_zip.py
@@ -45,9 +45,9 @@ class Unpacker_zip(Package):
         """
         # Test if zip file contains a file named as itself.
         if self.is_overwritten(zip_path):
-            log.debug("ZIP file contains a file with the same name, original is going to be overwrite")
+            log.debug("ZIP file contains a file with the same name, original is going to be overwritten")
             # TODO: add random string.
-            new_zip_path = zip_path + ".old"
+            new_zip_path = f"{zip_path}.old"
             shutil.move(zip_path, new_zip_path)
             zip_path = new_zip_path
 
@@ -61,7 +61,7 @@ class Unpacker_zip(Package):
                 try:
                     archive.extractall(path=extract_path, pwd="infected")
                 except RuntimeError as e:
-                    raise CuckooPackageError("Unable to extract Zip file: " "{0}".format(e))
+                    raise CuckooPackageError(f"Unable to extract Zip file: {e}")
             finally:
                 if recursion_depth < 4:
                     # Extract nested archives.
@@ -72,10 +72,11 @@ class Unpacker_zip(Package):
                                 self.extract_zip(os.path.join(extract_path, name), extract_path, password, recursion_depth + 1)
                             except BadZipfile:
                                 log.warning(
-                                    "Nested zip file '%s' name end with 'zip' extension is not a valid zip. Skip extracting" % name
+                                    "Nested zip file '%s' name end with 'zip' extension is not a valid zip, skipping extraction",
+                                    name,
                                 )
                             except RuntimeError as run_err:
-                                log.error("Error to extract nested zip file %s with details: %s" % name, run_err)
+                                log.error("Error to extract nested zip file %s with details: %s", name, run_err)
 
     def is_overwritten(self, zip_path):
         """Checks if the ZIP file contains another file with the same name, so it is going to be overwritten.
@@ -128,32 +129,32 @@ class Unpacker_zip(Package):
                             break
                 # Default to the first one if none found
                 file_name = file_name if file_name else zipinfos[0].filename
-                log.debug("Missing file option, auto executing: {0}".format(file_name))
+                log.debug("Missing file option, auto executing: %s", file_name)
             else:
                 raise CuckooPackageError("Empty ZIP archive")
 
         file_path = os.path.join(root, file_name)
-        log.debug('file_name: "%s"' % (file_name))
+        log.debug('file_name: "%s"', file_name)
         if file_name.lower().endswith(".lnk"):
             cmd_path = self.get_path("cmd.exe")
-            cmd_args = '/c start /wait "" "{0}"'.format(file_path)
+            cmd_args = f'/c start /wait "" "{file_path}"'
             return self.execute(cmd_path, cmd_args, file_path)
         elif file_name.lower().endswith(".msi"):
             msi_path = self.get_path("msiexec.exe")
-            msi_args = '/I "{0}"'.format(file_path)
+            msi_args = f'/I "{file_path}"'
             return self.execute(msi_path, msi_args, file_path)
         elif file_name.lower().endswith((".js", ".jse", ".vbs", ".vbe", ".wsf")):
             wscript = self.get_path_app_in_path("wscript.exe")
-            wscript_args = '"{0}"'.format(file_path)
+            wscript_args = f'"{file_path}"'
             return self.execute(wscript, wscript_args, file_path)
         elif file_name.lower().endswith((".dll", ".ocx")):
             rundll32 = self.get_path_app_in_path("rundll32.exe")
             function = self.options.get("function", "#1")
             arguments = self.options.get("arguments")
             dllloader = self.options.get("dllloader")
-            dll_args = '"{0}",{1}'.format(file_path, function)
+            dll_args = f'"{file_path}",{function}'
             if arguments:
-                dll_args += " {0}".format(arguments)
+                dll_args += f" {arguments}"
             if dllloader:
                 newname = os.path.join(os.path.dirname(rundll32), dllloader)
                 shutil.copy(rundll32, newname)
@@ -161,7 +162,7 @@ class Unpacker_zip(Package):
             return self.execute(rundll32, dll_args, file_path)
         elif file_name.lower().endswith(".ps1"):
             powershell = self.get_path_app_in_path("powershell.exe")
-            args = '-NoProfile -ExecutionPolicy bypass -File "{0}"'.format(path)
+            args = f'-NoProfile -ExecutionPolicy bypass -File "{path}"'
             return self.execute(powershell, args, file_path)
         else:
             return self.execute(file_path, self.options.get("arguments"), file_path)

--- a/analyzer/windows/modules/packages/applet.py
+++ b/analyzer/windows/modules/packages/applet.py
@@ -17,17 +17,14 @@ class Applet(Package):
     ]
 
     def make_html(self, path, class_name):
-        html = """
+        html = f"""
         <html>
             <body>
-                <applet archive="%s" code="%s" width="1" height="1">
+                <applet archive="{path}" code="{class_name}" width="1" height="1">
                 </applet>
             </body>
         </html>
-        """ % (
-            path,
-            class_name,
-        )
+        """
 
         _, file_path = tempfile.mkstemp(suffix=".html")
         with open(file_path, "w") as file_handle:
@@ -39,4 +36,4 @@ class Applet(Package):
         browser = self.get_path("browser")
         class_name = self.options.get("class")
         html_path = self.make_html(path, class_name)
-        return self.execute(browser, '"%s"' % html_path, html_path)
+        return self.execute(browser, f'"{html_path}"', html_path)

--- a/analyzer/windows/modules/packages/chm.py
+++ b/analyzer/windows/modules/packages/chm.py
@@ -24,8 +24,8 @@ class CHM(Package):
         # If the file doesn't have the proper .chm extension force it
         # and rename it. This is needed for hh to open correctly.
         if ext != ".chm":
-            new_path = path + ".chm"
+            new_path = f"{path}.chm"
             os.rename(path, new_path)
             path = new_path
 
-        return self.execute(hh, '"%s"' % path, path)
+        return self.execute(hh, f'"{path}"', path)

--- a/analyzer/windows/modules/packages/chrome.py
+++ b/analyzer/windows/modules/packages/chrome.py
@@ -16,4 +16,4 @@ class Chrome(Package):
     def start(self, url):
         chrome = self.get_path("Google Chrome")
         # pass the URL instead of a filename in this case
-        return self.execute(chrome, '"%s"' % url, url)
+        return self.execute(chrome, f'"{url}"', url)

--- a/analyzer/windows/modules/packages/cpl.py
+++ b/analyzer/windows/modules/packages/cpl.py
@@ -15,4 +15,4 @@ class CPL(Package):
 
     def start(self, path):
         control = self.get_path("control.exe")
-        return self.execute(control, '"%s"' % path, path)
+        return self.execute(control, f'"{path}"', path)

--- a/analyzer/windows/modules/packages/dll.py
+++ b/analyzer/windows/modules/packages/dll.py
@@ -28,7 +28,7 @@ class Dll(Package):
         # and rename it. This is needed for rundll32 to execute correctly.
         # See ticket #354 for details.
         if ext != ".dll":
-            new_path = path + ".dll"
+            new_path = f"{path}.dll"
             os.rename(path, new_path)
             path = new_path
 
@@ -46,8 +46,8 @@ class Dll(Package):
         except (ValueError, AssertionError):
             pass
 
-        args = '"{0}",{1}'.format(path, function)
+        args = f'"{path}",{function}'
         if arguments:
-            args += " {0}".format(arguments)
+            args += f" {arguments}"
 
         return self.execute(rundll32, args, path)

--- a/analyzer/windows/modules/packages/doc.py
+++ b/analyzer/windows/modules/packages/doc.py
@@ -25,8 +25,8 @@ class DOC(Package):
     def start(self, path):
         word = self.get_path_glob("Microsoft Office Word")
         if "." not in os.path.basename(path):
-            new_path = path + ".doc"
+            new_path = f"{path}.doc"
             os.rename(path, new_path)
             path = new_path
 
-        return self.execute(word, '"%s" /q' % path, path)
+        return self.execute(word, f'"{path}" /q', path)

--- a/analyzer/windows/modules/packages/doc2016.py
+++ b/analyzer/windows/modules/packages/doc2016.py
@@ -22,8 +22,8 @@ class DOC2016(Package):
     def start(self, path):
         word = self.get_path_glob("Microsoft Office Word")
         if "." not in os.path.basename(path):
-            new_path = path + ".doc"
+            new_path = f"{path}.doc"
             os.rename(path, new_path)
             path = new_path
 
-        return self.execute(word, '"%s" /q /dde /n' % path, path)
+        return self.execute(word, f'"{path}" /q /dde /n', path)

--- a/analyzer/windows/modules/packages/eml.py
+++ b/analyzer/windows/modules/packages/eml.py
@@ -17,4 +17,4 @@ class EML(Package):
 
     def start(self, path):
         outlook = self.get_path_glob("Microsoft Office Outlook")
-        return self.execute(outlook, '/eml "%s"' % path, path)
+        return self.execute(outlook, f'/eml "{path}"', path)

--- a/analyzer/windows/modules/packages/exe.py
+++ b/analyzer/windows/modules/packages/exe.py
@@ -22,7 +22,7 @@ class Exe(Package):
         # an exception that will crash the app if it does
         # not find an extension on the main exe's filename
         if "." not in os.path.basename(path):
-            new_path = path + ".exe"
+            new_path = f"{path}.exe"
             os.rename(path, new_path)
             path = new_path
 

--- a/analyzer/windows/modules/packages/firefox.py
+++ b/analyzer/windows/modules/packages/firefox.py
@@ -16,4 +16,4 @@ class Firefox(Package):
     def start(self, url):
         firefox = self.get_path("Mozilla Firefox")
         # pass the URL instead of a filename in this case
-        return self.execute(firefox, '"%s"' % url, url)
+        return self.execute(firefox, f'"{url}"', url)

--- a/analyzer/windows/modules/packages/generic.py
+++ b/analyzer/windows/modules/packages/generic.py
@@ -19,5 +19,5 @@ class Generic(Package):
 
     def start(self, path):
         cmd_path = self.get_path("cmd.exe")
-        cmd_args = '/c start /wait "" "{0}"'.format(path)
+        cmd_args = f'/c start /wait "" "{path}"'
         return self.execute(cmd_path, cmd_args, path)

--- a/analyzer/windows/modules/packages/hta.py
+++ b/analyzer/windows/modules/packages/hta.py
@@ -22,7 +22,7 @@ class HTA(Package):
         mshta = self.get_path("mshta.exe")
 
         if not path.endswith(".hta"):
-            os.rename(path, path + ".hta")
+            os.rename(path, f"{path}.hta")
             path += ".hta"
 
-        return self.execute(mshta, '"%s"' % path, path)
+        return self.execute(mshta, f'"{path}"', path)

--- a/analyzer/windows/modules/packages/html.py
+++ b/analyzer/windows/modules/packages/html.py
@@ -28,8 +28,8 @@ class HTML(Package):
         # be executed.
         # We help you sample to execute renaming it with a proper extension.
         if not path.endswith((".htm", ".html")):
-            shutil.copy(path, path + ".html")
+            shutil.copy(path, f"{path}.html")
             path += ".html"
             log.info("Submitted file is missing extension, adding .html")
 
-        return self.execute(iexplore, '"%s"' % path, path)
+        return self.execute(iexplore, f'"{path}"', path)

--- a/analyzer/windows/modules/packages/hwp.py
+++ b/analyzer/windows/modules/packages/hwp.py
@@ -12,4 +12,4 @@ class HWP(Package):
 
     def start(self, path):
         word = self.get_path("Hangul (Korean) Word Processor File 5.x")
-        return self.execute(word, args=[path], mode="office", trigger="file:%s" % path)
+        return self.execute(word, args=[path], mode="office", trigger=f"file:{path}")

--- a/analyzer/windows/modules/packages/ichitaro.py
+++ b/analyzer/windows/modules/packages/ichitaro.py
@@ -26,7 +26,7 @@ class ichitaro(Package):
         # Rename file to file.inp so it can open properly.
         ext = os.path.splitext(path)[-1].lower()
         if ext != ".jtd":
-            new_path = path + ".jtd"
+            new_path = f"{path}.jtd"
             os.rename(path, new_path)
             path = new_path
-        return self.execute(ichitaro, '"%s"' % path, path)
+        return self.execute(ichitaro, f'"{path}"', path)

--- a/analyzer/windows/modules/packages/ie.py
+++ b/analyzer/windows/modules/packages/ie.py
@@ -16,4 +16,4 @@ class IE(Package):
     def start(self, url):
         iexplore = self.get_path("Internet Explorer")
         # pass the URL instead of a filename in this case
-        return self.execute(iexplore, '"%s"' % url, url)
+        return self.execute(iexplore, f'"{url}"', url)

--- a/analyzer/windows/modules/packages/inp.py
+++ b/analyzer/windows/modules/packages/inp.py
@@ -29,7 +29,7 @@ class INP(Package):
         # Rename file to file.inp so it can open properly.
         ext = os.path.splitext(path)[-1].lower()
         if ext != ".inp":
-            new_path = path + ".inp"
+            new_path = f"{path}.inp"
             os.rename(path, new_path)
             path = new_path
-        return self.execute(inp, '"%s"' % path, path)
+        return self.execute(inp, f'"{path}"', path)

--- a/analyzer/windows/modules/packages/jar.py
+++ b/analyzer/windows/modules/packages/jar.py
@@ -18,8 +18,8 @@ class Jar(Package):
         class_path = self.options.get("class")
 
         if class_path:
-            args = '-cp "%s" %s' % (path, class_path)
+            args = f'-cp "{path}" {class_path}'
         else:
-            args = '-jar "%s"' % path
+            args = f'-jar "{path}"'
 
         return self.execute(java, args, path)

--- a/analyzer/windows/modules/packages/js.py
+++ b/analyzer/windows/modules/packages/js.py
@@ -17,17 +17,17 @@ class JS(Package):
 
     def start(self, path):
         wscript = self.get_path("wscript.exe")
-        args = '"%s"' % path
+        args = f'"{path}"'
         ext = os.path.splitext(path)[-1].lower()
         if ext != ".js" and ext != ".jse":
             if ext == ".jse" or (os.path.isfile(path) and "#@~^" == open(path, "rt").read(4)):
                 if ext != ".jse":
-                    os.rename(path, path + ".jse")
-                    path = path + ".jse"
+                    os.rename(path, f"{path}.jse")
+                    path = f"{path}.jse"
                     ext = ".jse"
             else:
-                os.rename(path, path + ".js")
-                path = path + ".js"
+                os.rename(path, f"{path}.js")
+                path = f"{path}.js"
 
         if ext == ".jse":
             # antivm fix
@@ -37,11 +37,11 @@ class JS(Package):
             # fuck antivm
             for i in range(20):
                 # calc
-                calc = os.path.join("c:\\windows", "system32", "calc.exe")
+                calc = os.path.join("C:\\windows", "system32", "calc.exe")
                 # cl = Process()
                 self.execute(calc, "", path)
             if free is False:
                 self.options["free"] = 0
 
-        args = '"%s"' % path
+        args = f'"{path}"'
         return self.execute(wscript, args, path)

--- a/analyzer/windows/modules/packages/js_antivm.py
+++ b/analyzer/windows/modules/packages/js_antivm.py
@@ -22,20 +22,20 @@ class JS_ANTIVM(Package):
         # fuck antivm
         for _ in range(50):
             # calc
-            calc = os.path.join("c:\\windows", "system32", "calc.exe")
+            calc = os.path.join("C:\\windows", "system32", "calc.exe")
             # cl = Process()
             self.execute(calc, "", path)
         if free is False:
             self.options["free"] = 0
         wscript = self.get_path("wscript.exe")
-        args = '"%s"' % path
+        args = f'"{path}"'
         ext = os.path.splitext(path)[-1].lower()
         if ext != ".js" and ext != ".jse":
             if os.path.isfile(path) and "#@~^" == open(path, "rt").read(4):
-                os.rename(path, path + ".jse")
-                path = path + ".jse"
+                os.rename(path, f"{path}.jse")
+                path = f"{path}.jse"
             else:
-                os.rename(path, path + ".js")
-                path = path + ".js"
-        args = '"%s"' % path
+                os.rename(path, f"{path}.js")
+                path = f"{path}.js"
+        args = f'"{path}"'
         return self.execute(wscript, args, path)

--- a/analyzer/windows/modules/packages/lnk.py
+++ b/analyzer/windows/modules/packages/lnk.py
@@ -16,10 +16,10 @@ class LNK(Package):
 
     def start(self, path):
         if "." not in os.path.basename(path):
-            new_path = path + ".lnk"
+            new_path = f"{path}.lnk"
             os.rename(path, new_path)
             path = new_path
 
         cmd_path = self.get_path("cmd.exe")
-        cmd_args = '/c start /wait "" "{0}"'.format(path)
+        cmd_args = f'/c start /wait "" "{path}"'
         return self.execute(cmd_path, cmd_args, path)

--- a/analyzer/windows/modules/packages/mht.py
+++ b/analyzer/windows/modules/packages/mht.py
@@ -28,8 +28,8 @@ class MHT(Package):
         # be executed.
         # We help you sample to execute renaming it with a proper extension.
         if not path.endswith(".mht"):
-            shutil.copy(path, path + ".mht")
+            shutil.copy(path, f"{path}.mht")
             path += ".mht"
             log.info("Submitted file is missing extension, adding .mht")
 
-        return self.execute(iexplore, '"%s"' % path, path)
+        return self.execute(iexplore, f'"{path}"', path)

--- a/analyzer/windows/modules/packages/msbuild.py
+++ b/analyzer/windows/modules/packages/msbuild.py
@@ -20,4 +20,4 @@ class MSBUILD(Package):
 
     def start(self, path):
         msbuild = self.get_path_glob("msbuild.exe")
-        return self.execute(msbuild, '"%s"' % path, path)
+        return self.execute(msbuild, f'"{path}"', path)

--- a/analyzer/windows/modules/packages/msg.py
+++ b/analyzer/windows/modules/packages/msg.py
@@ -17,4 +17,4 @@ class MSG(Package):
 
     def start(self, path):
         outlook = self.get_path_glob("Microsoft Office Outlook")
-        return self.execute(outlook, '/f "%s"' % path, path)
+        return self.execute(outlook, f'/f "{path}"', path)

--- a/analyzer/windows/modules/packages/msi.py
+++ b/analyzer/windows/modules/packages/msi.py
@@ -15,5 +15,5 @@ class Msi(Package):
 
     def start(self, path):
         msi_path = self.get_path("msiexec.exe")
-        msi_args = '/I "{0}" /qb ACCEPTEULA=1 LicenseAccepted=1'.format(path)
+        msi_args = f'/I "{path}" /qb ACCEPTEULA=1 LicenseAccepted=1'
         return self.execute(msi_path, msi_args, path)

--- a/analyzer/windows/modules/packages/nsis.py
+++ b/analyzer/windows/modules/packages/nsis.py
@@ -17,9 +17,9 @@ class NSIS(Package):
 
     def start(self, path):
         if "." not in os.path.basename(path):
-            new_path = path + ".exe"
+            new_path = f"{path}.exe"
             os.rename(path, new_path)
             path = new_path
         cmd_path = self.get_path("cmd.exe")
-        cmd_args = '/c start /wait "" "{0}" /NCRC'.format(path)
+        cmd_args = f'/c start /wait "" "{path}" /NCRC'
         return self.execute(cmd_path, cmd_args, path)

--- a/analyzer/windows/modules/packages/ollydbg.py
+++ b/analyzer/windows/modules/packages/ollydbg.py
@@ -7,4 +7,4 @@ class OllyDbg(Package):
 
     def start(self, path):
         arguments = self.options.get("arguments", "")
-        return self.execute("bin\\OllyDbg\\OLLYDBG.EXE", "%s %s" % (path, arguments), path)
+        return self.execute("bin\\OllyDbg\\OLLYDBG.EXE", f"{path} {arguments}", path)

--- a/analyzer/windows/modules/packages/pdf.py
+++ b/analyzer/windows/modules/packages/pdf.py
@@ -21,4 +21,4 @@ class PDF(Package):
 
     def start(self, path):
         reader = self.get_path_glob("Adobe Reader")
-        return self.execute(reader, '"%s"' % path, path)
+        return self.execute(reader, f'"{path}"', path)

--- a/analyzer/windows/modules/packages/ppt.py
+++ b/analyzer/windows/modules/packages/ppt.py
@@ -21,4 +21,4 @@ class PPT(Package):
 
     def start(self, path):
         powerpoint = self.get_path_glob("Microsoft Office PowerPoint")
-        return self.execute(powerpoint, '/s "%s"' % path, path)
+        return self.execute(powerpoint, f'/s "{path}"', path)

--- a/analyzer/windows/modules/packages/ppt2016.py
+++ b/analyzer/windows/modules/packages/ppt2016.py
@@ -19,4 +19,4 @@ class PPT2007(Package):
 
     def start(self, path):
         powerpoint = self.get_path_glob("Microsoft Office PowerPoint")
-        return self.execute(powerpoint, '/s "%s"' % path, path)
+        return self.execute(powerpoint, f'/s "{path}"', path)

--- a/analyzer/windows/modules/packages/processes.py
+++ b/analyzer/windows/modules/packages/processes.py
@@ -21,105 +21,105 @@ class PROCESSES(Package):
         """
         for i in xrange(20):
             #calc
-            calc = os.path.join("c:\\windows", "system32", "calc.exe")
+            calc = os.path.join("C:\\windows", "system32", "calc.exe")
             #cl = Process()
             self.execute(calc, "", path)
         #cl.close()
         """
-        iexplore = os.path.join("c:\\Program Files", "Internet Explorer", "iexplore.exe")
+        iexplore = os.path.join("C:\\Program Files", "Internet Explorer", "iexplore.exe")
         # ie = Process()
         self.execute(iexplore, "", path)
         # ie.close()
 
         # firefox
-        firefox = os.path.join("c:\\Program Files", "Mozilla Firefox", "firefox.exe")
+        firefox = os.path.join("C:\\Program Files", "Mozilla Firefox", "firefox.exe")
         # ff = Process()
         self.execute(firefox, "", path)
         # ff.close()
 
         # winrar
-        # winrar = os.path.join("c:\\Program Files", "WinRAR", "WinRAR.exe")
+        # winrar = os.path.join("C:\\Program Files", "WinRAR", "WinRAR.exe")
         # wr = Process()
         # self.execute(winrar, "", path)
         # wr.close()
 
         # media player
-        mc = os.path.join("c:\\Program Files", "Windows Media Player", "wmplayer.exe")
+        mc = os.path.join("C:\\Program Files", "Windows Media Player", "wmplayer.exe")
         # mc_p = Process()
         self.execute(mc, "/prefetch:1", path)
         # mc_p.close()
 
         # adobe pdf reader
-        pdf = os.path.join("c:\\Program Files", "Adobe", "Reader 11.0", "Reader", "AcroRd32.exe")
+        pdf = os.path.join("C:\\Program Files", "Adobe", "Reader 11.0", "Reader", "AcroRd32.exe")
         # pdf_p = Process()
         self.execute(mc, "", path)
         # pdf_p.close()
 
         # snipping tool
-        # snt = os.path.join("c:\\windows", "system32", "Snipping Tool.exe")
+        # snt = os.path.join("C:\\windows", "system32", "Snipping Tool.exe")
         # snt_p = Process()
         # self.execute(snt, "", path)
         # snt_p.close()
 
         # backup and restore tool
-        bnr = os.path.join("c:\\windows", "system32", "control.exe")
+        bnr = os.path.join("C:\\windows", "system32", "control.exe")
         # bnr_p = Process()
         self.execute(bnr, "/name Microsoft.BackupAndRestore", path)
         # bnr_p.close()
 
         # on screen keyboard
-        konscr = os.path.join("c:\\windows", "system32", "osk.exe")
+        konscr = os.path.join("C:\\windows", "system32", "osk.exe")
         # konscr_p = Process()
         self.execute(konscr, "", path)
         # konscr_p.close()
 
         # sync center
-        mobs = os.path.join("c:\\windows", "system32", "mobsync.exe")
+        mobs = os.path.join("C:\\windows", "system32", "mobsync.exe")
         # mobs_p = Process()
         self.execute(mobs, "", path)
         # mobs_p.close()
 
         # rdp
-        rdp = os.path.join("c:\\windows", "system32", "mstsc.exe")
+        rdp = os.path.join("C:\\windows", "system32", "mstsc.exe")
         # rdp_p = Process()
         self.execute(rdp, "", path)
         # rdp_p.close()
 
         # char map
-        chrm = os.path.join("c:\\windows", "system32", "charmap.exe")
+        chrm = os.path.join("C:\\windows", "system32", "charmap.exe")
         # chrm_p = Process()
         self.execute(chrm, "", path)
         # chrm_p.close()
 
         # media center
-        # mc = os.path.join("c:\\windows", "system32", "ehshell.exe")
+        # mc = os.path.join("C:\\windows", "system32", "ehshell.exe")
         # mc_p = Process()
         # self.execute(mc, "", path)
         # mc_p.close()
         """
             #xps viewer
-            xps = os.path.join("c:\\windows", "system32", "xpschvw.exe")
+            xps = os.path.join("C:\\windows", "system32", "xpschvw.exe")
             #xps_v = Process()
             self.execute(xps, "", path)
             #xps_v.close()
             """
         # notepad
-        # notepad = os.path.join("c:\\windows", "system32", "notepad32.exe")
+        # notepad = os.path.join("C:\\windows", "system32", "notepad32.exe")
         # np = Process()
         # self.execute(notepad, "", path)
         # np.close()
 
         # calc
-        calc = os.path.join("c:\\windows", "system32", "calc.exe")
+        calc = os.path.join("C:\\windows", "system32", "calc.exe")
         # cl = Process()
         self.execute(calc, "", path)
         # cl.close()
 
         # paint
-        paint = os.path.join("c:\\windows", "system32", "mspaint.exe")
+        paint = os.path.join("C:\\windows", "system32", "mspaint.exe")
         # pnt = Process()
         self.execute(paint, "", path)
         # pnt.close()
         time.sleep(5)
         word = self.get_path_glob("Microsoft Office Word")
-        return self.execute(word, '"%s" /q' % path, path)
+        return self.execute(word, f'"{path}" /q', path)

--- a/analyzer/windows/modules/packages/processes_simple.py
+++ b/analyzer/windows/modules/packages/processes_simple.py
@@ -21,104 +21,104 @@ class PROCESSES_simply(Package):
 
         for i in range(20):
             # calc
-            calc = os.path.join("c:\\windows", "system32", "calc.exe")
+            calc = os.path.join("C:\\windows", "system32", "calc.exe")
             # cl = Process()
             self.execute(calc, "", path)
         # cl.close()
         """
-            iexplore = os.path.join("c:\\Program Files", "Internet Explorer", "iexplore.exe")
+            iexplore = os.path.join("C:\\Program Files", "Internet Explorer", "iexplore.exe")
             #ie = Process()
             self.execute(iexplore, "", path)
             #ie.close()
 
             #firefox
-            firefox = os.path.join("c:\\Program Files", "Mozilla Firefox", "firefox.exe")
+            firefox = os.path.join("C:\\Program Files", "Mozilla Firefox", "firefox.exe")
             #ff = Process()
             self.execute(firefox, "", path)
             #ff.close()
 
             #winrar
-            #winrar = os.path.join("c:\\Program Files", "WinRAR", "WinRAR.exe")
+            #winrar = os.path.join("C:\\Program Files", "WinRAR", "WinRAR.exe")
             #wr = Process()
             #self.execute(winrar, "", path)
             #wr.close()
 
             #media player
-            mc = os.path.join("c:\\Program Files", "Windows Media Player", "wmplayer.exe")
+            mc = os.path.join("C:\\Program Files", "Windows Media Player", "wmplayer.exe")
             #mc_p = Process()
             self.execute(mc, "/prefetch:1", path)
             #mc_p.close()
 
             #adobe pdf reader
-            pdf = os.path.join("c:\\Program Files", "Adobe", "Reader 11.0", "Reader", "AcroRd32.exe")
+            pdf = os.path.join("C:\\Program Files", "Adobe", "Reader 11.0", "Reader", "AcroRd32.exe")
             #pdf_p = Process()
             self.execute(mc, "", path)
             #pdf_p.close()
 
             #snipping tool
-            #snt = os.path.join("c:\\windows", "system32", "Snipping Tool.exe")
+            #snt = os.path.join("C:\\windows", "system32", "Snipping Tool.exe")
             #snt_p = Process()
             #self.execute(snt, "", path)
             #snt_p.close()
 
             #backup and restore tool
-            bnr = os.path.join("c:\\windows", "system32", "control.exe")
+            bnr = os.path.join("C:\\windows", "system32", "control.exe")
             #bnr_p = Process()
             self.execute(bnr, "/name Microsoft.BackupAndRestore", path)
             #bnr_p.close()
 
             #on screen keyboard
-            konscr = os.path.join("c:\\windows", "system32", "osk.exe")
+            konscr = os.path.join("C:\\windows", "system32", "osk.exe")
             #konscr_p = Process()
             self.execute(konscr, "", path)
             #konscr_p.close()
 
             #sync center
-            mobs = os.path.join("c:\\windows", "system32", "mobsync.exe")
+            mobs = os.path.join("C:\\windows", "system32", "mobsync.exe")
             #mobs_p = Process()
             self.execute(mobs, "", path)
             #mobs_p.close()
 
             #rdp
-            rdp = os.path.join("c:\\windows", "system32", "mstsc.exe")
+            rdp = os.path.join("C:\\windows", "system32", "mstsc.exe")
             #rdp_p = Process()
             self.execute(rdp, "", path)
             #rdp_p.close()
 
             #char map
-            chrm = os.path.join("c:\\windows", "system32", "charmap.exe")
+            chrm = os.path.join("C:\\windows", "system32", "charmap.exe")
             #chrm_p = Process()
             self.execute(chrm, "", path)
             #chrm_p.close()
 
             #media center
-            #mc = os.path.join("c:\\windows", "system32", "ehshell.exe")
+            #mc = os.path.join("C:\\windows", "system32", "ehshell.exe")
             #mc_p = Process()
             #self.execute(mc, "", path)
             #mc_p.close()
             #xps viewer
-            xps = os.path.join("c:\\windows", "system32", "xpschvw.exe")
+            xps = os.path.join("C:\\windows", "system32", "xpschvw.exe")
             #xps_v = Process()
             self.execute(xps, "", path)
             #xps_v.close()
             #notepad
-            #notepad = os.path.join("c:\\windows", "system32", "notepad32.exe")
+            #notepad = os.path.join("C:\\windows", "system32", "notepad32.exe")
             #np = Process()
             #self.execute(notepad, "", path)
             #np.close()
 
             #calc
-            calc = os.path.join("c:\\windows", "system32", "calc.exe")
+            calc = os.path.join("C:\\windows", "system32", "calc.exe")
             #cl = Process()
             self.execute(calc, "", path)
             #cl.close()
 
             #paint
-            paint = os.path.join("c:\\windows", "system32", "mspaint.exe")
+            paint = os.path.join("C:\\windows", "system32", "mspaint.exe")
             #pnt = Process()
             self.execute(paint, "", path)
             #pnt.close()
             """
         time.sleep(5)
         word = self.get_path_glob("Microsoft Office Word")
-        return self.execute(word, '"%s" /q' % path, path)
+        return self.execute(word, f'"{path}" /q', path)

--- a/analyzer/windows/modules/packages/ps1.py
+++ b/analyzer/windows/modules/packages/ps1.py
@@ -21,8 +21,8 @@ class PS1(Package):
         powershell = self.get_path_glob("PowerShell")
 
         if not path.endswith(".ps1"):
-            os.rename(path, path + ".ps1")
+            os.rename(path, f"{path}.ps1")
             path += ".ps1"
 
-        args = '-NoProfile -ExecutionPolicy bypass -File "{0}"'.format(path)
+        args = f'-NoProfile -ExecutionPolicy bypass -File "{path}"'
         return self.execute(powershell, args, path)

--- a/analyzer/windows/modules/packages/ps1_x64.py
+++ b/analyzer/windows/modules/packages/ps1_x64.py
@@ -21,8 +21,8 @@ class PS1_x64(Package):
         powershell = self.get_path_glob("PowerShell")
 
         if not path.endswith(".ps1"):
-            os.rename(path, path + ".ps1")
+            os.rename(path, f"{path}.ps1")
             path += ".ps1"
 
-        args = '-NoProfile -ExecutionPolicy bypass -File "{0}"'.format(path)
+        args = f'-NoProfile -ExecutionPolicy bypass -File "{path}"'
         return self.execute(powershell, args, path)

--- a/analyzer/windows/modules/packages/pub.py
+++ b/analyzer/windows/modules/packages/pub.py
@@ -61,7 +61,7 @@ class PUB(Package):
 
         for oVersion in installedVersions:
             key = CreateKeyEx(
-                HKEY_CURRENT_USER, r"{0}\{1}\Publisher\Security".format(baseOfficeKeyPath, oVersion), 0, KEY_SET_VALUE
+                HKEY_CURRENT_USER, rf"{baseOfficeKeyPath}\{oVersion}\Publisher\Security", 0, KEY_SET_VALUE
             )
 
             SetValueEx(key, "VBAWarnings", 0, REG_DWORD, 1)
@@ -73,6 +73,6 @@ class PUB(Package):
         self.set_keys()
         publisher = self.get_path_glob("Microsoft Office Publisher")
         if not path.endswith(".pub"):
-            os.rename(path, path + ".pub")
+            os.rename(path, f"{path}.pub")
             path += ".pub"
-        return self.execute(publisher, '"%s"' % path, path)
+        return self.execute(publisher, f'"{path}"', path)

--- a/analyzer/windows/modules/packages/pub2016.py
+++ b/analyzer/windows/modules/packages/pub2016.py
@@ -57,7 +57,7 @@ class PUB2007(Package):
 
         for oVersion in installedVersions:
             key = CreateKeyEx(
-                HKEY_CURRENT_USER, r"{0}\{1}\Publisher\Security".format(baseOfficeKeyPath, oVersion), 0, KEY_SET_VALUE
+                HKEY_CURRENT_USER, rf"{baseOfficeKeyPath}\{oVersion}\Publisher\Security", 0, KEY_SET_VALUE
             )
 
             SetValueEx(key, "VBAWarnings", 0, REG_DWORD, 1)
@@ -69,6 +69,6 @@ class PUB2007(Package):
         self.set_keys()
         publisher = self.get_path_glob("Microsoft Office Publisher")
         if not path.endswith(".pub"):
-            os.rename(path, path + ".pub")
+            os.rename(path, f"{path}.pub")
             path += ".pub"
-        return self.execute(publisher, '"%s"' % path, path)
+        return self.execute(publisher, f'"{path}"', path)

--- a/analyzer/windows/modules/packages/python.py
+++ b/analyzer/windows/modules/packages/python.py
@@ -14,4 +14,4 @@ class Python(Package):
     def start(self, path):
         python = self.get_path_glob("Python")
         arguments = self.options.get("arguments", "")
-        return self.execute(python, "%s %s" % (path, arguments), path)
+        return self.execute(python, f"{path} {arguments}", path)

--- a/analyzer/windows/modules/packages/rar.py
+++ b/analyzer/windows/modules/packages/rar.py
@@ -38,7 +38,7 @@ class Rar(Package):
         if self.is_overwritten(rar_path):
             log.debug("RAR file contains a file with the same name, original is going to be overwrite")
             # TODO: add random string.
-            new_rar_path = rar_path + ".old"
+            new_rar_path = f"{rar_path}.old"
             shutil.move(rar_path, new_rar_path)
             rar_path = new_rar_path
 
@@ -52,7 +52,7 @@ class Rar(Package):
                 try:
                     archive.extractall(path=extract_path, pwd="infected")
                 except RuntimeError as e:
-                    raise CuckooPackageError("Unable to extract Rar file: " "{0}".format(e))
+                    raise CuckooPackageError(f"Unable to extract Rar file: {e}")
             finally:
                 # Extract nested archives.
                 for name in archive.namelist():
@@ -88,12 +88,12 @@ class Rar(Package):
 
     def start(self, path):
         if not HAS_RARFILE:
-            raise CuckooPackageError("rarfile Python module not installed in guest.")
+            raise CuckooPackageError("rarfile Python module not installed in guest")
 
         # Check file extension.
         ext = os.path.splitext(path)[-1].lower()
         if ext != ".rar":
-            new_path = path + ".rar"
+            new_path = f"{path}.rar"
             os.rename(path, new_path)
             path = new_path
 
@@ -116,14 +116,14 @@ class Rar(Package):
                         break
                 # Default to the first one if none found
                 file_name = file_name if file_name else rarinfos[0].filename
-                log.debug("Missing file option, auto executing: {0}".format(file_name))
+                log.debug("Missing file option, auto executing: %s", file_name)
             else:
                 raise CuckooPackageError("Empty RAR archive")
 
         file_path = os.path.join(root, file_name)
         if file_name.lower().endswith(".lnk"):
             cmd_path = self.get_path("cmd.exe")
-            cmd_args = '/c start /wait "" "{0}"'.format(file_path)
+            cmd_args = f'/c start /wait "" "{file_path}"'
             return self.execute(cmd_path, cmd_args, file_path)
         else:
             return self.execute(file_path, self.options.get("arguments"), file_path)

--- a/analyzer/windows/modules/packages/reg.py
+++ b/analyzer/windows/modules/packages/reg.py
@@ -16,5 +16,5 @@ class Reg(Package):
 
     def start(self, path):
         regexe = self.get_path("reg.exe")
-        reg_args = 'import "{0}"'.format(path)
+        reg_args = f'import "{path}"'
         return self.execute(regexe, reg_args, path)

--- a/analyzer/windows/modules/packages/regsvr.py
+++ b/analyzer/windows/modules/packages/regsvr.py
@@ -26,13 +26,13 @@ class Regsvr(Package):
         # and rename it. This is needed for rundll32 to execute correctly.
         # See ticket #354 for details.
         if ext != ".dll":
-            new_path = path + ".dll"
+            new_path = f"{path}.dll"
             os.rename(path, new_path)
             path = new_path
 
         args = ""
         if arguments:
-            args += "{0} ".format(arguments)
+            args += f"{arguments} "
         args += path
 
         return self.execute(regsvr32, args, path)

--- a/analyzer/windows/modules/packages/sct.py
+++ b/analyzer/windows/modules/packages/sct.py
@@ -15,6 +15,6 @@ class SCT(Package):
 
     def start(self, path):
         regsvr32 = self.get_path("regsvr32.exe")
-        args = "/u /n /i:{0} scrobj.dll".format(path)
+        args = f"/u /n /i:{path} scrobj.dll"
 
         return self.execute(regsvr32, args, path)

--- a/analyzer/windows/modules/packages/service.py
+++ b/analyzer/windows/modules/packages/service.py
@@ -69,12 +69,12 @@ class Service(Package):
             servicedesc = self.options.get("servicedesc", "CAPE Service")
             arguments = self.options.get("arguments")
             if "." not in os.path.basename(path):
-                new_path = path + ".exe"
+                new_path = f"{path}.exe"
                 os.rename(path, new_path)
                 path = new_path
-            binPath = '"{0}"'.format(path)
+            binPath = f'"{path}"'
             if arguments:
-                binPath += " {0}".format(arguments)
+                binPath += f" {arguments}"
             scm_handle = ADVAPI32.OpenSCManagerA(None, None, SC_MANAGER_ALL_ACCESS)
             if scm_handle == 0:
                 log.info("Failed to open SCManager")

--- a/analyzer/windows/modules/packages/vawtrak.py
+++ b/analyzer/windows/modules/packages/vawtrak.py
@@ -17,7 +17,7 @@ class IE(Package):
     def start(self, path):
         iexplore = self.get_path("Internet Explorer")
         # pass the URL instead of a filename in this case
-        self.execute(iexplore, '"%s"' % "about:blank", "about:blank")
+        self.execute(iexplore, '"about:blank"', "about:blank")
 
         args = self.options.get("arguments")
         appdata = self.options.get("appdata")
@@ -28,7 +28,7 @@ class IE(Package):
         # an exception that will crash the app if it does
         # not find an extension on the main exe's filename
         if "." not in os.path.basename(path):
-            new_path = path + ".exe"
+            new_path = f"{path}.exe"
             os.rename(path, new_path)
             path = new_path
 

--- a/analyzer/windows/modules/packages/vbejse.py
+++ b/analyzer/windows/modules/packages/vbejse.py
@@ -18,7 +18,7 @@ class VBSJSE(Package):
     def start(self, path):
         wscript = self.get_path("WScript")
         # We are here bcz of no extension
-        copyfile(path, path + ".vbe")
-        copyfile(path, path + ".jse")
-        self.execute(wscript, '"%s.vbe"' % path, path + ".vbe")
-        return self.execute(wscript, '"%s.jse"' % path, path + ".jse")
+        copyfile(path, f"{path}.vbe")
+        copyfile(path, f"{path}.jse")
+        self.execute(wscript, f'"{path}.vbe"', f"{path}.vbe")
+        return self.execute(wscript, f'"{path}.jse"', f"{path}.jse")

--- a/analyzer/windows/modules/packages/vbs.py
+++ b/analyzer/windows/modules/packages/vbs.py
@@ -27,10 +27,10 @@ class VBS(Package):
         ext = os.path.splitext(path)[-1].lower()
         if ext != ".vbs" and ext != ".vbe":
             if os.path.isfile(path) and b"#@~^" in open(path, "rb").read(100):
-                os.rename(path, path + ".vbe")
-                path = path + ".vbe"
+                os.rename(path, f"{path}.vbe")
+                path = f"{path}.vbe"
             else:
-                os.rename(path, path + ".vbs")
-                path = path + ".vbs"
+                os.rename(path, f"{path}.vbs")
+                path = f"{path}.vbs"
 
-        return self.execute(wscript, '"%s"' % path, path)
+        return self.execute(wscript, f'"{path}"', path)

--- a/analyzer/windows/modules/packages/wsf.py
+++ b/analyzer/windows/modules/packages/wsf.py
@@ -23,7 +23,7 @@ class WSF(Package):
 
         # Enforce the .wsf file extension as is required by wscript.
         if not path.endswith(".wsf"):
-            os.rename(path, path + ".wsf")
+            os.rename(path, f"{path}.wsf")
             path += ".wsf"
 
-        return self.execute(wscript, '"%s"' % path, path)
+        return self.execute(wscript, f'"{path}"', path)

--- a/analyzer/windows/modules/packages/xls.py
+++ b/analyzer/windows/modules/packages/xls.py
@@ -23,9 +23,9 @@ class XLS(Package):
 
     def start(self, path):
         if "." not in os.path.basename(path):
-            new_path = path + ".xls"
+            new_path = f"{path}.xls"
             os.rename(path, new_path)
             path = new_path
 
         excel = self.get_path_glob("Microsoft Office Excel")
-        return self.execute(excel, '"%s" /dde' % path, path)
+        return self.execute(excel, f'"{path}" /dde', path)

--- a/analyzer/windows/modules/packages/xls2016.py
+++ b/analyzer/windows/modules/packages/xls2016.py
@@ -21,9 +21,9 @@ class XLS2207(Package):
 
     def start(self, path):
         if "." not in os.path.basename(path):
-            new_path = path + ".xls"
+            new_path = f"{path}.xls"
             os.rename(path, new_path)
             path = new_path
 
         excel = self.get_path_glob("Microsoft Office Excel")
-        return self.execute(excel, '"%s" /dde' % path, path)
+        return self.execute(excel, f'"{path}" /dde', path)

--- a/analyzer/windows/modules/packages/xlst.py
+++ b/analyzer/windows/modules/packages/xlst.py
@@ -23,7 +23,7 @@ class XLST(Package):
         wmic = self.get_path("wmic.exe")
 
         if not path.endswith(".xsl"):
-            os.rename(path, path + ".xsl")
+            os.rename(path, f"{path}.xsl")
             path += ".xsl"
 
-        return self.execute(wmic, 'process LIST /FORMAT:"%s"' % path, path)
+        return self.execute(wmic, f'process LIST /FORMAT:"{path}"', path)

--- a/analyzer/windows/modules/packages/xps.py
+++ b/analyzer/windows/modules/packages/xps.py
@@ -15,5 +15,5 @@ class Xps(Package):
 
     def start(self, path):
         xpsrchvw_path = self.get_path("xpsrchvw.exe")
-        xpsrchvw_args = '"{0}"'.format(path)
+        xpsrchvw_args = f'"{path}"'
         return self.execute(xpsrchvw_path, xpsrchvw_args, path)

--- a/analyzer/windows/modules/packages/zip.py
+++ b/analyzer/windows/modules/packages/zip.py
@@ -40,9 +40,9 @@ class Zip(Package):
         """
         # Test if zip file contains a file named as itself.
         if self.is_overwritten(zip_path):
-            log.debug("ZIP file contains a file with the same name, original is going to be overwrite")
+            log.debug("ZIP file contains a file with the same name, original is going to be overwritten")
             # TODO: add random string.
-            new_zip_path = zip_path + ".old"
+            new_zip_path = f"{zip_path}.old"
             shutil.move(zip_path, new_zip_path)
             zip_path = new_zip_path
 
@@ -71,7 +71,7 @@ class Zip(Package):
                 try:
                     archive.extractall(path=extract_path, pwd=password)
                 except RuntimeError as e:
-                    raise CuckooPackageError("Unable to extract Zip file: " "{0}".format(e))
+                    raise CuckooPackageError(f"Unable to extract Zip file: {e}")
             finally:
                 if recursion_depth < 4:
                     # Extract nested archives.
@@ -87,10 +87,10 @@ class Zip(Package):
                                 )
                             except BadZipfile:
                                 log.warning(
-                                    "Nested zip file '%s' name end with 'zip' extension is not a valid zip. Skip extracting" % name
+                                    "Nested zip file '%s' name end with 'zip' extension is not a valid zip. Skip extracting", name
                                 )
                             except RuntimeError as run_err:
-                                log.error("Error to extract nested zip file %s with details: %s" % name, run_err)
+                                log.error("Error to extract nested zip file %s with details: %s", name, run_err)
 
     def is_overwritten(self, zip_path):
         """Checks if the ZIP file contains another file with the same name, so it is going to be overwritten.
@@ -143,32 +143,32 @@ class Zip(Package):
                         break
                 # Default to the first one if none found
                 file_name = file_name if file_name else zipinfos[0].filename
-                log.debug("Missing file option, auto executing: {0}".format(file_name))
+                log.debug("Missing file option, auto executing: %s", file_name)
             else:
                 raise CuckooPackageError("Empty ZIP archive")
 
         file_path = os.path.join(root, file_name)
-        log.debug('file_name: "%s"' % (file_name))
+        log.debug('file_name: "%s"', file_name)
         if file_name.lower().endswith(".lnk"):
             cmd_path = self.get_path("cmd.exe")
-            cmd_args = '/c start /wait "" "{0}"'.format(file_path)
+            cmd_args = f'/c start /wait "" "{file_path}"'
             return self.execute(cmd_path, cmd_args, file_path)
         elif file_name.lower().endswith(".msi"):
             msi_path = self.get_path("msiexec.exe")
-            msi_args = '/I "{0}"'.format(file_path)
+            msi_args = f'/I "{file_path}"'
             return self.execute(msi_path, msi_args, file_path)
         elif file_name.lower().endswith((".js", ".jse", ".vbs", ".vbe", ".wsf")):
             wscript = self.get_path_app_in_path("wscript.exe")
-            wscript_args = '"{0}"'.format(file_path)
+            wscript_args = f'"{file_path}"'
             return self.execute(wscript, wscript_args, file_path)
         elif file_name.lower().endswith(".dll"):
             rundll32 = self.get_path_app_in_path("rundll32.exe")
             function = self.options.get("function", "#1")
             arguments = self.options.get("arguments")
             dllloader = self.options.get("dllloader")
-            dll_args = '"{0}",{1}'.format(file_path, function)
+            dll_args = f'"{file_path}",{function}'
             if arguments:
-                dll_args += " {0}".format(arguments)
+                dll_args += f" {arguments}"
             if dllloader:
                 newname = os.path.join(os.path.dirname(rundll32), dllloader)
                 shutil.copy(rundll32, newname)
@@ -176,11 +176,11 @@ class Zip(Package):
             return self.execute(rundll32, dll_args, file_path)
         elif file_name.lower().endswith(".ps1"):
             powershell = self.get_path_app_in_path("powershell.exe")
-            args = '-NoProfile -ExecutionPolicy bypass -File "{0}"'.format(path)
+            args = f'-NoProfile -ExecutionPolicy bypass -File "{path}"'
             return self.execute(powershell, args, file_path)
         else:
             if "." not in os.path.basename(file_path):
-                new_path = file_path + ".exe"
+                new_path = file_f"{path}.exe"
                 os.rename(file_path, new_path)
                 file_path = new_path
             return self.execute(file_path, self.options.get("arguments"), file_path)

--- a/analyzer/windows/modules/packages/zip.py
+++ b/analyzer/windows/modules/packages/zip.py
@@ -180,7 +180,7 @@ class Zip(Package):
             return self.execute(powershell, args, file_path)
         else:
             if "." not in os.path.basename(file_path):
-                new_path = file_f"{path}.exe"
+                new_path = f"{file_path}.exe"
                 os.rename(file_path, new_path)
                 file_path = new_path
             return self.execute(file_path, self.options.get("arguments"), file_path)


### PR DESCRIPTION
Changes done:
1) Convert strings to f-strings (other than for logging)
2) Standardise logging (Capitalise first letter with a few exceptions, no full-stop at the end)
3) Convert all `c:\` to `C:\` (for paths referencing HomeDrive)

Other folders (e.g. `lib`) have not been looked yet.
All files have been run through `black -l 132`