### PR TITLE
Use default parameter for `.encode()` and `.decode()`

### DIFF
--- a/admin/admin.py
+++ b/admin/admin.py
@@ -179,7 +179,7 @@ def execute_command_on_all(remote_command):
         try:
             ssh = _connect_via_jump_box(server)
             _, ssh_stdout, _ = ssh.exec_command(remote_command)
-            ssh_out = ssh_stdout.read().decode("utf-8").strip()
+            ssh_out = ssh_stdout.read().decode().strip()
             if "Active: active (running)" in ssh_out and "systemctl status" not in remote_command:
                 log.info("[+] Service %s", green("restarted successfully and is UP"))
             else:
@@ -227,11 +227,11 @@ def deploy_file(queue):
                 if remote_command:
                     _, ssh_stdout, _ = ssh.exec_command(remote_command)
 
-                    ssh_out = ssh_stdout.read().decode("utf-8")
+                    ssh_out = ssh_stdout.read().decode()
                     log.info(ssh_out)
 
                 _, ssh_stdout, _ = ssh.exec_command(f"sha256sum {remote_file} | cut -d ' ' -f1")
-                remote_sha256 = ssh_stdout.read().strip().decode("utf-8")
+                remote_sha256 = ssh_stdout.read().strip().decode()
 
                 if local_sha256 == remote_sha256:
                     log.info(f"[+] {server} - Hashes are {green('correct')}: {local_sha256} - {remote_file}")
@@ -357,7 +357,7 @@ if __name__ == "__main__":
             http = urllib3.PoolManager()
             r = http.request("GET", CAPE_DIST_URL)
             if r.status == 200:
-                res = json.loads(r.data.decode("utf-8")).get("nodes", [])
+                res = json.loads(r.data.decode()).get("nodes", [])
                 servers = [urlparse(res[server]["url"]).hostname for server in res] + [MASTER_NODE]
         except (urllib3.exceptions.NewConnectionError, urllib3.exceptions.MaxRetryError):
             sys.exit("Can't retrieve list of servers")
@@ -376,22 +376,22 @@ if __name__ == "__main__":
     elif args.copy_file:
         local_file, remote_file = args.copy_file
         with open(local_file, "r") as f:
-            local_sha256 = sha256(f.read().encode("utf-8")).hexdigest()
+            local_sha256 = sha256(f.read().encode()).hexdigest()
         queue = Queue()
         queue.put((servers, local_file, remote_file, False, local_sha256))
         _ = deploy_file(queue)
     elif args.deploy_local_changes:
         out = subprocess.check_output(["git", "ls-files", "--other", "--modified", "--exclude-standard"])
-        files = [file.decode("utf-8") for file in list(filter(None, out.split(b"\n")))]
+        files = [file.decode() for file in list(filter(None, out.split(b"\n")))]
     elif args.deploy_remote_changes:
         out = subprocess.check_output(["git", "diff", "--name-only", "origin/master"])
-        files = [file.decode("utf-8") for file in list(filter(None, out.split(b"\n")))]
+        files = [file.decode() for file in list(filter(None, out.split(b"\n")))]
     elif args.sync_community:
         community_folder, destiny_folder, head = args.sync_community
         cwd = os.getcwd()
         os.chdir(os.path.expandvars(community_folder))
         out = subprocess.check_output(["git", "diff", "--name-only", f"HEAD~{head}"])
-        community_files = [file.decode("utf-8") for file in list(filter(None, out.split(b"\n")))]
+        community_files = [file.decode() for file in list(filter(None, out.split(b"\n")))]
         os.chdir(cwd)
         files = []
         for file in community_files:

--- a/agent/agent.py
+++ b/agent/agent.py
@@ -136,7 +136,7 @@ class MiniHTTPServer(object):
         obj.end_headers()
 
         if isinstance(ret, jsonify):
-            obj.wfile.write(ret.json().encode("utf-8"))
+            obj.wfile.write(ret.json().encode())
         elif isinstance(ret, send_file):
             ret.write(obj.wfile)
 

--- a/analyzer/linux/analyzer.py
+++ b/analyzer/linux/analyzer.py
@@ -386,6 +386,6 @@ if __name__ == "__main__":
                 "status": "complete",
                 "description": success,
             }
-            urlopen("http://127.0.0.1:8000/status", urlencode(data).encode("utf-8")).read()
+            urlopen("http://127.0.0.1:8000/status", urlencode(data).encode()).read()
         except Exception as e:
             print(e)

--- a/analyzer/linux/lib/common/results.py
+++ b/analyzer/linux/lib/common/results.py
@@ -114,14 +114,14 @@ class NetlogFile(NetlogConnection):
             pids = ""
         if filepath:
             self.proto = b"FILE 2\n%s\n%s\n%s\n%s\n%s\n" % (
-                dump_path.encode("utf8"),
+                dump_path.encode(),
                 filepath.encode("utf-8", "replace"),
-                pids.encode("utf8") if isinstance(pids, str) else pids,
-                metadata.encode("utf8") if isinstance(metadata, str) else metadata,
-                category.encode("utf8") if isinstance(category, str) else category,
+                pids.encode() if isinstance(pids, str) else pids,
+                metadata.encode() if isinstance(metadata, str) else metadata,
+                category.encode() if isinstance(category, str) else category,
             )
         else:
-            self.proto = b"FILE\n%s\n" % dump_path.encode("utf8")
+            self.proto = b"FILE\n%s\n" % dump_path.encode()
         self.connect()
 
 
@@ -133,4 +133,4 @@ class NetlogHandler(logging.Handler, NetlogConnection):
 
     def emit(self, record):
         msg = self.format(record)
-        self.send(msg.encode("utf-8") + b"\n")
+        self.send(msg.encode() + b"\n")

--- a/analyzer/linux/modules/auxiliary/stap.py
+++ b/analyzer/linux/modules/auxiliary/stap.py
@@ -57,7 +57,7 @@ class STAP(Auxiliary):
             stderr=subprocess.PIPE,
         )
 
-        while "systemtap_module_init() returned 0" not in self.proc.stderr.readline().decode("utf8"):
+        while "systemtap_module_init() returned 0" not in self.proc.stderr.readline().decode():
             pass
 
         self.proc.terminate()

--- a/analyzer/windows/analyzer.py
+++ b/analyzer/windows/analyzer.py
@@ -223,8 +223,8 @@ class Analyzer:
         # Create the folders used for storing the results.
         create_folders()
 
-        add_protected_path(os.getcwd().encode("utf-8"))
-        add_protected_path(PATHS["root"].encode("utf-8"))
+        add_protected_path(os.getcwd().encode())
+        add_protected_path(PATHS["root"].encode())
 
         # Initialize logging.
         init_logging()
@@ -868,14 +868,14 @@ class CommandPipeHandler(object):
     def _handle_debug(self, data):
         """Debug message from the monitor."""
         try:
-            log.debug(data.decode("utf-8"))
+            log.debug(data.decode())
         except Exception:
             log.debug(data)
 
     def _handle_info(self, data):
         """Regular message from the monitor."""
         try:
-            log.info(data.decode("utf-8"))
+            log.info(data.decode())
         except Exception:
             log.debug(data)
 
@@ -1063,7 +1063,7 @@ class CommandPipeHandler(object):
             si.dwFlags = 1
             # SW_HIDE
             si.wShowWindow = 0
-            subprocess.call(f"sc config {servname.decode('utf-8')} type= own", startupinfo=si)
+            subprocess.call(f"sc config {servname.decode()} type= own", startupinfo=si)
             log.info('Announced starting service "%s"', servname)
             if not self.analyzer.MONITORED_SERVICES:
                 # Inject into services.exe so we can monitor service creation
@@ -1252,7 +1252,7 @@ class CommandPipeHandler(object):
     def _handle_file_new(self, file_path):
         """Notification of a new dropped file."""
         if os.path.exists(file_path):
-            self.analyzer.files.add_file(file_path.decode("utf-8"), self.pid)
+            self.analyzer.files.add_file(file_path.decode(), self.pid)
 
     def _handle_file_cape(self, data):
         """Notification of a new dropped file."""
@@ -1260,9 +1260,9 @@ class CommandPipeHandler(object):
         file_path, pid, ppid, metadata = data.split(b"|")
         if os.path.exists(file_path):
             self.analyzer.files.dump_file(
-                file_path.decode("utf-8"),
-                pids=[pid.decode("utf-8")],
-                ppids=[ppid.decode("utf-8")],
+                file_path.decode(),
+                pids=[pid.decode()],
+                ppids=[ppid.decode()],
                 metadata=metadata,
                 category="CAPE",
             )
@@ -1273,7 +1273,7 @@ class CommandPipeHandler(object):
     def _handle_file_del(self, data):
         """Notification of a file being removed (if it exists) - we have to
         dump it before it's being removed."""
-        file_path = data.decode("utf8")
+        file_path = data.decode()
         if os.path.exists(file_path):
             self.analyzer.files.delete_file(file_path, self.pid)
 
@@ -1285,9 +1285,9 @@ class CommandPipeHandler(object):
             file_path, pid, ppid, metadata = file_path.split(b"|")
             if os.path.exists(file_path):
                 self.analyzer.files.dump_file(
-                    file_path.decode("utf-8"),
-                    pids=[pid.decode("utf-8")],
-                    ppids=[ppid.decode("utf-8")],
+                    file_path.decode(),
+                    pids=[pid.decode()],
+                    ppids=[ppid.decode()],
                     metadata=metadata,
                     category="procdump",
                 )
@@ -1295,9 +1295,9 @@ class CommandPipeHandler(object):
         else:
             if os.path.exists(file_path):
                 if b"\\memory\\" in file_path:
-                    self.analyzer.files.dump_file(file_path.decode("utf-8"), category="memory")
+                    self.analyzer.files.dump_file(file_path.decode(), category="memory")
                 else:
-                    self.analyzer.files.add_file(file_path.decode("utf-8"), self.pid)
+                    self.analyzer.files.add_file(file_path.decode(), self.pid)
             else:
                 log.info("File doesn't exist, %s", file_path)
 
@@ -1335,8 +1335,8 @@ class CommandPipeHandler(object):
             return
 
         old_filepath, new_filepath = data.split(b"::", 1)
-        new_filepath = new_filepath.decode("utf8")
-        self.analyzer.files.move_file(old_filepath.decode("utf8"), new_filepath, self.pid)
+        new_filepath = new_filepath.decode()
+        self.analyzer.files.move_file(old_filepath.decode(), new_filepath, self.pid)
 
     def dispatch(self, data):
         response = "NOPE"
@@ -1389,7 +1389,7 @@ if __name__ == "__main__":
         data["status"] = "exception"
         data["description"] = "You probably submitted the job with wrong package"
         try:
-            urlopen("http://127.0.0.1:8000/status", urlencode(data).encode("utf-8")).read()
+            urlopen("http://127.0.0.1:8000/status", urlencode(data).encode()).read()
         except Exception as e:
             print(e)
         sys.exit()
@@ -1425,6 +1425,6 @@ if __name__ == "__main__":
             else:
                 data["description"] = complete_excp
         try:
-            urlopen("http://127.0.0.1:8000/status", urlencode(data).encode("utf-8")).read()
+            urlopen("http://127.0.0.1:8000/status", urlencode(data).encode()).read()
         except Exception as e:
             print(e)

--- a/analyzer/windows/lib/api/process.py
+++ b/analyzer/windows/lib/api/process.py
@@ -61,9 +61,9 @@ def get_referrer_url(interest):
 
     escapedurl = urllib.parse.quote(interest, "")
     itemidx = random.randint(1, 30)
-    vedstr = b"0CCEQfj" + base64.urlsafe_b64encode(random_string(random.randint(5, 8) * 3).encode("utf-8"))
-    eistr = base64.urlsafe_b64encode(random_string(12).encode("utf-8"))
-    usgstr = b"AFQj" + base64.urlsafe_b64encode(random_string(12).encode("utf-8"))
+    vedstr = b"0CCEQfj" + base64.urlsafe_b64encode(random_string(random.randint(5, 8) * 3).encode())
+    eistr = base64.urlsafe_b64encode(random_string(12).encode())
+    usgstr = b"AFQj" + base64.urlsafe_b64encode(random_string(12).encode())
     referrer = f"http://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd={itemidx}&ved={vedstr}&url={escapedurl}&ei={eistr}&usg={usgstr}"
     return referrer
 

--- a/analyzer/windows/lib/common/results.py
+++ b/analyzer/windows/lib/common/results.py
@@ -127,16 +127,16 @@ class NetlogFile(NetlogConnection):
             ppids = ""
         if filepath:
             self.proto = b"FILE 2\n%s\n%s\n%s\n%s\n%s\n%s\n%d\n" % (
-                dump_path.encode("utf8"),
+                dump_path.encode(),
                 filepath.encode("utf-8", "replace"),
-                pids.encode("utf8") if isinstance(pids, str) else pids,
-                ppids.encode("utf8") if isinstance(ppids, str) else ppids,
-                metadata.encode("utf8") if isinstance(metadata, str) else metadata,
-                category.encode("utf8") if isinstance(category, str) else category,
+                pids.encode() if isinstance(pids, str) else pids,
+                ppids.encode() if isinstance(ppids, str) else ppids,
+                metadata.encode() if isinstance(metadata, str) else metadata,
+                category.encode() if isinstance(category, str) else category,
                 1 if duplicated else 0,
             )
         else:
-            self.proto = b"FILE\n%s\n" % dump_path.encode("utf8")
+            self.proto = b"FILE\n%s\n" % dump_path.encode()
         self.connect()
 
 
@@ -148,4 +148,4 @@ class NetlogHandler(logging.Handler, NetlogConnection):
 
     def emit(self, record):
         msg = self.format(record)
-        self.send(msg.encode("utf-8") + b"\n")
+        self.send(msg.encode() + b"\n")

--- a/analyzer/windows/modules/auxiliary/digisig.py
+++ b/analyzer/windows/modules/auxiliary/digisig.py
@@ -135,7 +135,7 @@ class DigiSig(Auxiliary):
             else:
                 self.json_data["error"] = True
                 errmsg = b" ".join(b"".join(err.split(b":")[1:]).split())
-                self.json_data["error_desc"] = errmsg.decode("utf-8")
+                self.json_data["error_desc"] = errmsg.decode()
                 if b"file format cannot be verified" in err:
                     log.debug("File format not recognized")
                 elif b"No signature found" not in err:
@@ -149,7 +149,7 @@ class DigiSig(Auxiliary):
             if self.json_data:
                 log.info("Uploading signature results to aux/%s.json", self.__class__.__name__)
                 upload = BytesIO()
-                upload.write(json.dumps(self.json_data, ensure_ascii=False).encode("utf-8"))
+                upload.write(json.dumps(self.json_data, ensure_ascii=False).encode())
                 upload.seek(0)
                 nf = NetlogFile()
                 nf.init("aux/DigiSig.json")

--- a/analyzer/windows/modules/packages/zip.py
+++ b/analyzer/windows/modules/packages/zip.py
@@ -48,7 +48,7 @@ class Zip(Package):
 
         # requires bytes not str
         if not isinstance(password, bytes):
-            password = password.encode("utf-8")
+            password = password.encode()
 
         # Extraction.
         with ZipFile(zip_path, "r") as archive:

--- a/lib/cuckoo/common/demux.py
+++ b/lib/cuckoo/common/demux.py
@@ -41,7 +41,7 @@ if sf_version:
 
 log = logging.getLogger(__name__)
 cuckoo_conf = Config()
-tmp_path = cuckoo_conf.cuckoo.get("tmppath", "/tmp").encode("utf8")
+tmp_path = cuckoo_conf.cuckoo.get("tmppath", "/tmp").encode()
 
 demux_extensions_list = [
     "",
@@ -120,7 +120,7 @@ def options2passwd(options):
     if "password=" in options:
         password = get_options(options).get("password")
         if password and isinstance(password, bytes):
-            password = password.decode("utf8")
+            password = password.decode()
 
     return password
 
@@ -223,7 +223,7 @@ def demux_sample(filename, package, options, use_sflock=True):
     """
     # sflock requires filename to be bytes object for Py3
     if isinstance(filename, str) and use_sflock:
-        filename = filename.encode("utf8")
+        filename = filename.encode()
     # if a package was specified, then don't do anything special
     if package:
         return [filename]

--- a/lib/cuckoo/common/fraunhofer_helper.py
+++ b/lib/cuckoo/common/fraunhofer_helper.py
@@ -24,6 +24,6 @@ def get_dga_lookup_dict():
     dga_lookup_path = os.path.join(CUCKOO_ROOT, "data", "dga_lookup_dict.json.gz")
     if os.path.exists(dga_lookup_path):
         with gzip.GzipFile(dga_lookup_path, "r") as fin:
-            return json.loads(fin.read().decode("utf-8"))
+            return json.loads(fin.read().decode())
 
     return {}

--- a/lib/cuckoo/common/integrations/Kixtart/detokenize.py
+++ b/lib/cuckoo/common/integrations/Kixtart/detokenize.py
@@ -58,11 +58,11 @@ class Kixtart:
 
     def decrypt(self):
         arc4 = ARC4.new(key=self.session_key)
-        self.logger.info(f'[*]\tdecrypting with session key {hexlify(self.session_key).decode("utf-8")}')
+        self.logger.info(f'[*]\tdecrypting with session key {hexlify(self.session_key).decode()}')
         token_data = arc4.decrypt(bytes(self.ciphertext))
         self.code_length = int.from_bytes(token_data[:4], byteorder="little")
         self.tokenized = token_data[4:]
-        self.logger.debug(f'raw tokenized script: {hexlify(self.tokenized).decode("utf-8")}')
+        self.logger.debug(f'raw tokenized script: {hexlify(self.tokenized).decode()}')
         self.parse()
         return self.tokenized
 
@@ -84,7 +84,7 @@ class Kixtart:
     def parse_functions(self):
         i = 0
         buf = self.function_data
-        self.logger.debug(f'Parsing function data {hexlify(buf).decode("utf-8")}')
+        self.logger.debug(f'Parsing function data {hexlify(buf).decode()}')
         # TODO have not looked into parsing scripts relying on multiple files
         filename = ""
         while buf[i] != 0:
@@ -133,7 +133,7 @@ class Kixtart:
 
                 # func = f'{filename}.{function_name}({",".join(parameters)})'
                 func = f'{function_name}({",".join(parameters)})'
-                # self.logger.debug(f'{func}: {hexlify(function_data).decode("utf-8")}')
+                # self.logger.debug(f'{func}: {hexlify(function_data).decode()}')
                 self.detokenize(function_data, labels, func)
                 i += 1
             except Exception:
@@ -193,7 +193,7 @@ class Kixtart:
         self.detokenize(self.tokenized, labels=labels, function=None)
 
         if self.function_data:
-            # self.logger.debug(f'Function data: {hexlify(self.function_data).decode("utf-8")}')
+            # self.logger.debug(f'Function data: {hexlify(self.function_data).decode()}')
             self.parse_functions()
         self.trim_script()
 
@@ -276,21 +276,21 @@ class Kixtart:
             if b == 0xE7:
                 # TODO is this null terminated or 2 bytes?
                 offset = int.from_bytes(buf[i + 1 : i + 3], byteorder="little")
-                self.script[line_num] += "$" + self.variables[offset].decode("utf-8")
+                self.script[line_num] += "$" + self.variables[offset].decode()
                 i += 3
                 continue
             # object method -  Fetch method name from vars table
             if b == 0xE8:
                 # TODO is this null terminated or 2 bytes?
                 offset = int.from_bytes(buf[i + 1 : i + 3], byteorder="little")
-                self.script[line_num] += "." + self.variables[offset].decode("utf-8")
+                self.script[line_num] += "." + self.variables[offset].decode()
                 i += 3
                 continue
             # Function? name from var table
             if b == 0xE9:
                 # TODO is this null terminated or 2 bytes?
                 offset = int.from_bytes(buf[i + 1 : i + 3], byteorder="little")
-                self.script[line_num] += self.variables[offset].decode("utf-8")
+                self.script[line_num] += self.variables[offset].decode()
                 i += 3
                 continue
             # Keyword

--- a/lib/cuckoo/common/objects.py
+++ b/lib/cuckoo/common/objects.py
@@ -140,7 +140,7 @@ def IsPEImage(buf, size=False):
     if size < DOS_HEADER_LIMIT:
         return False
     if isinstance(buf, str):
-        buf = buf.encode("utf-8")
+        buf = buf.encode()
     dos_header = buf[:DOS_HEADER_LIMIT]
     nt_headers = None
 
@@ -393,7 +393,7 @@ class File(object):
             return None
 
         try:
-            return pydeep.hash_file(self.file_path).decode("utf-8")
+            return pydeep.hash_file(self.file_path).decode()
         except Exception:
             return None
 
@@ -412,7 +412,7 @@ class File(object):
         @return: entry point bytes (16).
         """
         try:
-            return binascii.b2a_hex(pe.get_data(pe.OPTIONAL_HEADER.AddressOfEntryPoint, 0x10)).decode("utf-8")
+            return binascii.b2a_hex(pe.get_data(pe.OPTIONAL_HEADER.AddressOfEntryPoint, 0x10)).decode()
         except Exception:
             return None
 
@@ -492,12 +492,12 @@ class File(object):
     def _yara_encode_string(self, yara_string):
         # Beware, spaghetti code ahead.
         try:
-            new = yara_string.decode("utf-8")
+            new = yara_string.decode()
         except UnicodeDecodeError as e:
             # yara_string = binascii.hexlify(yara_string.lstrip("uU")).upper()
             yara_string = binascii.hexlify(yara_string).upper()
             yara_string = b" ".join(yara_string[i : i + 2] for i in range(0, len(yara_string), 2))
-            new = "{ %s }" % yara_string.decode("utf-8")
+            new = "{ %s }" % yara_string.decode()
 
         return new
 
@@ -518,7 +518,7 @@ class File(object):
         try:
             results, rule = [], File.yara_rules[category]
             if isinstance(self.file_path, bytes):
-                path = self.file_path.decode("utf-8")
+                path = self.file_path.decode()
             else:
                 path = self.file_path
             for match in rule.match(path, externals=externals):
@@ -599,7 +599,7 @@ class File(object):
                             if not exported_symbol.name:
                                 continue
                             if isinstance(exported_symbol.name, bytes):
-                                exports.append(re.sub(b"[^A-Za-z0-9_?@-]", b"", exported_symbol.name).decode("utf-8"))
+                                exports.append(re.sub(b"[^A-Za-z0-9_?@-]", b"", exported_symbol.name).decode())
                             else:
                                 exports.append(re.sub("[^A-Za-z0-9_?@-]", "", exported_symbol.name))
                         except Exception as e:

--- a/lib/cuckoo/common/quarantine.py
+++ b/lib/cuckoo/common/quarantine.py
@@ -751,7 +751,7 @@ func_map = {
 
 
 def unquarantine(f):
-    f = f.decode("utf8") if type(f) is bytes else f
+    f = f.decode() if type(f) is bytes else f
     base = os.path.basename(f)
     realbase, ext = os.path.splitext(base)
 

--- a/lib/cuckoo/common/utils.py
+++ b/lib/cuckoo/common/utils.py
@@ -85,7 +85,7 @@ referrer_url_re = re.compile(
 # change to read from config
 zippwd = web_cfg.zipped_download.get("zip_pwd", b"infected")
 if not isinstance(zippwd, bytes):
-    zippwd = zippwd.encode("utf-8")
+    zippwd = zippwd.encode()
 
 
 texttypes = [
@@ -330,7 +330,7 @@ def bytes2str(convert):
     """
     if isinstance(convert, bytes):
         try:
-            convert = convert.decode("utf-8")
+            convert = convert.decode()
         except UnicodeDecodeError:
             convert = "".join(chr(_) for _ in convert)
 
@@ -343,7 +343,7 @@ def bytes2str(convert):
         for k, v in items:
             if type(v) is bytes:
                 try:
-                    tmp_dict[k] = v.decode("utf-8")
+                    tmp_dict[k] = v.decode()
                 except UnicodeDecodeError:
                     tmp_dict[k] = "".join(str(ord(_)) for _ in v)
         return tmp_dict
@@ -353,7 +353,7 @@ def bytes2str(convert):
         for k, v in items:
             if type(v) is bytes:
                 try:
-                    converted_list.append(v.decode("utf-8"))
+                    converted_list.append(v.decode())
                 except UnicodeDecodeError:
                     converted_list.append("".join(str(ord(_)) for _ in v))
 
@@ -382,7 +382,7 @@ def wide2str(string: Tuple[str, bytes]):
         if type(string) is bytes:
             return string.decode("utf-16")
         else:
-            return string.encode("utf-8").decode("utf-16")
+            return string.encode().decode("utf-16")
     else:
         return string
 

--- a/lib/cuckoo/core/database.py
+++ b/lib/cuckoo/core/database.py
@@ -1503,7 +1503,7 @@ class Database(object, metaclass=Singleton):
         extracted_files = demux_sample(file_path, package, options)
         # check if len is 1 and the same file, if diff register file, and set parent
         if not isinstance(file_path, bytes):
-            file_path = file_path.encode("utf-8")
+            file_path = file_path.encode()
         if extracted_files and file_path not in extracted_files:
             sample_parent_id = self.register_sample(File(file_path), source_url=source_url)
             if conf.cuckoo.delete_archive:
@@ -1514,7 +1514,7 @@ class Database(object, metaclass=Singleton):
         if "file" in opts:
             runfile = opts["file"].lower()
             if isinstance(runfile, str):
-                runfile = runfile.encode("utf-8")
+                runfile = runfile.encode()
             for xfile in extracted_files:
                 if runfile in xfile.lower():
                     extracted_files = [xfile]
@@ -1672,7 +1672,7 @@ class Database(object, metaclass=Singleton):
         sample_parent_id = None
         # check if len is 1 and the same file, if diff register file, and set parent
         if not isinstance(file_path, bytes):
-            file_path = file_path.encode("utf-8")
+            file_path = file_path.encode()
         if extracted_files and file_path not in extracted_files:
             sample_parent_id = self.register_sample(File(file_path))
             if conf.cuckoo.delete_archive:

--- a/lib/cuckoo/core/resultserver.py
+++ b/lib/cuckoo/core/resultserver.py
@@ -207,7 +207,7 @@ class FileUpload(ProtocolHandler):
 
         log.debug("Task #%s: File upload for %r", self.task_id, dump_path)
         if not duplicated:
-            file_path = os.path.join(self.storagepath, dump_path.decode("utf-8"))
+            file_path = os.path.join(self.storagepath, dump_path.decode())
 
             try:
                 self.fd = open_exclusive(file_path)
@@ -231,7 +231,7 @@ class FileUpload(ProtocolHandler):
                             "pids": pids,
                             "ppids": ppids,
                             "metadata": metadata.decode("utf-8", "replace"),
-                            "category": category.decode("utf-8") if category in (b"CAPE", b"files", b"memory", b"procdump") else "",
+                            "category": category.decode() if category in (b"CAPE", b"files", b"memory", b"procdump") else "",
                         },
                         ensure_ascii=False,
                     ),

--- a/lib/cuckoo/core/rooter.py
+++ b/lib/cuckoo/core/rooter.py
@@ -82,7 +82,7 @@ def rooter(command, *args, **kwargs):
                     "args": args,
                     "kwargs": kwargs,
                 }
-            ).encode("utf-8")
+            ).encode()
         )
 
         try:

--- a/modules/machinery/physical.py
+++ b/modules/machinery/physical.py
@@ -129,7 +129,7 @@ class Physical(Machinery):
                             taskID_Deploy = t["id"]
 
                     # Deploy Task to reset physical machine to former state
-                    payload = json.dumps({"taskTypeID": taskID_Deploy, "shutdown": "", "wol": "true"}).encode("utf8")
+                    payload = json.dumps({"taskTypeID": taskID_Deploy, "shutdown": "", "wol": "true"}).encode()
 
                     r_deploy = requests.post(
                         "http://" + self.options.fog.hostname + "/fog/host/" + hostID + "/task", headers=headers, data=payload

--- a/modules/processing/CAPE.py
+++ b/modules/processing/CAPE.py
@@ -335,7 +335,7 @@ class CAPE(Processing):
         for cape_file in self.cape["payloads"] or []:
             if file_info["size"] == cape_file["size"]:
                 if HAVE_PYDEEP:
-                    ssdeep_grade = pydeep.compare(file_info["ssdeep"].encode("utf-8"), cape_file["ssdeep"].encode("utf-8"))
+                    ssdeep_grade = pydeep.compare(file_info["ssdeep"].encode(), cape_file["ssdeep"].encode())
                     if ssdeep_grade >= ssdeep_threshold:
                         append_file = False
                 if file_info.get("entrypoint") and file_info.get("ep_bytes") and cape_file.get("entrypoint"):

--- a/modules/processing/behavior.py
+++ b/modules/processing/behavior.py
@@ -530,7 +530,7 @@ class Summary:
             fileinfo = self.get_raw_argument(call, "FileInformation")
             if filename and infoclass and infoclass == 13 and fileinfo and len(fileinfo) > 0:
                 if not isinstance(fileinfo, bytes):
-                    fileinfo = fileinfo.encode("utf-8")
+                    fileinfo = fileinfo.encode()
                 disp = struct.unpack_from("B", fileinfo)[0]
                 if disp and filename not in self.delete_files:
                     self.delete_files.append(filename)

--- a/modules/processing/memory.py
+++ b/modules/processing/memory.py
@@ -298,7 +298,7 @@ class VolatilityManager(object):
                 raise CuckooProcessingError("Error opening file %s" % e)
 
             nulltermonly = self.voptions.basic.get("strings_nullterminated_only", True)
-            minchars = str(self.voptions.basic.get("strings_minchars", 5)).encode("utf-8")
+            minchars = str(self.voptions.basic.get("strings_minchars", 5)).encode()
 
             if nulltermonly:
                 apat = b"([\x20-\x7e]{" + minchars + b",})\x00"
@@ -309,7 +309,7 @@ class VolatilityManager(object):
 
             strings = re.findall(apat, data)
             for ws in re.findall(upat, data):
-                strings.append(ws.decode("utf-16le").encode("utf-8"))
+                strings.append(ws.decode("utf-16le").encode())
             f = open(self.memfile + ".strings", "wb")
             f.write(b"\n".join(strings))
             f.close()

--- a/modules/processing/network.py
+++ b/modules/processing/network.py
@@ -1298,7 +1298,7 @@ def next_connection_packets(piter, linktype=1):
             "dst": dip,
             "sport": sport,
             "dport": dport,
-            "raw": b64encode(payload_from_raw(raw, linktype)).decode("utf-8"),
+            "raw": b64encode(payload_from_raw(raw, linktype)).decode(),
             "direction": first_ft == ft,
         }
 

--- a/modules/processing/parsers/CAPE/Azorult.py
+++ b/modules/processing/parsers/CAPE/Azorult.py
@@ -77,6 +77,6 @@ def config(filebuf):
 
     c2_domain = string_from_offset(filebuf, c2_list_offset)
     if c2_domain:
-        config.setdefault("address", c2_domain.decode("utf-8"))
+        config.setdefault("address", c2_domain.decode())
 
     return config

--- a/modules/processing/parsers/CAPE/BuerLoader.py
+++ b/modules/processing/parsers/CAPE/BuerLoader.py
@@ -35,7 +35,7 @@ def config(filebuf):
     count = 0
     for item in data.split(b"\x00\x00"):
         try:
-            dec = decrypt_string(item.lstrip(b"\x00").rstrip(b"\x00").decode("utf8"))
+            dec = decrypt_string(item.lstrip(b"\x00").rstrip(b"\x00").decode())
         except:
             pass
         if "dll" not in dec and " " not in dec and ";" not in dec and "." in dec:

--- a/modules/processing/parsers/CAPE/DridexLoader.py
+++ b/modules/processing/parsers/CAPE/DridexLoader.py
@@ -145,7 +145,7 @@ def config(filebuf):
                 )
             for item in raw.split(b"\x00"):
                 if len(item) == LEN_BLOB_KEY - 1:
-                    cfg["RC4 key"] = item.split(b";")[0].decode("utf-8")
+                    cfg["RC4 key"] = item.split(b";")[0].decode()
 
     if botnet_code:
         botnet_rva = struct.unpack("i", filebuf[botnet_code + 23 : botnet_code + 27])[0] - image_base

--- a/modules/processing/parsers/CAPE/Emotet.py
+++ b/modules/processing/parsers/CAPE/Emotet.py
@@ -426,8 +426,8 @@ def config(filebuf):
     except ValueError as e:
         log.error(e)
     if pem_key:
-        # self.reporter.add_metadata("other", {"RSA public key": pem_key.exportKey().decode('utf8')})
-        conf_dict.setdefault("RSA public key", pem_key.exportKey().decode("utf8"))
+        # self.reporter.add_metadata("other", {"RSA public key": pem_key.exportKey().decode()})
+        conf_dict.setdefault("RSA public key", pem_key.exportKey().decode())
     else:
         if yara_matches.get("$ref_rsa"):
             ref_rsa_offset = int(yara_matches["$ref_rsa"])

--- a/modules/processing/parsers/CAPE/Fareit.py
+++ b/modules/processing/parsers/CAPE/Fareit.py
@@ -54,11 +54,11 @@ def config(memdump_path, read=False):
                 if url is None:
                     continue
                 if gate_url.match(url):
-                    artifacts_raw["controllers"].append(url.lower().decode("utf-8"))
+                    artifacts_raw["controllers"].append(url.lower().decode())
                 elif exe_url.match(url):
-                    artifacts_raw["downloads"].append(url.lower().decode("utf-8"))
+                    artifacts_raw["downloads"].append(url.lower().decode())
                 elif dll_url.match(url):
-                    artifacts_raw["downloads"].append(url.lower().decode("utf-8"))
+                    artifacts_raw["downloads"].append(url.lower().decode())
         except Exception as e:
             print(e, sys.exc_info(), "PONY")
     artifacts_raw["controllers"] = list(set(artifacts_raw["controllers"]))

--- a/modules/processing/parsers/CAPE/GuLoader.py
+++ b/modules/processing/parsers/CAPE/GuLoader.py
@@ -10,7 +10,7 @@ def config(data):
     urls_dict = dict()
 
     try:
-        urls_dict["URLs"] = [url.lower().decode("utf-8") for url in url_regex.findall(data)]
+        urls_dict["URLs"] = [url.lower().decode() for url in url_regex.findall(data)]
     except Exception as e:
         print(e)
 

--- a/modules/processing/parsers/CAPE/Hancitor.py
+++ b/modules/processing/parsers/CAPE/Hancitor.py
@@ -22,10 +22,10 @@ def config(filebuf):
                 ENCRYPT_DATA = DATA_SECTION[24:2000]
                 DECRYPTED_DATA = ARC4.new(RC4_KEY).decrypt(ENCRYPT_DATA)
                 build_id, controllers = list(filter(None, DECRYPTED_DATA.split(b"\x00")))
-                cfg.setdefault("Build ID", build_id.decode("utf-8"))
+                cfg.setdefault("Build ID", build_id.decode())
                 controllers = list(filter(None, controllers.split(b"|")))
                 if controllers:
-                    cfg.setdefault("address", [url.decode("utf-8") for url in controllers])
+                    cfg.setdefault("address", [url.decode() for url in controllers])
     except Exception as e:
         log.warning(e)
 

--- a/modules/processing/parsers/CAPE/IcedIDLoader.py
+++ b/modules/processing/parsers/CAPE/IcedIDLoader.py
@@ -55,7 +55,7 @@ def config(filebuf):
             for section in pe.sections:
                 if section.Name == b".d\x00\x00\x00\x00\x00\x00":
                     config_section = bytearray(section.get_data())
-                    decoded = iced_decode(config_section).decode("utf-8")
+                    decoded = iced_decode(config_section).decode()
                     cfg["address"] = decoded
                     return cfg
 

--- a/modules/processing/parsers/CAPE/Loki.py
+++ b/modules/processing/parsers/CAPE/Loki.py
@@ -173,7 +173,7 @@ def config(filebuf):
     if urls:
         cfg.setdefault("address", list())
 
-    cfg["address"] = [url.decode("utf-8") for url in urls]
+    cfg["address"] = [url.decode() for url in urls]
     return cfg
 
 

--- a/modules/processing/parsers/CAPE/SquirrelWaffle.py
+++ b/modules/processing/parsers/CAPE/SquirrelWaffle.py
@@ -67,7 +67,7 @@ def config(data):
         for i in range(len(chunks)):
             if len(chunks[i]) > 100:
                 try:
-                    decrypted = xor_data(chunks[i], chunks[i + 1]).decode("utf-8")
+                    decrypted = xor_data(chunks[i], chunks[i + 1]).decode()
                     if "\r\n" in decrypted and "|" not in decrypted:
                         config["IP Blocklist"] = list(filter(None, decrypted.split("\r\n")))
                     elif "|" in decrypted and "." in decrypted and "\r\n" not in decrypted:
@@ -85,5 +85,5 @@ def config(data):
                     c2key_offset = int(item[0])
                     key_rva = struct.unpack("i", data[c2key_offset + 28 : c2key_offset + 32])[0] - pe.OPTIONAL_HEADER.ImageBase
                     key_offset = pe.get_offset_from_rva(key_rva)
-                    config["C2 key"] = string_from_offset(data, key_offset).decode("utf-8")
+                    config["C2 key"] = string_from_offset(data, key_offset).decode()
                     return config

--- a/modules/processing/parsers/CAPE/Strrat.py
+++ b/modules/processing/parsers/CAPE/Strrat.py
@@ -36,7 +36,7 @@ unpad = lambda s: s[0 : -s[-1]]
 def unzip_config(filepath):
     data = ""
     try:
-        z = zipfile.ZipFile(filepath.decode("utf8"))
+        z = zipfile.ZipFile(filepath.decode())
         for name in z.namelist():
             if "config.txt" in name:
                 data = z.read(name)
@@ -65,7 +65,7 @@ def decode(data):
             decoded = aesdecrypt(data, passkey)
         except Exception:
             return
-    return decoded.decode("utf8")
+    return decoded.decode()
 
 
 def config(data):

--- a/modules/processing/parsers/CAPE/UrsnifV3.py
+++ b/modules/processing/parsers/CAPE/UrsnifV3.py
@@ -46,7 +46,7 @@ SECTION_KEYS = {
 
 
 def string_from_offset(buffer, offset):
-    string = buffer[offset : offset + MAX_STRING_SIZE].split(b"\0")[0].decode("utf-8")
+    string = buffer[offset : offset + MAX_STRING_SIZE].split(b"\0")[0].decode()
     return string
 
 

--- a/modules/processing/parsers/mwcp/QakBot.py
+++ b/modules/processing/parsers/mwcp/QakBot.py
@@ -193,7 +193,7 @@ class QakBot(Parser):
                             # we found the parent process and still need to decrypt/(blzpack) decompress the main DLL
                             dec_bytes = decrypt_data(res_data)
                             decompressed = decompress(dec_bytes)
-                            self.reporter.add_metadata("other", {"Loader Build": parse_build(pe).decode("utf-8")})
+                            self.reporter.add_metadata("other", {"Loader Build": parse_build(pe).decode()})
                             pe2 = pefile.PE(data=decompressed)
                             for rsrc in pe2.DIRECTORY_ENTRY_RESOURCE.entries:
                                 for entry in rsrc.directory.entries:
@@ -206,7 +206,7 @@ class QakBot(Parser):
                                             config = parse_config(dec_bytes)
                                             # log.info("qbot_config:{}".format(config))
                                             self.reporter.add_metadata(
-                                                "other", {"Core DLL Build": parse_build(pe2).decode("utf-8")}
+                                                "other", {"Core DLL Build": parse_build(pe2).decode()}
                                             )
 
                                         elif entry.name.__str__() == "311":
@@ -239,10 +239,10 @@ class QakBot(Parser):
                             dec_bytes = decrypt_data2(res_data)
                             config = parse_config(dec_bytes)
 
-                        self.reporter.add_metadata("other", {"Loader Build": parse_build(pe).decode("utf-8")})
+                        self.reporter.add_metadata("other", {"Loader Build": parse_build(pe).decode()})
 
                         for k, v in config.items():
-                            # log.info( { k.decode("utf-8"): v.decode("utf-8") })
+                            # log.info( { k.decode(): v.decode() })
                             self.reporter.add_metadata("other", {k: v})
 
                         # log.info("controllers:{}".format(controllers))

--- a/modules/processing/parsers/mwcp/Remcos.py
+++ b/modules/processing/parsers/mwcp/Remcos.py
@@ -163,7 +163,7 @@ class Remcos(Parser):
                         elif i in [0]:
                             host, port, password = cont.split(b"|")[0].split(b":")
                             p_data["Control"] = "tcp://{}:{}:{}".format(
-                                host.decode("utf-8"), port.decode("utf-8"), password.decode("utf-8")
+                                host.decode(), port.decode(), password.decode()
                             )
 
                         else:

--- a/modules/processing/procmemory.py
+++ b/modules/processing/procmemory.py
@@ -76,7 +76,7 @@ class ProcessMemory(Processing):
         results = []
         do_strings = self.options.get("strings", False)
         nulltermonly = self.options.get("nullterminated_only", True)
-        minchars = str(self.options.get("minchars", 5)).encode("utf-8")
+        minchars = str(self.options.get("minchars", 5)).encode()
 
         if os.path.exists(self.pmemory_path):
             for dmp in os.listdir(self.pmemory_path):
@@ -137,7 +137,7 @@ class ProcessMemory(Processing):
                     matchdict = procdump.search(upat, all=True)
                     ustrings = matchdict["matches"]
                     for ws in ustrings:
-                        strings.append(ws.decode("utf-16le").encode("utf-8"))
+                        strings.append(ws.decode("utf-16le").encode())
 
                     proc["strings_path"] = dmp_path + ".strings"
                     proc["extracted_pe"] = extracted_pes

--- a/modules/processing/static.py
+++ b/modules/processing/static.py
@@ -848,7 +848,7 @@ class PortableExecutable(object):
                     m = hashlib.md5()
                     m.update(simplified)
                     simphash = m.hexdigest()
-                    icon = base64.b64encode(output.getvalue()).decode("utf-8")
+                    icon = base64.b64encode(output.getvalue()).decode()
                     output.close()
                     img.close()
                     return icon, fullhash, simphash, dhash
@@ -1012,7 +1012,7 @@ class PortableExecutable(object):
                     if extension.oid._name == "authorityKeyIdentifier" and extension.value.key_identifier:
                         cert_data["extensions_{}".format(extension.oid._name)] = base64.b64encode(
                             extension.value.key_identifier
-                        ).decode("utf-8")
+                        ).decode()
                     elif extension.oid._name == "subjectKeyIdentifier" and extension.value.digest:
                         cert_data["extensions_{}".format(extension.oid._name)] = base64.b64encode(extension.value.digest).decode(
                             "utf-8"
@@ -1040,7 +1040,7 @@ class PortableExecutable(object):
                             if isinstance(name.value, bytes):
                                 cert_data["extensions_{}_{}".format(extension.oid._name, index)] = base64.b64encode(
                                     name.value
-                                ).decode("utf-8")
+                                ).decode()
                             else:
                                 if hasattr(name.value, "rfc4514_string"):
                                     cert_data["extensions_{}_{}".format(extension.oid._name, index)] = name.value.rfc4514_string()

--- a/modules/processing/strings.py
+++ b/modules/processing/strings.py
@@ -31,11 +31,11 @@ def extract_strings(path, nulltermonly, minchars):
         endlimit = b"8192"
 
     if nulltermonly:
-        apat = b"([\x20-\x7e]{" + str(minchars).encode("utf-8") + b"," + endlimit + b"})\x00"
-        upat = b"((?:[\x20-\x7e][\x00]){" + str(minchars).encode("utf-8") + b"," + endlimit + b"})\x00\x00"
+        apat = b"([\x20-\x7e]{" + str(minchars).encode() + b"," + endlimit + b"})\x00"
+        upat = b"((?:[\x20-\x7e][\x00]){" + str(minchars).encode() + b"," + endlimit + b"})\x00\x00"
     else:
-        apat = b"[\x20-\x7e]{" + str(minchars).encode("utf-8") + b"," + endlimit + b"}"
-        upat = b"(?:[\x20-\x7e][\x00]){" + str(minchars).encode("utf-8") + b"," + endlimit + b"}"
+        apat = b"[\x20-\x7e]{" + str(minchars).encode() + b"," + endlimit + b"}"
+        upat = b"(?:[\x20-\x7e][\x00]){" + str(minchars).encode() + b"," + endlimit + b"}"
 
     strings = [bytes2str(string) for string in re.findall(apat, data)]
     for ws in re.findall(upat, data):

--- a/modules/processing/suricata.py
+++ b/modules/processing/suricata.py
@@ -55,7 +55,7 @@ class Suricata(Processing):
 
     def json_default(self, obj):
         if isinstance(obj, bytes):
-            return obj.decode("utf8")
+            return obj.decode()
         raise TypeError
 
     def run(self):

--- a/modules/processing/virustotal.py
+++ b/modules/processing/virustotal.py
@@ -82,7 +82,7 @@ def vt_lookup(category: str, target: str, on_demand: bool = False):
                 slashsplit.append("")
             target = "/".join(slashsplit)
 
-            sha256 = hashlib.sha256(target.encode("utf-8")).hexdigest()
+            sha256 = hashlib.sha256(target.encode()).hexdigest()
             url = VIRUSTOTAL_URL_URL.format(id=target)
 
         try:

--- a/modules/reporting/compressresults.py
+++ b/modules/reporting/compressresults.py
@@ -35,7 +35,7 @@ class CompressResults(Report):
         for keyword in ("CAPE", "procdump"):
             if keyword in results:
                 try:
-                    cape_json = json.dumps(results[keyword], encoding="latin-1", ensure_ascii=False).encode("utf8")
+                    cape_json = json.dumps(results[keyword], encoding="latin-1", ensure_ascii=False).encode()
                     compressed_data = zlib.compress(cape_json)
                     results[keyword] = Binary(compressed_data)
                 except UnicodeDecodeError as e:
@@ -43,7 +43,7 @@ class CompressResults(Report):
         # compress behaviour analysis (enhanced & summary)
         if "enhanced" in results["behavior"]:
             try:
-                compressed_behavior_enhanced = zlib.compress(JSONEncoder().encode(results["behavior"]["enhanced"]).encode("utf8"))
+                compressed_behavior_enhanced = zlib.compress(JSONEncoder().encode(results["behavior"]["enhanced"]).encode())
                 results["behavior"]["enhanced"] = Binary(compressed_behavior_enhanced)
             except UnicodeDecodeError as e:
                 log.warn("Failed to compress Enhanced Behaviour: {}".format(e.reason))

--- a/modules/reporting/jsondump.py
+++ b/modules/reporting/jsondump.py
@@ -23,7 +23,7 @@ class JsonDump(Report):
 
     def default(self, obj):
         if isinstance(obj, bytes):
-            return obj.decode("utf8")
+            return obj.decode()
         raise TypeError
 
     def run(self, results):

--- a/modules/reporting/litereport.py
+++ b/modules/reporting/litereport.py
@@ -27,7 +27,7 @@ class LiteReport(Report):
 
     def default(self, obj):
         if isinstance(obj, bytes):
-            return obj.decode("utf8")
+            return obj.decode()
         raise TypeError
 
     def run(self, results):

--- a/modules/reporting/maec5.py
+++ b/modules/reporting/maec5.py
@@ -141,7 +141,7 @@ def convert_to_unicode(input):
     elif isinstance(input, list):
         return [convert_to_unicode(element) for element in input]
     elif isinstance(input, str) or isinstance(input, int) or isinstance(input, float):
-        return six.text_type(input).decode("utf-8")
+        return six.text_type(input).decode()
     else:
         return input
 

--- a/modules/reporting/mongodb.py
+++ b/modules/reporting/mongodb.py
@@ -97,9 +97,9 @@ class MongoDB(Report):
             # we do not want to convert that.
             if type(v) is str:
                 try:
-                    v.encode("utf-8")
+                    v.encode()
                 except UnicodeEncodeError:
-                    obj[k] = "".join(str(ord(_)) for _ in v).encode("utf-8")
+                    obj[k] = "".join(str(ord(_)) for _ in v).encode()
             else:
                 cls.ensure_valid_utf8(v)
 

--- a/modules/reporting/reporthtml.py
+++ b/modules/reporting/reporthtml.py
@@ -50,7 +50,7 @@ class ReportHTML(Report):
 
                 shot = {}
                 shot["id"] = os.path.splitext(File(shot_path).get_name())[0]
-                shot["data"] = base64.b64encode(open(shot_path, "rb").read()).decode("utf-8")
+                shot["data"] = base64.b64encode(open(shot_path, "rb").read()).decode()
                 shots.append(shot)
 
                 counter += 1

--- a/modules/reporting/reporthtmlsummary.py
+++ b/modules/reporting/reporthtmlsummary.py
@@ -64,7 +64,7 @@ class ReportHTMLSummary(Report):
 
                 shot = {}
                 shot["id"] = os.path.splitext(File(shot_path).get_name())[0]
-                shot["data"] = base64.b64encode(output.getvalue()).decode("utf-8")
+                shot["data"] = base64.b64encode(output.getvalue()).decode()
                 shots.append(shot)
                 output.close()
 

--- a/utils/create_bloom.py
+++ b/utils/create_bloom.py
@@ -82,8 +82,8 @@ if __name__ == "__main__":
             first_entry = True
         for domain in domain_list:
             # insert domain into bloomfilter
-            if not domain.lower().encode("utf8") in bloom:
-                bloom.add(domain.lower().encode("utf8"))
+            if not domain.lower().encode() in bloom:
+                bloom.add(domain.lower().encode())
 
             # insert into family/domain lookup table
             dga_lookup_dict[domain] = family
@@ -92,7 +92,7 @@ if __name__ == "__main__":
     if not (first_entry and test_domain and test_family):
         logging.error("Unknown error while creating bloomfilter and DGA dict")
         sys.exit(-1)
-    if test_domain.lower().encode("utf8") in bloom and dga_lookup_dict.get(test_domain.lower(), "") == test_family:
+    if test_domain.lower().encode() in bloom and dga_lookup_dict.get(test_domain.lower(), "") == test_family:
         logging.info("%s (%s)", test_domain, test_family)
         logging.info("Bloomfilter and DGA dict successfully created")
     else:
@@ -107,6 +107,6 @@ if __name__ == "__main__":
 
     lookup_path = os.path.join(CUCKOO_ROOT, "data", "dga_lookup_dict.json.gz")
     with gzip.GzipFile(lookup_path, "w") as fout:
-        fout.write(json.dumps(dga_lookup_dict).encode("utf8"))
+        fout.write(json.dumps(dga_lookup_dict).encode())
 
     logging.info("Successfully generated bloomfilter and dga dict file")

--- a/utils/dist.py
+++ b/utils/dist.py
@@ -56,7 +56,7 @@ reporting_conf = Config("reporting")
 
 zip_pwd = Config("web").zipped_download.zip_pwd
 if type(zip_pwd) is not bytes:
-    zip_pwd = zip_pwd.encode("utf-8")
+    zip_pwd = zip_pwd.encode()
 
 # init
 logging.getLogger("elasticsearch").setLevel(logging.WARNING)

--- a/utils/rooter.py
+++ b/utils/rooter.py
@@ -575,6 +575,6 @@ if __name__ == "__main__":
                         "output": output,
                         "exception": error,
                     }
-                ).encode("utf-8"),
+                ).encode(),
                 addr,
             )

--- a/utils/submit.py
+++ b/utils/submit.py
@@ -316,7 +316,7 @@ def main():
 
                 try:
                     task_ids, extra_details = db.demux_sample_and_add_to_db(
-                        file_path=file_path.encode("utf-8"),
+                        file_path=file_path.encode(),
                         package=args.package,
                         timeout=sane_timeout,
                         options=args.options,

--- a/web/analysis/templatetags/analysis_tags.py
+++ b/web/analysis/templatetags/analysis_tags.py
@@ -18,7 +18,7 @@ from django.template.defaultfilters import register
 def network_rn_func(value):
     """get basename from path"""
     if isinstance(value, bytes):
-        value = value.decode("utf-8")
+        value = value.decode()
     return list(filter(None, value.split("\r\n")))
 
 

--- a/web/analysis/views.py
+++ b/web/analysis/views.py
@@ -768,13 +768,13 @@ def gen_moloch_from_suri_http(suricata):
                 e["moloch_http_uri_url"] = (
                     settings.MOLOCH_BASE
                     + "?date=-1&expression=http.uri"
-                    + quote("\x3d\x3d\x22%s\x22" % (e["uri"].encode("utf8")), safe="")
+                    + quote("\x3d\x3d\x22%s\x22" % (e["uri"].encode()), safe="")
                 )
             if e.get("ua"):
                 e["moloch_http_ua_url"] = (
                     settings.MOLOCH_BASE
                     + "?date=-1&expression=http.user-agent"
-                    + quote("\x3d\x3d\x22%s\x22" % (e["ua"].encode("utf8")), safe="")
+                    + quote("\x3d\x3d\x22%s\x22" % (e["ua"].encode()), safe="")
                 )
             if e.get("method"):
                 e["moloch_http_method_url"] = (
@@ -1233,7 +1233,7 @@ def report(request, task_id):
 
         if os.path.exists(vba2graph_svg_path) and os.path.normpath(vba2graph_svg_path).startswith(ANALYSIS_BASE_PATH):
             with open(vba2graph_svg_path, "rb") as f:
-                vba2graph_dict_content.setdefault(report["target"]["file"]["sha256"], f.read().decode("utf8"))
+                vba2graph_dict_content.setdefault(report["target"]["file"]["sha256"], f.read().decode())
 
     bingraph = reporting_cfg.bingraph.enabled
     bingraph_dict_content = {}
@@ -1968,7 +1968,7 @@ def vtupload(request, category, task_id, filename, dlfile):
                 id = response.json().get("data", {}).get("id")
                 if id:
                     hashbytes, _ = base64.b64decode(id).split(b":")
-                    md5hash = hashbytes.decode("utf8")
+                    md5hash = hashbytes.decode()
                     return render(
                         request, "success_vtup.html", {"permalink": "https://www.virustotal.com/gui/file/{id}".format(id=md5hash)}
                     )

--- a/web/apiv2/views.py
+++ b/web/apiv2/views.py
@@ -343,13 +343,13 @@ def tasks_create_file(request):
                 try:
                     File(path).get_type()
                 except TypeError:
-                    details["errors"].append({os.path.basename(tmp_path).decode("utf-8"): "Error submitting file - bad file type"})
+                    details["errors"].append({os.path.basename(tmp_path).decode(): "Error submitting file - bad file type"})
                     continue
             else:
                 details["content"] = get_file_content(tmp_path)
                 status, task_ids_tmp = download_file(**details)
                 if status == "error":
-                    details["errors"].append({os.path.basename(tmp_path).decode("utf-8"): task_ids_tmp})
+                    details["errors"].append({os.path.basename(tmp_path).decode(): task_ids_tmp})
                 else:
                     details["task_ids"] = task_ids_tmp
 
@@ -570,7 +570,7 @@ def tasks_create_dlnexec(request):
 
         status, task_ids_tmp = download_file(**details)
         if status == "error":
-            details["errors"].append({os.path.basename(path).decode("utf-8"): task_ids_tmp})
+            details["errors"].append({os.path.basename(path).decode(): task_ids_tmp})
         else:
             details["task_ids"] = task_ids_tmp
 

--- a/web/web/settings.py
+++ b/web/web/settings.py
@@ -64,7 +64,7 @@ URL_ANALYSIS = web_cfg.url_analysis.get("enabled", False)
 DLNEXEC = web_cfg.dlnexec.get("enabled", False)
 ZIP_PWD = zip_cfg.get("zip_pwd", b"infected")
 if not isinstance(ZIP_PWD, bytes):
-    ZIP_PWD = ZIP_PWD.encode("utf-8")
+    ZIP_PWD = ZIP_PWD.encode()
 MOLOCH_BASE = moloch_cfg.get("base")
 MOLOCH_NODE = moloch_cfg.get("node")
 MOLOCH_ENABLED = moloch_cfg.get("enabled", False)


### PR DESCRIPTION
Changed `.decode("utf-8")` and `.encode("utf-8")` to `.decode()` and `.encode()` respectively
Note: `.decode("utf-8")`, `.decode("utf8")` and `.decode()` all do the same thing

May seem like a small update but I think it goes a long way in improving code readability