### PR TITLE
Cleanup of analyzer packages

### DIFF
--- a/analyzer/windows/lib/common/common.py
+++ b/analyzer/windows/lib/common/common.py
@@ -1,0 +1,16 @@
+from __future__ import absolute_import
+
+import logging
+import os
+
+log = logging.getLogger(__name__)
+
+
+def check_file_extension(path: str, ext: str) -> str:
+    # Check file extension.
+    # If the file doesn't have the proper extension force it and rename it.
+    if os.path.splitext(path)[-1].lower() != ext:
+        os.rename(path, f"{path}{ext}")
+        log.info(f"Submitted file is missing extension, adding {ext}")
+        return path + ext
+    return path

--- a/analyzer/windows/modules/packages/UPX.py
+++ b/analyzer/windows/modules/packages/UPX.py
@@ -7,6 +7,7 @@ import os
 import shutil
 
 from lib.common.abstracts import Package
+from lib.common.common import check_file_extension
 
 
 class UPX(Package):
@@ -27,12 +28,7 @@ class UPX(Package):
         arguments = self.options.get("arguments")
         appdata = self.options.get("appdata")
 
-        # If the file doesn't have an extension, add .exe
-        if "." not in os.path.basename(path):
-            new_path = f"{path}.exe"
-            os.rename(path, new_path)
-            path = new_path
-
+        path = check_file_extension(path, ".exe")
         if appdata:
             # run the executable from the APPDATA directory, required for some malware
             basepath = os.getenv("APPDATA")

--- a/analyzer/windows/modules/packages/UPX_dll.py
+++ b/analyzer/windows/modules/packages/UPX_dll.py
@@ -7,6 +7,7 @@ import os
 import shutil
 
 from lib.common.abstracts import Package
+from lib.common.common import check_file_extension
 
 
 class UPX_dll(Package):
@@ -28,15 +29,7 @@ class UPX_dll(Package):
         arguments = self.options.get("arguments")
         dllloader = self.options.get("dllloader")
 
-        # Check file extension.
-        ext = os.path.splitext(path)[-1].lower()
-        # If the file doesn't have the proper .dll extension force it
-        # and rename it. This is needed for rundll32 to execute correctly.
-        # See ticket #354 for details.
-        if ext != ".dll":
-            new_path = f"{path}.dll"
-            os.rename(path, new_path)
-            path = new_path
+        path = check_file_extension(path, ".dll")
 
         args = f"{path},{function}"
         if arguments:

--- a/analyzer/windows/modules/packages/Unpacker.py
+++ b/analyzer/windows/modules/packages/Unpacker.py
@@ -2,10 +2,8 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
-import os
-
 from lib.common.abstracts import Package
+from lib.common.common import check_file_extension
 
 
 class Unpacker(Package):
@@ -31,9 +29,5 @@ class Unpacker(Package):
         # See CWinApp::SetCurrentHandles(), it will throw
         # an exception that will crash the app if it does
         # not find an extension on the main exe's filename
-        if "." not in os.path.basename(path):
-            new_path = f"{path}.exe"
-            os.rename(path, new_path)
-            path = new_path
-
+        path = check_file_extension(path, ".exe")
         return self.execute(path, arguments, path)

--- a/analyzer/windows/modules/packages/Unpacker_dll.py
+++ b/analyzer/windows/modules/packages/Unpacker_dll.py
@@ -7,6 +7,7 @@ import os
 import shutil
 
 from lib.common.abstracts import Package
+from lib.common.common import check_file_extension
 
 
 class Unpacker_dll(Package):
@@ -29,15 +30,10 @@ class Unpacker_dll(Package):
         arguments = self.options.get("arguments")
         dllloader = self.options.get("dllloader")
 
-        # Check file extension.
-        ext = os.path.splitext(path)[-1].lower()
         # If the file doesn't have the proper .dll extension force it
         # and rename it. This is needed for rundll32 to execute correctly.
         # See ticket #354 for details.
-        if ext != ".dll":
-            new_path = f"{path}.dll"
-            os.rename(path, new_path)
-            path = new_path
+        path = check_file_extension(path, ".dll")
 
         args = f"{path},{function}"
         if arguments:

--- a/analyzer/windows/modules/packages/Unpacker_js.py
+++ b/analyzer/windows/modules/packages/Unpacker_js.py
@@ -27,7 +27,7 @@ class Unpacker_JS(Package):
         wscript = self.get_path("wscript.exe")
         args = f'"{path}"'
         ext = os.path.splitext(path)[-1].lower()
-        if ext != ".js" and ext != ".jse":
+        if ext not in (".js", ".jse"):
             if os.path.isfile(path) and "#@~^" in open(path, "rb").read(100):
                 os.rename(path, f"{path}.jse")
                 path = f"{path}.jse"

--- a/analyzer/windows/modules/packages/Unpacker_js.py
+++ b/analyzer/windows/modules/packages/Unpacker_js.py
@@ -28,7 +28,9 @@ class Unpacker_JS(Package):
         args = f'"{path}"'
         ext = os.path.splitext(path)[-1].lower()
         if ext not in (".js", ".jse"):
-            if os.path.isfile(path) and "#@~^" in open(path, "rb").read(100):
+            with open(path, "r") as tmpfile:
+                magic_bytes = tmpfile.read(4)
+            if magic_bytes == "#@~^":
                 os.rename(path, f"{path}.jse")
                 path = f"{path}.jse"
             else:

--- a/analyzer/windows/modules/packages/Unpacker_ps1.py
+++ b/analyzer/windows/modules/packages/Unpacker_ps1.py
@@ -2,10 +2,8 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
-import os
-
 from lib.common.abstracts import Package
+from lib.common.common import check_file_extension
 
 
 class PS1(Package):
@@ -25,10 +23,6 @@ class PS1(Package):
 
     def start(self, path):
         powershell = self.get_path_glob("PowerShell")
-
-        if not path.endswith(".ps1"):
-            os.rename(path, f"{path}.ps1")
-            path += ".ps1"
-
+        path = check_file_extension(path, ".ps1")
         args = f'-NoProfile -ExecutionPolicy bypass -File "{path}"'
         return self.execute(powershell, args, path)

--- a/analyzer/windows/modules/packages/Unpacker_regsvr.py
+++ b/analyzer/windows/modules/packages/Unpacker_regsvr.py
@@ -2,10 +2,8 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
-import os
-
 from lib.common.abstracts import Package
+from lib.common.common import check_file_extension
 
 
 class Unpacker_Regsvr(Package):
@@ -27,15 +25,10 @@ class Unpacker_Regsvr(Package):
         regsvr32 = self.get_path("regsvr32.exe")
         arguments = self.options.get("arguments")
 
-        # Check file extension.
-        ext = os.path.splitext(path)[-1].lower()
         # If the file doesn't have the proper .dll extension force it
         # and rename it. This is needed for rundll32 to execute correctly.
         # See ticket #354 for details.
-        if ext != ".dll":
-            new_path = f"{path}.dll"
-            os.rename(path, new_path)
-            path = new_path
+        path = check_file_extension(path, ".dll")
 
         args = path
         if arguments:

--- a/analyzer/windows/modules/packages/chm.py
+++ b/analyzer/windows/modules/packages/chm.py
@@ -2,10 +2,8 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
-import os
-
 from lib.common.abstracts import Package
+from lib.common.common import check_file_extension
 
 
 class CHM(Package):
@@ -17,14 +15,5 @@ class CHM(Package):
 
     def start(self, path):
         hh = self.get_path_glob("hh.exe")
-
-        # Check file extension.
-        ext = os.path.splitext(path)[-1].lower()
-        # If the file doesn't have the proper .chm extension force it
-        # and rename it. This is needed for hh to open correctly.
-        if ext != ".chm":
-            new_path = f"{path}.chm"
-            os.rename(path, new_path)
-            path = new_path
-
+        path = check_file_extension(path, ".chm")
         return self.execute(hh, f'"{path}"', path)

--- a/analyzer/windows/modules/packages/chrome.py
+++ b/analyzer/windows/modules/packages/chrome.py
@@ -2,8 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
-
 from lib.common.abstracts import Package
 
 

--- a/analyzer/windows/modules/packages/cpl.py
+++ b/analyzer/windows/modules/packages/cpl.py
@@ -2,8 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
-
 from lib.common.abstracts import Package
 
 

--- a/analyzer/windows/modules/packages/dll.py
+++ b/analyzer/windows/modules/packages/dll.py
@@ -7,6 +7,7 @@ import os
 import shutil
 
 from lib.common.abstracts import Package
+from lib.common.common import check_file_extension
 
 
 class Dll(Package):
@@ -22,15 +23,10 @@ class Dll(Package):
         arguments = self.options.get("arguments", "")
         dllloader = self.options.get("dllloader")
 
-        # Check file extension.
-        ext = os.path.splitext(path)[-1].lower()
         # If the file doesn't have the proper .dll extension force it
         # and rename it. This is needed for rundll32 to execute correctly.
         # See ticket #354 for details.
-        if ext != ".dll":
-            new_path = f"{path}.dll"
-            os.rename(path, new_path)
-            path = new_path
+        path = check_file_extension(path, ".dll")
 
         if dllloader:
             newname = os.path.join(os.path.dirname(rundll32), dllloader)

--- a/analyzer/windows/modules/packages/doc.py
+++ b/analyzer/windows/modules/packages/doc.py
@@ -2,10 +2,8 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
-import os
-
 from lib.common.abstracts import Package
+from lib.common.common import check_file_extension
 
 
 class DOC(Package):
@@ -24,9 +22,5 @@ class DOC(Package):
 
     def start(self, path):
         word = self.get_path_glob("Microsoft Office Word")
-        if "." not in os.path.basename(path):
-            new_path = f"{path}.doc"
-            os.rename(path, new_path)
-            path = new_path
-
+        path = check_file_extension(path, ".doc")
         return self.execute(word, f'"{path}" /q', path)

--- a/analyzer/windows/modules/packages/doc2016.py
+++ b/analyzer/windows/modules/packages/doc2016.py
@@ -2,10 +2,8 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
-import os
-
 from lib.common.abstracts import Package
+from lib.common.common import check_file_extension
 
 
 class DOC2016(Package):
@@ -21,9 +19,5 @@ class DOC2016(Package):
 
     def start(self, path):
         word = self.get_path_glob("Microsoft Office Word")
-        if "." not in os.path.basename(path):
-            new_path = f"{path}.doc"
-            os.rename(path, new_path)
-            path = new_path
-
+        path = check_file_extension(path, ".doc")
         return self.execute(word, f'"{path}" /q /dde /n', path)

--- a/analyzer/windows/modules/packages/eml.py
+++ b/analyzer/windows/modules/packages/eml.py
@@ -2,8 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
-
 from lib.common.abstracts import Package
 
 

--- a/analyzer/windows/modules/packages/exe.py
+++ b/analyzer/windows/modules/packages/exe.py
@@ -8,6 +8,7 @@ import shutil
 from subprocess import call
 
 from lib.common.abstracts import Package
+from lib.common.common import check_file_extension
 
 
 class Exe(Package):
@@ -22,10 +23,7 @@ class Exe(Package):
         # See CWinApp::SetCurrentHandles(), it will throw
         # an exception that will crash the app if it does
         # not find an extension on the main exe's filename
-        if "." not in os.path.basename(path):
-            new_path = f"{path}.exe"
-            os.rename(path, new_path)
-            path = new_path
+        path = check_file_extension(path, ".exe")
 
         if appdata:
             # run the executable from the APPDATA directory, required for some malware

--- a/analyzer/windows/modules/packages/firefox.py
+++ b/analyzer/windows/modules/packages/firefox.py
@@ -2,8 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
-
 from lib.common.abstracts import Package
 
 

--- a/analyzer/windows/modules/packages/generic.py
+++ b/analyzer/windows/modules/packages/generic.py
@@ -2,8 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
-
 from lib.common.abstracts import Package
 
 

--- a/analyzer/windows/modules/packages/hta.py
+++ b/analyzer/windows/modules/packages/hta.py
@@ -2,13 +2,8 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
-import logging
-import os
-
 from lib.common.abstracts import Package
-
-log = logging.getLogger(__name__)
+from lib.common.common import check_file_extension
 
 
 class HTA(Package):
@@ -20,9 +15,5 @@ class HTA(Package):
 
     def start(self, path):
         mshta = self.get_path("mshta.exe")
-
-        if not path.endswith(".hta"):
-            os.rename(path, f"{path}.hta")
-            path += ".hta"
-
+        path = check_file_extension(path, ".hta")
         return self.execute(mshta, f'"{path}"', path)

--- a/analyzer/windows/modules/packages/ichitaro.py
+++ b/analyzer/windows/modules/packages/ichitaro.py
@@ -13,9 +13,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
-
 from lib.common.abstracts import Package
+from lib.common.common import check_file_extension
 
 
 # While this should work, it is an experimental rule - do a PR if you see fit! Viewer only.
@@ -27,9 +26,5 @@ class ichitaro(Package):
     def start(self, path):
         ichitaro = self.get_path("TAROVIEW.EXE")
         # Rename file to file.inp so it can open properly.
-        ext = os.path.splitext(path)[-1].lower()
-        if ext != ".jtd":
-            new_path = f"{path}.jtd"
-            os.rename(path, new_path)
-            path = new_path
+        path = check_file_extension(path, ".jtd")
         return self.execute(ichitaro, f'"{path}"', path)

--- a/analyzer/windows/modules/packages/ie.py
+++ b/analyzer/windows/modules/packages/ie.py
@@ -2,8 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
-
 from lib.common.abstracts import Package
 
 

--- a/analyzer/windows/modules/packages/inp.py
+++ b/analyzer/windows/modules/packages/inp.py
@@ -13,9 +13,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
-
 from lib.common.abstracts import Package
+from lib.common.common import check_file_extension
 
 
 # While this should work, it is an experimental rule - do a PR if you see fit!
@@ -30,9 +29,5 @@ class INP(Package):
     def start(self, path):
         inp = self.get_path("Inpage.exe")
         # Rename file to file.inp so it can open properly.
-        ext = os.path.splitext(path)[-1].lower()
-        if ext != ".inp":
-            new_path = f"{path}.inp"
-            os.rename(path, new_path)
-            path = new_path
+        path = check_file_extension(path, ".inp")
         return self.execute(inp, f'"{path}"', path)

--- a/analyzer/windows/modules/packages/jar.py
+++ b/analyzer/windows/modules/packages/jar.py
@@ -2,8 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
-
 from lib.common.abstracts import Package
 
 

--- a/analyzer/windows/modules/packages/js.py
+++ b/analyzer/windows/modules/packages/js.py
@@ -19,7 +19,7 @@ class JS(Package):
         wscript = self.get_path("wscript.exe")
         args = f'"{path}"'
         ext = os.path.splitext(path)[-1].lower()
-        if ext != ".js" and ext != ".jse":
+        if ext not in (".js", ".jse"):
             if ext == ".jse" or (os.path.isfile(path) and "#@~^" == open(path, "rt").read(4)):
                 if ext != ".jse":
                     os.rename(path, f"{path}.jse")

--- a/analyzer/windows/modules/packages/js_antivm.py
+++ b/analyzer/windows/modules/packages/js_antivm.py
@@ -30,7 +30,7 @@ class JS_ANTIVM(Package):
         wscript = self.get_path("wscript.exe")
         args = f'"{path}"'
         ext = os.path.splitext(path)[-1].lower()
-        if ext != ".js" and ext != ".jse":
+        if ext not in (".js", ".jse"):
             if os.path.isfile(path) and "#@~^" == open(path, "rt").read(4):
                 os.rename(path, f"{path}.jse")
                 path = f"{path}.jse"

--- a/analyzer/windows/modules/packages/lnk.py
+++ b/analyzer/windows/modules/packages/lnk.py
@@ -2,10 +2,8 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
-import os
-
 from lib.common.abstracts import Package
+from lib.common.common import check_file_extension
 
 
 class LNK(Package):
@@ -16,11 +14,7 @@ class LNK(Package):
     ]
 
     def start(self, path):
-        if "." not in os.path.basename(path):
-            new_path = f"{path}.lnk"
-            os.rename(path, new_path)
-            path = new_path
-
+        path = check_file_extension(path, ".lnk")
         cmd_path = self.get_path("cmd.exe")
         cmd_args = f'/c start /wait "" "{path}"'
         return self.execute(cmd_path, cmd_args, path)

--- a/analyzer/windows/modules/packages/mht.py
+++ b/analyzer/windows/modules/packages/mht.py
@@ -2,13 +2,8 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
-import logging
-import shutil
-
 from lib.common.abstracts import Package
-
-log = logging.getLogger(__name__)
+from lib.common.common import check_file_extension
 
 
 class MHT(Package):
@@ -27,9 +22,5 @@ class MHT(Package):
         # IE is going to open it as a text file, so your precious sample will not
         # be executed.
         # We help you sample to execute renaming it with a proper extension.
-        if not path.endswith(".mht"):
-            shutil.copy(path, f"{path}.mht")
-            path += ".mht"
-            log.info("Submitted file is missing extension, adding .mht")
-
+        path = check_file_extension(path, ".mht")
         return self.execute(iexplore, f'"{path}"', path)

--- a/analyzer/windows/modules/packages/msbuild.py
+++ b/analyzer/windows/modules/packages/msbuild.py
@@ -1,8 +1,6 @@
 # This file is part of CAPE Sandbox - https://github.com/kevoreilly/CAPEv2
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
-
 from lib.common.abstracts import Package
 
 

--- a/analyzer/windows/modules/packages/msg.py
+++ b/analyzer/windows/modules/packages/msg.py
@@ -2,8 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
-
 from lib.common.abstracts import Package
 
 

--- a/analyzer/windows/modules/packages/msi.py
+++ b/analyzer/windows/modules/packages/msi.py
@@ -2,8 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
-
 from lib.common.abstracts import Package
 
 

--- a/analyzer/windows/modules/packages/nsis.py
+++ b/analyzer/windows/modules/packages/nsis.py
@@ -2,10 +2,8 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
-import os
-
 from lib.common.abstracts import Package
+from lib.common.common import check_file_extension
 
 
 class NSIS(Package):
@@ -18,10 +16,7 @@ class NSIS(Package):
     ]
 
     def start(self, path):
-        if "." not in os.path.basename(path):
-            new_path = f"{path}.exe"
-            os.rename(path, new_path)
-            path = new_path
+        path = check_file_extension(path, ".exe")
         cmd_path = self.get_path("cmd.exe")
         cmd_args = f'/c start /wait "" "{path}" /NCRC'
         return self.execute(cmd_path, cmd_args, path)

--- a/analyzer/windows/modules/packages/ollydbg.py
+++ b/analyzer/windows/modules/packages/ollydbg.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from lib.common.abstracts import Package
 
 

--- a/analyzer/windows/modules/packages/pdf.py
+++ b/analyzer/windows/modules/packages/pdf.py
@@ -2,8 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
-
 from lib.common.abstracts import Package
 
 

--- a/analyzer/windows/modules/packages/ppt.py
+++ b/analyzer/windows/modules/packages/ppt.py
@@ -2,8 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
-
 from lib.common.abstracts import Package
 
 

--- a/analyzer/windows/modules/packages/ppt2016.py
+++ b/analyzer/windows/modules/packages/ppt2016.py
@@ -2,8 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
-
 from lib.common.abstracts import Package
 
 

--- a/analyzer/windows/modules/packages/ps1.py
+++ b/analyzer/windows/modules/packages/ps1.py
@@ -2,10 +2,8 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
-import os
-
 from lib.common.abstracts import Package
+from lib.common.common import check_file_extension
 
 # Originally proposed by David Maciejak.
 
@@ -19,10 +17,6 @@ class PS1(Package):
 
     def start(self, path):
         powershell = self.get_path_glob("PowerShell")
-
-        if not path.endswith(".ps1"):
-            os.rename(path, f"{path}.ps1")
-            path += ".ps1"
-
+        path = check_file_extension(path, ".ps1")
         args = f'-NoProfile -ExecutionPolicy bypass -File "{path}"'
         return self.execute(powershell, args, path)

--- a/analyzer/windows/modules/packages/ps1_x64.py
+++ b/analyzer/windows/modules/packages/ps1_x64.py
@@ -2,10 +2,8 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
-import os
-
 from lib.common.abstracts import Package
+from lib.common.common import check_file_extension
 
 # Originally proposed by David Maciejak.
 
@@ -19,10 +17,6 @@ class PS1_x64(Package):
 
     def start(self, path):
         powershell = self.get_path_glob("PowerShell")
-
-        if not path.endswith(".ps1"):
-            os.rename(path, f"{path}.ps1")
-            path += ".ps1"
-
+        path = check_file_extension(path, ".ps1")
         args = f'-NoProfile -ExecutionPolicy bypass -File "{path}"'
         return self.execute(powershell, args, path)

--- a/analyzer/windows/modules/packages/pub.py
+++ b/analyzer/windows/modules/packages/pub.py
@@ -3,10 +3,10 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 from __future__ import absolute_import
-import os
 from winreg import HKEY_CURRENT_USER, KEY_READ, KEY_SET_VALUE, REG_DWORD, CreateKeyEx, EnumKey, OpenKey, QueryInfoKey, SetValueEx
 
 from lib.common.abstracts import Package
+from lib.common.common import check_file_extension
 
 
 class PUB(Package):
@@ -52,7 +52,5 @@ class PUB(Package):
     def start(self, path):
         self.set_keys()
         publisher = self.get_path_glob("Microsoft Office Publisher")
-        if not path.endswith(".pub"):
-            os.rename(path, f"{path}.pub")
-            path += ".pub"
+        path = check_file_extension(path, ".pub")
         return self.execute(publisher, f'"{path}"', path)

--- a/analyzer/windows/modules/packages/pub2016.py
+++ b/analyzer/windows/modules/packages/pub2016.py
@@ -3,10 +3,10 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 from __future__ import absolute_import
-import os
 from winreg import HKEY_CURRENT_USER, KEY_READ, KEY_SET_VALUE, REG_DWORD, CreateKeyEx, EnumKey, OpenKey, QueryInfoKey, SetValueEx
 
 from lib.common.abstracts import Package
+from lib.common.common import check_file_extension
 
 
 class PUB2007(Package):
@@ -48,7 +48,5 @@ class PUB2007(Package):
     def start(self, path):
         self.set_keys()
         publisher = self.get_path_glob("Microsoft Office Publisher")
-        if not path.endswith(".pub"):
-            os.rename(path, f"{path}.pub")
-            path += ".pub"
+        path = check_file_extension(path, ".pub")
         return self.execute(publisher, f'"{path}"', path)

--- a/analyzer/windows/modules/packages/python.py
+++ b/analyzer/windows/modules/packages/python.py
@@ -2,8 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
-
 from lib.common.abstracts import Package
 
 

--- a/analyzer/windows/modules/packages/rar.py
+++ b/analyzer/windows/modules/packages/rar.py
@@ -16,6 +16,7 @@ except ImportError:
 
 from lib.common.abstracts import Package
 from lib.common.exceptions import CuckooPackageError
+from lib.common.common import check_file_extension
 
 log = logging.getLogger(__name__)
 
@@ -90,11 +91,7 @@ class Rar(Package):
             raise CuckooPackageError("rarfile Python module not installed in guest")
 
         # Check file extension.
-        ext = os.path.splitext(path)[-1].lower()
-        if ext != ".rar":
-            new_path = f"{path}.rar"
-            os.rename(path, new_path)
-            path = new_path
+        path = check_file_extension(path, ".rar")
 
         root = os.environ["TEMP"]
         password = self.options.get("password")

--- a/analyzer/windows/modules/packages/reg.py
+++ b/analyzer/windows/modules/packages/reg.py
@@ -2,8 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
-
 from lib.common.abstracts import Package
 
 

--- a/analyzer/windows/modules/packages/regsvr.py
+++ b/analyzer/windows/modules/packages/regsvr.py
@@ -2,10 +2,8 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
-import os
-
 from lib.common.abstracts import Package
+from lib.common.common import check_file_extension
 
 
 class Regsvr(Package):
@@ -19,15 +17,10 @@ class Regsvr(Package):
         regsvr32 = self.get_path("regsvr32.exe")
         arguments = self.options.get("arguments")
 
-        # Check file extension.
-        ext = os.path.splitext(path)[-1].lower()
         # If the file doesn't have the proper .dll extension force it
         # and rename it. This is needed for rundll32 to execute correctly.
         # See ticket #354 for details.
-        if ext != ".dll":
-            new_path = f"{path}.dll"
-            os.rename(path, new_path)
-            path = new_path
+        path = check_file_extension(path, ".dll")
 
         args = ""
         if arguments:

--- a/analyzer/windows/modules/packages/sct.py
+++ b/analyzer/windows/modules/packages/sct.py
@@ -1,8 +1,6 @@
 # This file is part of CAPE Sandbox - https://github.com/kevoreilly/CAPE
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
-
 from lib.common.abstracts import Package
 
 
@@ -16,5 +14,4 @@ class SCT(Package):
     def start(self, path):
         regsvr32 = self.get_path("regsvr32.exe")
         args = f"/u /n /i:{path} scrobj.dll"
-
         return self.execute(regsvr32, args, path)

--- a/analyzer/windows/modules/packages/service.py
+++ b/analyzer/windows/modules/packages/service.py
@@ -5,11 +5,11 @@
 from __future__ import absolute_import
 import ctypes
 import logging
-import os
 import sys
 
 from lib.api.process import Process
 from lib.common.abstracts import Package
+from lib.common.common import check_file_extension
 from lib.common.defines import ADVAPI32, KERNEL32
 
 INJECT_CREATEREMOTETHREAD = 0
@@ -67,10 +67,7 @@ class Service(Package):
             servicename = self.options.get("servicename", "CAPEService")
             servicedesc = self.options.get("servicedesc", "CAPE Service")
             arguments = self.options.get("arguments")
-            if "." not in os.path.basename(path):
-                new_path = f"{path}.exe"
-                os.rename(path, new_path)
-                path = new_path
+            path = check_file_extension(path, ".exe")
             binPath = f'"{path}"'
             if arguments:
                 binPath += f" {arguments}"

--- a/analyzer/windows/modules/packages/swf.py
+++ b/analyzer/windows/modules/packages/swf.py
@@ -2,8 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
-
 from lib.common.abstracts import Package
 
 

--- a/analyzer/windows/modules/packages/vawtrak.py
+++ b/analyzer/windows/modules/packages/vawtrak.py
@@ -6,6 +6,7 @@ import shutil
 from subprocess import call
 
 from lib.common.abstracts import Package
+from lib.common.common import check_file_extension
 
 
 class IE(Package):
@@ -28,10 +29,7 @@ class IE(Package):
         # See CWinApp::SetCurrentHandles(), it will throw
         # an exception that will crash the app if it does
         # not find an extension on the main exe's filename
-        if "." not in os.path.basename(path):
-            new_path = f"{path}.exe"
-            os.rename(path, new_path)
-            path = new_path
+        path = check_file_extension(path, ".exe")
 
         if appdata:
             # run the executable from the APPDATA directory, required for some malware

--- a/analyzer/windows/modules/packages/vbs.py
+++ b/analyzer/windows/modules/packages/vbs.py
@@ -26,7 +26,9 @@ class VBS(Package):
         # and rename it. This is needed for wscript to execute correctly.
         ext = os.path.splitext(path)[-1].lower()
         if ext not in (".vbs", ".vbe"):
-            if os.path.isfile(path) and b"#@~^" in open(path, "rb").read(100):
+            with open("path", "r") as tmpfile:
+                magic_bytes = tmpfile.read(4)
+            if magic_bytes == "#@~^":
                 os.rename(path, f"{path}.vbe")
                 path = f"{path}.vbe"
             else:

--- a/analyzer/windows/modules/packages/vbs.py
+++ b/analyzer/windows/modules/packages/vbs.py
@@ -25,7 +25,7 @@ class VBS(Package):
         # If the file doesn't have the proper .vbs extension force it
         # and rename it. This is needed for wscript to execute correctly.
         ext = os.path.splitext(path)[-1].lower()
-        if ext != ".vbs" and ext != ".vbe":
+        if ext not in (".vbs", ".vbe"):
             if os.path.isfile(path) and b"#@~^" in open(path, "rb").read(100):
                 os.rename(path, f"{path}.vbe")
                 path = f"{path}.vbe"

--- a/analyzer/windows/modules/packages/wsf.py
+++ b/analyzer/windows/modules/packages/wsf.py
@@ -2,13 +2,8 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
-import logging
-import os
-
 from lib.common.abstracts import Package
-
-log = logging.getLogger(__name__)
+from lib.common.common import check_file_extension
 
 
 class WSF(Package):
@@ -20,10 +15,6 @@ class WSF(Package):
 
     def start(self, path):
         wscript = self.get_path("WScript")
-
         # Enforce the .wsf file extension as is required by wscript.
-        if not path.endswith(".wsf"):
-            os.rename(path, f"{path}.wsf")
-            path += ".wsf"
-
+        path = check_file_extension(path, ".wsf")
         return self.execute(wscript, f'"{path}"', path)

--- a/analyzer/windows/modules/packages/xls.py
+++ b/analyzer/windows/modules/packages/xls.py
@@ -2,10 +2,8 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
-import os
-
 from lib.common.abstracts import Package
+from lib.common.common import check_file_extension
 
 
 class XLS(Package):
@@ -22,10 +20,6 @@ class XLS(Package):
     ]
 
     def start(self, path):
-        if "." not in os.path.basename(path):
-            new_path = f"{path}.xls"
-            os.rename(path, new_path)
-            path = new_path
-
+        path = check_file_extension(path, ".xls")
         excel = self.get_path_glob("Microsoft Office Excel")
         return self.execute(excel, f'"{path}" /dde', path)

--- a/analyzer/windows/modules/packages/xls2016.py
+++ b/analyzer/windows/modules/packages/xls2016.py
@@ -2,10 +2,8 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
-import os
-
 from lib.common.abstracts import Package
+from lib.common.common import check_file_extension
 
 
 class XLS2207(Package):
@@ -20,10 +18,6 @@ class XLS2207(Package):
     ]
 
     def start(self, path):
-        if "." not in os.path.basename(path):
-            new_path = f"{path}.xls"
-            os.rename(path, new_path)
-            path = new_path
-
+        path = check_file_extension(path, ".xls")
         excel = self.get_path_glob("Microsoft Office Excel")
         return self.execute(excel, f'"{path}" /dde', path)

--- a/analyzer/windows/modules/packages/xlst.py
+++ b/analyzer/windows/modules/packages/xlst.py
@@ -2,13 +2,8 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
-import logging
-import os
-
 from lib.common.abstracts import Package
-
-log = logging.getLogger(__name__)
+from lib.common.common import check_file_extension
 
 
 class XLST(Package):
@@ -21,9 +16,5 @@ class XLST(Package):
 
     def start(self, path):
         wmic = self.get_path("wmic.exe")
-
-        if not path.endswith(".xsl"):
-            os.rename(path, f"{path}.xsl")
-            path += ".xsl"
-
+        path = check_file_extension(path, ".xsl")
         return self.execute(wmic, f'process LIST /FORMAT:"{path}"', path)

--- a/analyzer/windows/modules/packages/xps.py
+++ b/analyzer/windows/modules/packages/xps.py
@@ -2,8 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
-
 from lib.common.abstracts import Package
 
 

--- a/analyzer/windows/modules/packages/zip.py
+++ b/analyzer/windows/modules/packages/zip.py
@@ -15,6 +15,7 @@ except ImportError:
 
 from lib.common.abstracts import Package
 from lib.common.exceptions import CuckooPackageError
+from lib.common.common import check_file_extension
 
 log = logging.getLogger(__name__)
 
@@ -176,8 +177,5 @@ class Zip(Package):
             args = f'-NoProfile -ExecutionPolicy bypass -File "{path}"'
             return self.execute(powershell, args, file_path)
         else:
-            if "." not in os.path.basename(file_path):
-                new_path = f"{file_path}.exe"
-                os.rename(file_path, new_path)
-                file_path = new_path
+            path = check_file_extension(path, ".exe")
             return self.execute(file_path, self.options.get("arguments"), file_path)


### PR DESCRIPTION
Summary of changes:

1. Remove unnecessary `from __future__ import absolute_import`
2. Move adding of file_extensions to `common.py` to reduce code duplication