### PR TITLE
Sort imports for analyzer, admin and agent folders

### DIFF
--- a/admin/admin.py
+++ b/admin/admin.py
@@ -22,11 +22,12 @@ import os
 import shutil
 import subprocess
 import sys
-import urllib3
 from hashlib import sha256
 from queue import Queue
 from threading import Thread
 from urllib import urlparse
+
+import urllib3
 
 try:
     import re2 as re
@@ -42,17 +43,8 @@ except ImportError:
     sys.exit()
 
 try:
-    from admin_conf import (
-        REMOTE_SERVER_USER,
-        CAPE_PATH,
-        VOL_PATH,
-        JUMP_BOX,
-        MASTER_NODE,
-        CAPE_DIST_URL,
-        JUMP_BOX_USERNAME,
-        JUMP_BOX_PORT,
-        SERVERS_STATIC_LIST,
-    )
+    from admin_conf import (CAPE_DIST_URL, CAPE_PATH, JUMP_BOX, JUMP_BOX_PORT, JUMP_BOX_USERNAME, MASTER_NODE, REMOTE_SERVER_USER,
+                            SERVERS_STATIC_LIST, VOL_PATH)
 except ModuleNotFoundError:
     sys.exit("[-] You need to create admin_conf.py, see admin_conf.py_example")
 

--- a/agent/agent.py
+++ b/agent/agent.py
@@ -3,7 +3,6 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 from __future__ import absolute_import, print_function
-
 import argparse
 import cgi
 import http.server

--- a/analyzer/linux/analyzer.py
+++ b/analyzer/linux/analyzer.py
@@ -3,14 +3,14 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 from __future__ import absolute_import
-import os
-import sys
-import pkgutil
-import logging
-import tempfile
-import traceback
-import time
 import datetime
+import logging
+import os
+import pkgutil
+import sys
+import tempfile
+import time
+import traceback
 import zipfile
 from urllib.parse import urlencode
 from urllib.request import urlopen
@@ -21,8 +21,8 @@ from lib.common.constants import PATHS
 from lib.common.exceptions import CuckooError, CuckooPackageError
 from lib.common.results import upload_to_host
 from lib.core.config import Config
-from lib.core.startup import create_folders, init_logging
 from lib.core.packages import choose_package_class
+from lib.core.startup import create_folders, init_logging
 from modules import auxiliary
 
 log = logging.getLogger()

--- a/analyzer/linux/lib/api/process.py
+++ b/analyzer/linux/lib/api/process.py
@@ -3,9 +3,9 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 from __future__ import absolute_import
+import logging
 import os
 import subprocess
-import logging
 
 log = logging.getLogger(__name__)
 

--- a/analyzer/linux/lib/api/screenshot.py
+++ b/analyzer/linux/lib/api/screenshot.py
@@ -1,24 +1,14 @@
 # Copyright (C) 2010-2015 Cuckoo Foundation.
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
+
 from __future__ import absolute_import
 import logging
-
-log = logging.getLogger(__name__)
-
-log.debug("Importing 'math'")
 import math
-import logging
 
 log = logging.getLogger(__name__)
 
 try:
-    log.debug("Importing 'pyscreenshot'")
-    try:
-        import pyscreenshot as ImageGrab
-    except ImportError:
-        log.error("Missed dependency: pip3 install pyscreenshot")
-        HAVE_PIL = False
     log.debug("Importing 'PIL.ImageChops'")
     # from PIL import ImageChops
     from PIL.ImageChops import difference

--- a/analyzer/linux/lib/common/abstracts.py
+++ b/analyzer/linux/lib/common/abstracts.py
@@ -3,6 +3,7 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 from __future__ import absolute_import
+
 from lib.api.process import Process
 from lib.common.exceptions import CuckooPackageError
 

--- a/analyzer/linux/lib/common/apicalls.py
+++ b/analyzer/linux/lib/common/apicalls.py
@@ -2,13 +2,15 @@
 # Copyright (C) 2015 Dmitry Rodionov
 # This software may be modified and distributed under the terms
 # of the MIT license. See the LICENSE file for details.
+
 from __future__ import absolute_import
-import os
-import json
-from getpass import getuser
 import logging
+import os
+
 from lib.core.config import Config
-from lib.common.common import sanitize_path, path_for_script, filelines, current_directory
+
+# from getpass import getuser
+
 
 log = logging.getLogger(__name__)
 

--- a/analyzer/linux/lib/common/constants.py
+++ b/analyzer/linux/lib/common/constants.py
@@ -1,9 +1,11 @@
 # Copyright (C) 2014-2016 Cuckoo Foundation.
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
+
 from __future__ import absolute_import
 import os
 import tempfile
+
 from lib.common.rand import random_string
 
 ROOT = os.path.join(tempfile.gettempdir(), random_string(6, 10))

--- a/analyzer/linux/lib/common/hashing.py
+++ b/analyzer/linux/lib/common/hashing.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2014-2016 Cuckoo Foundation.
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
+
 from __future__ import absolute_import
 import hashlib
 

--- a/analyzer/linux/lib/common/results.py
+++ b/analyzer/linux/lib/common/results.py
@@ -3,8 +3,8 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 from __future__ import absolute_import
-import os
 import logging
+import os
 import socket
 import time
 

--- a/analyzer/linux/lib/core/packages.py
+++ b/analyzer/linux/lib/core/packages.py
@@ -2,18 +2,17 @@
 # Copyright (C) 2015 Dmitry Rodionov
 # This software may be modified and distributed under the terms
 # of the MIT license. See the LICENSE file for details.
+
 from __future__ import absolute_import
-
-from lib.common.apicalls import apicalls
-
 import inspect
-from os import sys, path, waitpid, environ
 import logging
-import time
 import subprocess
-from lib.common.results import NetlogFile
-from lib.core.config import Config
+import time
+from os import environ, path, sys, waitpid
+
 from lib.api.process import Process
+from lib.common.apicalls import apicalls
+from lib.common.results import NetlogFile
 
 log = logging.getLogger(__name__)
 

--- a/analyzer/linux/lib/core/startup.py
+++ b/analyzer/linux/lib/core/startup.py
@@ -3,8 +3,8 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 from __future__ import absolute_import
-import os
 import logging
+import os
 
 from lib.common.constants import PATHS
 from lib.common.results import NetlogHandler

--- a/analyzer/linux/modules/auxiliary/filecollector.py
+++ b/analyzer/linux/modules/auxiliary/filecollector.py
@@ -1,15 +1,15 @@
+import hashlib
+import logging
 import os
 import time
-import logging
-import hashlib
 from threading import Thread
+
 from lib.common.abstracts import Auxiliary
-from lib.common.results import upload_to_host
 from lib.common.hashing import hash_file
+from lib.common.results import upload_to_host
 
 try:
     import pyinotify
-
     HAVE_PYINOTIFY = True
 except ImportError:
     HAVE_PYINOTIFY = False

--- a/analyzer/linux/modules/auxiliary/human.py
+++ b/analyzer/linux/modules/auxiliary/human.py
@@ -3,14 +3,13 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-import random
 import logging
-from threading import Thread
+import random
 import time
-import subprocess
-import os
-from Xlib.display import Display
+from threading import Thread
+
 import pyautogui
+from Xlib.display import Display
 
 from lib.common.abstracts import Auxiliary
 

--- a/analyzer/linux/modules/auxiliary/screenshots.py
+++ b/analyzer/linux/modules/auxiliary/screenshots.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2010-2015 Cuckoo Foundation.
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
+
 from __future__ import absolute_import
 import logging
 import time

--- a/analyzer/linux/modules/auxiliary/screenshots.py
+++ b/analyzer/linux/modules/auxiliary/screenshots.py
@@ -3,28 +3,15 @@
 # See the file 'docs/LICENSE' for copying permission.
 from __future__ import absolute_import
 import logging
-
-log = logging.getLogger(__name__)
-
-log.debug("Importing 'time'")
 import time
-
-log.debug("Importing 'StringIO'")
 from io import BytesIO
-
-log.debug("Importing 'Thread'")
 from threading import Thread
 
-log.debug("Importing 'Auxiliary'")
+from lib.api.screenshot import Screenshot
 from lib.common.abstracts import Auxiliary
-
-log.debug("Importing 'NetlogFile'")
 from lib.common.results import NetlogFile
 
-log.debug("Importing 'Screenshot'")
-from lib.api.screenshot import Screenshot
-
-log.debug("Imports OK")
+log = logging.getLogger(__name__)
 
 SHOT_DELAY = 1
 # Skip the following area when comparing screen shots.

--- a/analyzer/linux/modules/packages/doc.py
+++ b/analyzer/linux/modules/packages/doc.py
@@ -4,6 +4,7 @@
 # of the MIT license. See the LICENSE file for details.
 
 from os import system
+
 from lib.core.packages import Package
 
 

--- a/analyzer/linux/modules/packages/firefox.py
+++ b/analyzer/linux/modules/packages/firefox.py
@@ -3,7 +3,6 @@
 # This software may be modified and distributed under the terms
 # of the MIT license. See the LICENSE file for details.
 
-from os import system
 from lib.core.packages import Package
 
 

--- a/analyzer/linux/modules/packages/generic.py
+++ b/analyzer/linux/modules/packages/generic.py
@@ -4,6 +4,7 @@
 # of the MIT license. See the LICENSE file for details.
 
 from os import system
+
 from lib.core.packages import Package
 
 

--- a/analyzer/linux/modules/packages/pdf.py
+++ b/analyzer/linux/modules/packages/pdf.py
@@ -4,6 +4,7 @@
 # of the MIT license. See the LICENSE file for details.
 
 from os import system
+
 from lib.core.packages import Package
 
 

--- a/analyzer/linux/modules/packages/perl.py
+++ b/analyzer/linux/modules/packages/perl.py
@@ -4,6 +4,7 @@
 # of the MIT license. See the LICENSE file for details.
 
 from os import system
+
 from lib.core.packages import Package
 
 

--- a/analyzer/linux/modules/packages/wget.py
+++ b/analyzer/linux/modules/packages/wget.py
@@ -3,11 +3,11 @@
 # This software may be modified and distributed under the terms
 # of the MIT license. See the LICENSE file for details.
 
-from os import system, chmod
 import logging
+from os import chmod, system
 from subprocess import check_output
-from lib.core.packages import Package, choose_package_class
 
+from lib.core.packages import Package, choose_package_class
 
 log = logging.getLogger(__name__)
 

--- a/analyzer/linux/modules/packages/zip.py
+++ b/analyzer/linux/modules/packages/zip.py
@@ -4,12 +4,13 @@
 # of the MIT license. See the LICENSE file for details.
 
 import logging
-from shutil import move
-from os import path, environ
+from os import environ, path
 from random import SystemRandom
+from shutil import move
 from string import ascii_letters
 from subprocess import check_output
-from zipfile import ZipFile, BadZipfile
+from zipfile import BadZipfile, ZipFile
+
 from lib.core.packages import Package, choose_package_class
 
 log = logging.getLogger(__name__)

--- a/analyzer/windows/analyzer.py
+++ b/analyzer/windows/analyzer.py
@@ -5,40 +5,35 @@
 #  https://github.com/cuckoosandbox/cuckoo/blob/ad5bf8939fb4b86d03c4d96014b174b8b56885e3/cuckoo/core/plugins.py#L29
 
 from __future__ import absolute_import
+import hashlib
+import logging
 import os
-import sys
+import pkgutil
 import socket
 import struct
-import pkgutil
-import logging
-import hashlib
+import subprocess
+import sys
 import timeit
 import traceback
-import subprocess
-from ctypes import create_string_buffer, create_unicode_buffer, POINTER
-from ctypes import byref, c_int, sizeof, cast, c_void_p, c_ulong
-
-from threading import Lock
+from ctypes import POINTER, byref, c_int, c_ulong, c_void_p, cast, create_string_buffer, create_unicode_buffer, sizeof
 from shutil import copy
+from threading import Lock
 from urllib.parse import urlencode
 from urllib.request import urlopen
 
 from lib.api.process import Process
-from lib.common.abstracts import Package, Auxiliary
-from lib.common.constants import PATHS, PIPE, SHUTDOWN_MUTEX, TERMINATE_EVENT, LOGSERVER_PREFIX
-from lib.common.constants import CAPEMON32_NAME, CAPEMON64_NAME, LOADER32_NAME, LOADER64_NAME
-from lib.common.defines import ADVAPI32, KERNEL32, NTDLL
-from lib.common.defines import SYSTEM_PROCESS_INFORMATION
-from lib.common.defines import EVENT_MODIFY_STATE
+from lib.common.abstracts import Auxiliary, Package
+from lib.common.constants import (CAPEMON32_NAME, CAPEMON64_NAME, LOADER32_NAME, LOADER64_NAME, LOGSERVER_PREFIX, PATHS, PIPE,
+                                  SHUTDOWN_MUTEX, TERMINATE_EVENT)
+from lib.common.defines import ADVAPI32, EVENT_MODIFY_STATE, KERNEL32, NTDLL, SYSTEM_PROCESS_INFORMATION
 from lib.common.exceptions import CuckooError, CuckooPackageError
 from lib.common.hashing import hash_file
 from lib.common.results import upload_to_host
 from lib.core.config import Config
-from lib.core.pipe import PipeServer, PipeForwarder, PipeDispatcher
-from lib.core.pipe import disconnect_pipes
 from lib.core.packages import choose_package
+from lib.core.pipe import PipeDispatcher, PipeForwarder, PipeServer, disconnect_pipes
 from lib.core.privileges import grant_debug_privilege
-from lib.core.startup import create_folders, init_logging, disconnect_logger, set_clock
+from lib.core.startup import create_folders, disconnect_logger, init_logging, set_clock
 from modules import auxiliary
 
 log = logging.getLogger()

--- a/analyzer/windows/lib/api/process.py
+++ b/analyzer/windows/lib/api/process.py
@@ -3,35 +3,31 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 from __future__ import absolute_import
-import os
-import sys
+import base64
 import logging
+import os
+import platform
 import random
 import subprocess
-import platform
-import urllib.request, urllib.parse, urllib.error
-import base64
-from time import time
-from ctypes import byref, c_ulong, create_string_buffer, create_unicode_buffer, c_int, sizeof
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from ctypes import byref, c_int, c_ulong, create_string_buffer, sizeof
 from shutil import copy
 
-from lib.common.results import upload_to_host
-from lib.common.constants import PIPE, PATHS, SHUTDOWN_MUTEX, TERMINATE_EVENT, LOGSERVER_PREFIX
-from lib.common.constants import CAPEMON32_NAME, CAPEMON64_NAME, LOADER32_NAME, LOADER64_NAME
-from lib.common.defines import ULONG_PTR
-from lib.common.defines import KERNEL32, NTDLL, SYSTEM_INFO, STILL_ACTIVE
-from lib.common.defines import THREAD_ALL_ACCESS, PROCESS_ALL_ACCESS, TH32CS_SNAPPROCESS
-from lib.common.defines import STARTUPINFO, PROCESS_INFORMATION, PROCESSENTRY32
-from lib.common.defines import CREATE_NEW_CONSOLE, CREATE_SUSPENDED
-from lib.common.defines import MEM_RESERVE, MEM_COMMIT, PAGE_READWRITE
-from lib.common.defines import MEMORY_BASIC_INFORMATION
-from lib.common.defines import WAIT_TIMEOUT, EVENT_MODIFY_STATE
-from lib.common.defines import MEM_IMAGE, MEM_MAPPED, MEM_PRIVATE
-from lib.common.defines import GENERIC_READ, GENERIC_WRITE, OPEN_EXISTING
+from lib.common.constants import (CAPEMON32_NAME, CAPEMON64_NAME, LOADER32_NAME, LOADER64_NAME, LOGSERVER_PREFIX, PATHS, PIPE,
+                                  SHUTDOWN_MUTEX, TERMINATE_EVENT)
+from lib.common.defines import (CREATE_NEW_CONSOLE, CREATE_SUSPENDED, EVENT_MODIFY_STATE, GENERIC_READ, GENERIC_WRITE, KERNEL32,
+                                NTDLL, OPEN_EXISTING, PROCESS_ALL_ACCESS, PROCESS_INFORMATION, PROCESSENTRY32, STARTUPINFO,
+                                SYSTEM_INFO, TH32CS_SNAPPROCESS, THREAD_ALL_ACCESS, ULONG_PTR)
 from lib.common.errors import get_error_string
 from lib.common.rand import random_string
+from lib.common.results import upload_to_host
 from lib.core.config import Config
 from lib.core.log import LogServer
+
+# from lib.common.defines import STILL_ACTIVE
 
 INJECT_CREATEREMOTETHREAD = 0
 INJECT_QUEUEUSERAPC = 1

--- a/analyzer/windows/lib/api/screenshot.py
+++ b/analyzer/windows/lib/api/screenshot.py
@@ -3,12 +3,7 @@
 # See the file 'docs/LICENSE' for copying permission.
 from __future__ import absolute_import
 import logging
-
-log = logging.getLogger(__name__)
-
-log.debug("Importing 'math'")
 import math
-import logging
 
 log = logging.getLogger(__name__)
 

--- a/analyzer/windows/lib/api/screenshot.py
+++ b/analyzer/windows/lib/api/screenshot.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2010-2015 Cuckoo Foundation.
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
+
 from __future__ import absolute_import
 import logging
 import math

--- a/analyzer/windows/lib/api/utils.py
+++ b/analyzer/windows/lib/api/utils.py
@@ -13,10 +13,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import absolute_import
-import os
 import logging
-import subprocess
 import socket
+import subprocess
 
 try:
     import re2 as re

--- a/analyzer/windows/lib/common/abstracts.py
+++ b/analyzer/windows/lib/common/abstracts.py
@@ -4,20 +4,17 @@
 
 from __future__ import absolute_import
 import glob
-import os
 import logging
+import os
 import shutil
+
+from lib.api.process import Process
+from lib.common.exceptions import CuckooPackageError
 
 INJECT_CREATEREMOTETHREAD = 0
 INJECT_QUEUEUSERAPC = 1
 
 log = logging.getLogger(__name__)
-log.info("Started imports")
-from lib.api.process import Process
-from lib.api.utils import Utils
-from lib.common.exceptions import CuckooPackageError
-
-log.info("End imports")
 
 
 class Package(object):

--- a/analyzer/windows/lib/common/constants.py
+++ b/analyzer/windows/lib/common/constants.py
@@ -4,8 +4,8 @@
 
 from __future__ import absolute_import
 import os
-from lib.common.rand import random_string
 
+from lib.common.rand import random_string
 
 ROOT = os.path.join(os.getenv("SystemDrive"), "\\", random_string(6, 10))
 

--- a/analyzer/windows/lib/common/decode_vbe_jse.py
+++ b/analyzer/windows/lib/common/decode_vbe_jse.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
 __description__ = "Decode VBE script"
 __author__ = "Didier Stevens"
@@ -24,14 +23,14 @@ Reference:
   https://gallery.technet.microsoft.com/Encode-and-Decode-a-VB-a480d74c
 """
 
-import optparse
-import sys
-import os
-import signal
-import textwrap
-import re
-import zipfile
 import binascii
+import optparse
+import os
+import re
+import signal
+import sys
+import textwrap
+import zipfile
 
 MALWARE_PASSWORD = "infected"
 

--- a/analyzer/windows/lib/common/defines.py
+++ b/analyzer/windows/lib/common/defines.py
@@ -3,7 +3,8 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 from __future__ import absolute_import
-from ctypes import *
+from ctypes import (POINTER, WINFUNCTYPE, Structure, Union, c_bool, c_char, c_double, c_int, c_ubyte, c_uint, c_ulonglong, c_ushort,
+                    c_void_p, c_wchar_p, windll)
 
 NTDLL = windll.ntdll
 KERNEL32 = windll.kernel32

--- a/analyzer/windows/lib/common/results.py
+++ b/analyzer/windows/lib/common/results.py
@@ -3,8 +3,8 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 from __future__ import absolute_import
-import os
 import logging
+import os
 import socket
 import time
 from pathlib import Path

--- a/analyzer/windows/lib/core/log.py
+++ b/analyzer/windows/lib/core/log.py
@@ -3,19 +3,15 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 from __future__ import absolute_import
-import socket
 import logging
+import socket
 import traceback
-from ctypes import create_string_buffer, create_unicode_buffer
-from ctypes import byref, c_int, sizeof, addressof
+from ctypes import addressof, byref, c_int, create_string_buffer, sizeof
 from threading import Thread
 
-from lib.common.defines import ADVAPI32, KERNEL32
-from lib.common.defines import ERROR_MORE_DATA, ERROR_PIPE_CONNECTED
-from lib.common.defines import PIPE_ACCESS_INBOUND, PIPE_TYPE_MESSAGE
-from lib.common.defines import PIPE_READMODE_MESSAGE, PIPE_WAIT
-from lib.common.defines import PIPE_UNLIMITED_INSTANCES, INVALID_HANDLE_VALUE
-from lib.common.defines import SECURITY_DESCRIPTOR, SECURITY_ATTRIBUTES
+from lib.common.defines import (ADVAPI32, ERROR_MORE_DATA, ERROR_PIPE_CONNECTED, INVALID_HANDLE_VALUE, KERNEL32,
+                                PIPE_ACCESS_INBOUND, PIPE_READMODE_MESSAGE, PIPE_TYPE_MESSAGE, PIPE_UNLIMITED_INSTANCES, PIPE_WAIT,
+                                SECURITY_ATTRIBUTES, SECURITY_DESCRIPTOR)
 
 log = logging.getLogger()
 

--- a/analyzer/windows/lib/core/packages.py
+++ b/analyzer/windows/lib/core/packages.py
@@ -3,8 +3,8 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 from __future__ import absolute_import
-import os
 import re
+
 from lib.common.decode_vbe_jse import DecodeVBEJSE
 
 

--- a/analyzer/windows/lib/core/pipe.py
+++ b/analyzer/windows/lib/core/pipe.py
@@ -3,20 +3,17 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
+import errno
 import logging
 import socket
 import threading
-import errno
+from ctypes import addressof, byref, c_uint, create_string_buffer, sizeof
 
-from ctypes import create_string_buffer, c_uint, byref, sizeof, addressof
+from lib.common.defines import (ADVAPI32, ERROR_BROKEN_PIPE, ERROR_MORE_DATA, ERROR_PIPE_CONNECTED, INVALID_HANDLE_VALUE, KERNEL32,
+                                PIPE_ACCESS_DUPLEX, PIPE_ACCESS_INBOUND, PIPE_READMODE_BYTE, PIPE_READMODE_MESSAGE, PIPE_TYPE_BYTE,
+                                PIPE_TYPE_MESSAGE, PIPE_UNLIMITED_INSTANCES, PIPE_WAIT, SECURITY_ATTRIBUTES, SECURITY_DESCRIPTOR)
 
-from lib.common.defines import KERNEL32, PIPE_ACCESS_INBOUND, ERROR_MORE_DATA
-from lib.common.defines import PIPE_TYPE_BYTE, PIPE_WAIT, ERROR_PIPE_CONNECTED
-from lib.common.defines import PIPE_UNLIMITED_INSTANCES, INVALID_HANDLE_VALUE
-from lib.common.defines import FILE_FLAG_WRITE_THROUGH, PIPE_READMODE_BYTE
-from lib.common.defines import ERROR_BROKEN_PIPE, PIPE_TYPE_MESSAGE
-from lib.common.defines import PIPE_ACCESS_DUPLEX, PIPE_READMODE_MESSAGE
-from lib.common.defines import SECURITY_DESCRIPTOR, SECURITY_ATTRIBUTES, ADVAPI32
+# from lib.common.defines import FILE_FLAG_WRITE_THROUGH
 
 log = logging.getLogger(__name__)
 

--- a/analyzer/windows/lib/core/privileges.py
+++ b/analyzer/windows/lib/core/privileges.py
@@ -3,11 +3,10 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 from __future__ import absolute_import
-from ctypes import wintypes, POINTER
+from ctypes import POINTER, wintypes
 
-from lib.common.defines import ADVAPI32, KERNEL32, SE_PRIVILEGE_ENABLED
-from lib.common.defines import LUID, TOKEN_PRIVILEGES, PROCESS_ALL_ACCESS
-from lib.common.defines import TOKEN_ALL_ACCESS, LUID_AND_ATTRIBUTES
+from lib.common.defines import (ADVAPI32, KERNEL32, LUID, LUID_AND_ATTRIBUTES, PROCESS_ALL_ACCESS, SE_PRIVILEGE_ENABLED,
+                                TOKEN_ALL_ACCESS, TOKEN_PRIVILEGES)
 
 
 def grant_debug_privilege(pid=None):

--- a/analyzer/windows/lib/core/startup.py
+++ b/analyzer/windows/lib/core/startup.py
@@ -3,14 +3,14 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 from __future__ import absolute_import
-import os
 import ctypes
 import logging
+import os
 from datetime import datetime
 
 from lib.common.constants import PATHS
-from lib.common.results import NetlogHandler
 from lib.common.defines import KERNEL32, SYSTEMTIME
+from lib.common.results import NetlogHandler
 
 log = logging.getLogger()
 

--- a/analyzer/windows/modules/auxiliary/browser.py
+++ b/analyzer/windows/modules/auxiliary/browser.py
@@ -3,9 +3,9 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 from __future__ import absolute_import
-import time
-import os
 import logging
+import os
+import time
 from threading import Thread
 
 from lib.api.process import Process

--- a/analyzer/windows/modules/auxiliary/curtain.py
+++ b/analyzer/windows/modules/auxiliary/curtain.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import
-import os
-import time
 import logging
+import os
 import subprocess
+import time
 from threading import Thread
 
 from lib.common.abstracts import Auxiliary

--- a/analyzer/windows/modules/auxiliary/digisig.py
+++ b/analyzer/windows/modules/auxiliary/digisig.py
@@ -3,10 +3,10 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 from __future__ import absolute_import
-import os
 import json
-import logging
 import locale
+import logging
+import os
 from io import BytesIO
 
 from lib.api.utils import Utils

--- a/analyzer/windows/modules/auxiliary/disguise.py
+++ b/analyzer/windows/modules/auxiliary/disguise.py
@@ -4,14 +4,15 @@
 
 from __future__ import absolute_import
 import io
+import logging
 import os
+import platform
 import re
 import subprocess
-import logging
 from random import randint
-from winreg import *
 from uuid import uuid4
-import platform
+from winreg import (HKEY_CURRENT_USER, HKEY_LOCAL_MACHINE, KEY_READ, KEY_SET_VALUE, KEY_WOW64_64KEY, REG_DWORD, REG_SZ, CloseKey,
+                    CreateKeyEx, EnumKey, EnumValue, OpenKey, QueryInfoKey, SetValueEx)
 
 from lib.common.abstracts import Auxiliary
 from lib.common.rand import random_integer, random_string

--- a/analyzer/windows/modules/auxiliary/evtx.py
+++ b/analyzer/windows/modules/auxiliary/evtx.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import
-from threading import Thread
 import logging
-import zipfile
 import os
+import zipfile
+from threading import Thread
 
 from lib.common.abstracts import Auxiliary
 from lib.common.results import upload_to_host

--- a/analyzer/windows/modules/auxiliary/human.py
+++ b/analyzer/windows/modules/auxiliary/human.py
@@ -4,17 +4,14 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 from __future__ import absolute_import
-import random
 import logging
+import random
 import traceback
+from ctypes import POINTER, WINFUNCTYPE, c_bool, c_int, create_unicode_buffer, memmove, sizeof
 from threading import Thread
-from ctypes import WINFUNCTYPE, POINTER
-from ctypes import c_bool, c_int, create_unicode_buffer, create_string_buffer, memmove, sizeof
 
 from lib.common.abstracts import Auxiliary
-from lib.common.defines import KERNEL32, USER32
-from lib.common.defines import WM_GETTEXT, WM_GETTEXTLENGTH, WM_CLOSE, BM_CLICK
-from lib.common.defines import GMEM_MOVEABLE, CF_TEXT
+from lib.common.defines import BM_CLICK, CF_TEXT, GMEM_MOVEABLE, KERNEL32, USER32, WM_CLOSE, WM_GETTEXT, WM_GETTEXTLENGTH
 
 log = logging.getLogger(__name__)
 

--- a/analyzer/windows/modules/auxiliary/screenshots.py
+++ b/analyzer/windows/modules/auxiliary/screenshots.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2010-2015 Cuckoo Foundation.
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
+
 from __future__ import absolute_import
 import logging
 import time

--- a/analyzer/windows/modules/auxiliary/screenshots.py
+++ b/analyzer/windows/modules/auxiliary/screenshots.py
@@ -3,28 +3,15 @@
 # See the file 'docs/LICENSE' for copying permission.
 from __future__ import absolute_import
 import logging
-
-log = logging.getLogger(__name__)
-
-log.debug("Importing 'time'")
 import time
-
-log.debug("Importing 'StringIO'")
 from io import BytesIO
-
-log.debug("Importing 'Thread'")
 from threading import Thread
 
-log.debug("Importing 'Auxiliary'")
+from lib.api.screenshot import Screenshot
 from lib.common.abstracts import Auxiliary
-
-log.debug("Importing 'NetlogFile'")
 from lib.common.results import NetlogFile
 
-log.debug("Importing 'Screenshot'")
-from lib.api.screenshot import Screenshot
-
-log.debug("Imports OK")
+log = logging.getLogger(__name__)
 
 SHOT_DELAY = 1
 # Skip the following area when comparing screen shots.

--- a/analyzer/windows/modules/auxiliary/tlsdump.py
+++ b/analyzer/windows/modules/auxiliary/tlsdump.py
@@ -3,12 +3,12 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 import logging
+from ctypes import byref, sizeof
 
 from lib.api.process import Process
 from lib.common.abstracts import Auxiliary
-from lib.common.exceptions import CuckooError
-from ctypes import byref, c_ulong, create_string_buffer, create_unicode_buffer, c_int, sizeof
 from lib.common.defines import KERNEL32, PROCESSENTRY32, TH32CS_SNAPPROCESS
+from lib.common.exceptions import CuckooError
 
 log = logging.getLogger(__name__)
 

--- a/analyzer/windows/modules/auxiliary/usage.py
+++ b/analyzer/windows/modules/auxiliary/usage.py
@@ -3,13 +3,13 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 from __future__ import absolute_import
-from ctypes import *
 import logging
 import time
+from ctypes import byref, create_string_buffer, sizeof
 from threading import Thread
 
 from lib.common.abstracts import Auxiliary
-from lib.common.defines import PDH, KERNEL32, PVOID, DWORD, MEMORYSTATUSEX, PDH_FMT_COUNTERVALUE, PDH_FMT_DOUBLE
+from lib.common.defines import DWORD, KERNEL32, MEMORYSTATUSEX, PDH, PDH_FMT_COUNTERVALUE, PDH_FMT_DOUBLE, PVOID
 from lib.common.results import NetlogFile
 
 log = logging.getLogger(__name__)

--- a/analyzer/windows/modules/packages/Shellcode-Unpacker.py
+++ b/analyzer/windows/modules/packages/Shellcode-Unpacker.py
@@ -3,9 +3,9 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 from __future__ import absolute_import
+import logging
 import os
 import shutil
-import logging
 
 from lib.common.abstracts import Package
 

--- a/analyzer/windows/modules/packages/Unpacker.py
+++ b/analyzer/windows/modules/packages/Unpacker.py
@@ -4,7 +4,6 @@
 
 from __future__ import absolute_import
 import os
-import shutil
 
 from lib.common.abstracts import Package
 

--- a/analyzer/windows/modules/packages/Unpacker_regsvr.py
+++ b/analyzer/windows/modules/packages/Unpacker_regsvr.py
@@ -4,7 +4,6 @@
 
 from __future__ import absolute_import
 import os
-import shutil
 
 from lib.common.abstracts import Package
 

--- a/analyzer/windows/modules/packages/Unpacker_zip.py
+++ b/analyzer/windows/modules/packages/Unpacker_zip.py
@@ -3,16 +3,15 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 from __future__ import absolute_import
+import logging
 import os
 import shutil
-import logging
+from zipfile import BadZipfile, ZipFile
 
 try:
     import re2 as re
 except ImportError:
     import re
-
-from zipfile import ZipFile, BadZipfile
 
 from lib.common.abstracts import Package
 from lib.common.exceptions import CuckooPackageError

--- a/analyzer/windows/modules/packages/chm.py
+++ b/analyzer/windows/modules/packages/chm.py
@@ -4,7 +4,6 @@
 
 from __future__ import absolute_import
 import os
-import shutil
 
 from lib.common.abstracts import Package
 

--- a/analyzer/windows/modules/packages/chrome.py
+++ b/analyzer/windows/modules/packages/chrome.py
@@ -3,6 +3,7 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 from __future__ import absolute_import
+
 from lib.common.abstracts import Package
 
 

--- a/analyzer/windows/modules/packages/cpl.py
+++ b/analyzer/windows/modules/packages/cpl.py
@@ -3,6 +3,7 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 from __future__ import absolute_import
+
 from lib.common.abstracts import Package
 
 

--- a/analyzer/windows/modules/packages/eml.py
+++ b/analyzer/windows/modules/packages/eml.py
@@ -3,6 +3,7 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 from __future__ import absolute_import
+
 from lib.common.abstracts import Package
 
 

--- a/analyzer/windows/modules/packages/exe.py
+++ b/analyzer/windows/modules/packages/exe.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import
 import os
 import shutil
 from subprocess import call
+
 from lib.common.abstracts import Package
 
 

--- a/analyzer/windows/modules/packages/firefox.py
+++ b/analyzer/windows/modules/packages/firefox.py
@@ -3,6 +3,7 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 from __future__ import absolute_import
+
 from lib.common.abstracts import Package
 
 

--- a/analyzer/windows/modules/packages/generic.py
+++ b/analyzer/windows/modules/packages/generic.py
@@ -3,7 +3,6 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 from __future__ import absolute_import
-from random import randint
 
 from lib.common.abstracts import Package
 

--- a/analyzer/windows/modules/packages/hta.py
+++ b/analyzer/windows/modules/packages/hta.py
@@ -3,8 +3,8 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 from __future__ import absolute_import
-import os
 import logging
+import os
 
 from lib.common.abstracts import Package
 

--- a/analyzer/windows/modules/packages/html.py
+++ b/analyzer/windows/modules/packages/html.py
@@ -3,8 +3,8 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 from __future__ import absolute_import
-import shutil
 import logging
+import shutil
 
 from lib.common.abstracts import Package
 

--- a/analyzer/windows/modules/packages/ichitaro.py
+++ b/analyzer/windows/modules/packages/ichitaro.py
@@ -12,6 +12,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import os
 
 from lib.common.abstracts import Package

--- a/analyzer/windows/modules/packages/ichitaro.py
+++ b/analyzer/windows/modules/packages/ichitaro.py
@@ -13,7 +13,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import os
+
 from lib.common.abstracts import Package
+
 
 # While this should work, it is an experimental rule - do a PR if you see fit! Viewer only.
 class ichitaro(Package):

--- a/analyzer/windows/modules/packages/ie.py
+++ b/analyzer/windows/modules/packages/ie.py
@@ -3,6 +3,7 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 from __future__ import absolute_import
+
 from lib.common.abstracts import Package
 
 

--- a/analyzer/windows/modules/packages/inp.py
+++ b/analyzer/windows/modules/packages/inp.py
@@ -13,7 +13,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import os
+
 from lib.common.abstracts import Package
+
 
 # While this should work, it is an experimental rule - do a PR if you see fit!
 class INP(Package):

--- a/analyzer/windows/modules/packages/inp.py
+++ b/analyzer/windows/modules/packages/inp.py
@@ -12,6 +12,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import os
 
 from lib.common.abstracts import Package

--- a/analyzer/windows/modules/packages/jar.py
+++ b/analyzer/windows/modules/packages/jar.py
@@ -3,6 +3,7 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 from __future__ import absolute_import
+
 from lib.common.abstracts import Package
 
 

--- a/analyzer/windows/modules/packages/lnk.py
+++ b/analyzer/windows/modules/packages/lnk.py
@@ -4,6 +4,7 @@
 
 from __future__ import absolute_import
 import os
+
 from lib.common.abstracts import Package
 
 

--- a/analyzer/windows/modules/packages/mht.py
+++ b/analyzer/windows/modules/packages/mht.py
@@ -3,8 +3,8 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 from __future__ import absolute_import
-import shutil
 import logging
+import shutil
 
 from lib.common.abstracts import Package
 

--- a/analyzer/windows/modules/packages/msbuild.py
+++ b/analyzer/windows/modules/packages/msbuild.py
@@ -2,7 +2,6 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 from __future__ import absolute_import
-import os
 
 from lib.common.abstracts import Package
 

--- a/analyzer/windows/modules/packages/msg.py
+++ b/analyzer/windows/modules/packages/msg.py
@@ -3,6 +3,7 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 from __future__ import absolute_import
+
 from lib.common.abstracts import Package
 
 

--- a/analyzer/windows/modules/packages/msi.py
+++ b/analyzer/windows/modules/packages/msi.py
@@ -3,6 +3,7 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 from __future__ import absolute_import
+
 from lib.common.abstracts import Package
 
 

--- a/analyzer/windows/modules/packages/nsis.py
+++ b/analyzer/windows/modules/packages/nsis.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2010-2015 Cuckoo Foundation.
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
+
 from __future__ import absolute_import
 import os
 

--- a/analyzer/windows/modules/packages/nsis.py
+++ b/analyzer/windows/modules/packages/nsis.py
@@ -3,6 +3,7 @@
 # See the file 'docs/LICENSE' for copying permission.
 from __future__ import absolute_import
 import os
+
 from lib.common.abstracts import Package
 
 

--- a/analyzer/windows/modules/packages/ollydbg.py
+++ b/analyzer/windows/modules/packages/ollydbg.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+
 from lib.common.abstracts import Package
 
 

--- a/analyzer/windows/modules/packages/pdf.py
+++ b/analyzer/windows/modules/packages/pdf.py
@@ -3,6 +3,7 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 from __future__ import absolute_import
+
 from lib.common.abstracts import Package
 
 

--- a/analyzer/windows/modules/packages/ppt.py
+++ b/analyzer/windows/modules/packages/ppt.py
@@ -3,6 +3,7 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 from __future__ import absolute_import
+
 from lib.common.abstracts import Package
 
 

--- a/analyzer/windows/modules/packages/ppt2016.py
+++ b/analyzer/windows/modules/packages/ppt2016.py
@@ -3,6 +3,7 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 from __future__ import absolute_import
+
 from lib.common.abstracts import Package
 
 

--- a/analyzer/windows/modules/packages/processes.py
+++ b/analyzer/windows/modules/packages/processes.py
@@ -1,8 +1,7 @@
 from __future__ import absolute_import
 import os
 import time
-import shutil
-from subprocess import call
+
 from lib.common.abstracts import Package
 
 

--- a/analyzer/windows/modules/packages/processes_simple.py
+++ b/analyzer/windows/modules/packages/processes_simple.py
@@ -1,8 +1,7 @@
 from __future__ import absolute_import
 import os
 import time
-import shutil
-from subprocess import call
+
 from lib.common.abstracts import Package
 
 

--- a/analyzer/windows/modules/packages/pub.py
+++ b/analyzer/windows/modules/packages/pub.py
@@ -4,23 +4,10 @@
 
 from __future__ import absolute_import
 import os
-from lib.common.abstracts import Package
+from winreg import (HKEY_CURRENT_USER, KEY_READ, KEY_SET_VALUE, REG_DWORD, CloseKey, CreateKeyEx, EnumKey, OpenKey, QueryInfoKey,
+                    SetValueEx)
 
-from winreg import (
-    OpenKey,
-    CreateKeyEx,
-    SetValueEx,
-    CloseKey,
-    QueryInfoKey,
-    EnumKey,
-    EnumValue,
-    HKEY_LOCAL_MACHINE,
-    HKEY_CURRENT_USER,
-    KEY_SET_VALUE,
-    KEY_READ,
-    REG_SZ,
-    REG_DWORD,
-)
+from lib.common.abstracts import Package
 
 
 class PUB(Package):

--- a/analyzer/windows/modules/packages/pub2016.py
+++ b/analyzer/windows/modules/packages/pub2016.py
@@ -4,23 +4,10 @@
 
 from __future__ import absolute_import
 import os
-from lib.common.abstracts import Package
+from winreg import (HKEY_CURRENT_USER, KEY_READ, KEY_SET_VALUE, REG_DWORD, CloseKey, CreateKeyEx, EnumKey, OpenKey, QueryInfoKey,
+                    SetValueEx)
 
-from winreg import (
-    OpenKey,
-    CreateKeyEx,
-    SetValueEx,
-    CloseKey,
-    QueryInfoKey,
-    EnumKey,
-    EnumValue,
-    HKEY_LOCAL_MACHINE,
-    HKEY_CURRENT_USER,
-    KEY_SET_VALUE,
-    KEY_READ,
-    REG_SZ,
-    REG_DWORD,
-)
+from lib.common.abstracts import Package
 
 
 class PUB2007(Package):

--- a/analyzer/windows/modules/packages/python.py
+++ b/analyzer/windows/modules/packages/python.py
@@ -3,6 +3,7 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 from __future__ import absolute_import
+
 from lib.common.abstracts import Package
 
 

--- a/analyzer/windows/modules/packages/rar.py
+++ b/analyzer/windows/modules/packages/rar.py
@@ -3,14 +3,13 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 from __future__ import absolute_import
-import os
-import shutil
 import logging
+import os
 import re
+import shutil
 
 try:
-    from rarfile import RarFile, BadRarFile
-
+    from rarfile import BadRarFile, RarFile
     HAS_RARFILE = True
 except ImportError:
     HAS_RARFILE = False

--- a/analyzer/windows/modules/packages/regsvr.py
+++ b/analyzer/windows/modules/packages/regsvr.py
@@ -4,7 +4,6 @@
 
 from __future__ import absolute_import
 import os
-import shutil
 
 from lib.common.abstracts import Package
 

--- a/analyzer/windows/modules/packages/service.py
+++ b/analyzer/windows/modules/packages/service.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2010-2015 Cuckoo Foundation.
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
+
 from __future__ import absolute_import
 import ctypes
 import logging

--- a/analyzer/windows/modules/packages/service.py
+++ b/analyzer/windows/modules/packages/service.py
@@ -2,15 +2,14 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 from __future__ import absolute_import
+import ctypes
+import logging
 import os
-import shutil
 import sys
+
 from lib.api.process import Process
 from lib.common.abstracts import Package
 from lib.common.defines import ADVAPI32, KERNEL32
-import logging
-import traceback
-import ctypes
 
 INJECT_CREATEREMOTETHREAD = 0
 INJECT_QUEUEUSERAPC = 1

--- a/analyzer/windows/modules/packages/swf.py
+++ b/analyzer/windows/modules/packages/swf.py
@@ -3,6 +3,7 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 from __future__ import absolute_import
+
 from lib.common.abstracts import Package
 
 

--- a/analyzer/windows/modules/packages/vawtrak.py
+++ b/analyzer/windows/modules/packages/vawtrak.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import
 import os
 import shutil
 from subprocess import call
+
 from lib.common.abstracts import Package
 
 

--- a/analyzer/windows/modules/packages/vbejse.py
+++ b/analyzer/windows/modules/packages/vbejse.py
@@ -3,8 +3,8 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 from __future__ import absolute_import
-import os
 from shutil import copyfile
+
 from lib.common.abstracts import Package
 
 

--- a/analyzer/windows/modules/packages/xls.py
+++ b/analyzer/windows/modules/packages/xls.py
@@ -5,6 +5,7 @@
 
 from __future__ import absolute_import
 import os
+
 from lib.common.abstracts import Package
 
 

--- a/analyzer/windows/modules/packages/xls.py
+++ b/analyzer/windows/modules/packages/xls.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-
 from __future__ import absolute_import
 import os
 

--- a/analyzer/windows/modules/packages/xls2016.py
+++ b/analyzer/windows/modules/packages/xls2016.py
@@ -5,6 +5,7 @@
 
 from __future__ import absolute_import
 import os
+
 from lib.common.abstracts import Package
 
 

--- a/analyzer/windows/modules/packages/xls2016.py
+++ b/analyzer/windows/modules/packages/xls2016.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-
 from __future__ import absolute_import
 import os
 

--- a/analyzer/windows/modules/packages/xlst.py
+++ b/analyzer/windows/modules/packages/xlst.py
@@ -3,8 +3,8 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 from __future__ import absolute_import
-import os
 import logging
+import os
 
 from lib.common.abstracts import Package
 

--- a/analyzer/windows/modules/packages/xps.py
+++ b/analyzer/windows/modules/packages/xps.py
@@ -3,6 +3,7 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 from __future__ import absolute_import
+
 from lib.common.abstracts import Package
 
 

--- a/analyzer/windows/modules/packages/zip.py
+++ b/analyzer/windows/modules/packages/zip.py
@@ -3,16 +3,16 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 from __future__ import absolute_import
+import logging
 import os
 import shutil
-import logging
 
 try:
     import re2 as re
 except ImportError:
     import re
 
-from zipfile import ZipFile, BadZipfile
+from zipfile import BadZipfile, ZipFile
 
 from lib.common.abstracts import Package
 from lib.common.exceptions import CuckooPackageError

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[tool.black]
+line-length = 132
+
+[tool.isort]
+profile = "black"
+no_lines_before = ["FUTURE", "STDLIB"]
+multi_line_output = 0
+line_length = 132
+include_trailing_comma = false


### PR DESCRIPTION
- Added pyproject.toml to standardise isort configuration
- Removed unused imports
  - Imports that are used in comments are commented
- Standardisation: 1 newline / start of file before start of imports