### PR TITLE
Logging and print cleanup for lib/cuckoo/core

### DIFF
--- a/lib/cuckoo/core/database.py
+++ b/lib/cuckoo/core/database.py
@@ -598,9 +598,7 @@ class Database(object, metaclass=Singleton):
                 self.engine = create_engine(connection_string)
         except ImportError as e:
             lib = e.message.split()[-1]
-            raise CuckooDependencyError(
-                f"Missing database driver, unable to import {lib} (install with `pip install {lib}`)"
-            )
+            raise CuckooDependencyError(f"Missing database driver, unable to import {lib} (install with `pip install {lib}`)")
 
     def _get_or_create(self, session, model, **kwargs):
         """Get an ORM instance or create it if not exist.

--- a/lib/cuckoo/core/database.py
+++ b/lib/cuckoo/core/database.py
@@ -190,7 +190,7 @@ class Machine(Base):
     resultserver_port = Column(String(255), nullable=False)
 
     def __repr__(self):
-        return "<Machine('{0}','{1}')>".format(self.id, self.name)
+        return f"<Machine('{self.id}','{self.name}')>"
 
     def to_dict(self):
         """Converts object to dict.
@@ -235,7 +235,7 @@ class Tag(Base):
     name = Column(String(255), nullable=False, unique=True)
 
     def __repr__(self):
-        return "<Tag('{0}','{1}')>".format(self.id, self.name)
+        return f"<Tag('{self.id}','{self.name}')>"
 
     def __init__(self, name):
         self.name = name
@@ -256,7 +256,7 @@ class Guest(Base):
     task_id = Column(Integer, ForeignKey("tasks.id"), nullable=False, unique=True)
 
     def __repr__(self):
-        return "<Guest('{0}','{1}')>".format(self.id, self.name)
+        return f"<Guest('{self.id}','{self.name}')>"
 
     def to_dict(self):
         """Converts object to dict.
@@ -306,7 +306,7 @@ class Sample(Base):
     )
 
     def __repr__(self):
-        return "<Sample('{0}','{1}')>".format(self.id, self.sha256)
+        return f"<Sample('{self.id}','{self.sha256}')>"
 
     def to_dict(self):
         """Converts object to dict.
@@ -369,7 +369,7 @@ class Error(Base):
         self.task_id = task_id
 
     def __repr__(self):
-        return "<Error('{0}','{1}','{2}')>".format(self.id, self.message, self.task_id)
+        return f"<Error('{self.id}','{self.message}','{self.task_id}')>"
 
 
 class Task(Base):
@@ -489,7 +489,7 @@ class Task(Base):
         self.target = target
 
     def __repr__(self):
-        return "<Task('{0}','{1}')>".format(self.id, self.target)
+        return f"<Task('{self.id}','{self.target}')>"
 
 
 class AlembicVersion(Base):
@@ -526,9 +526,9 @@ class Database(object, metaclass=Singleton):
                     try:
                         create_folder(folder=db_dir)
                     except CuckooOperationalError as e:
-                        raise CuckooDatabaseError("Unable to create database directory: {0}".format(e))
+                        raise CuckooDatabaseError(f"Unable to create database directory: {e}")
 
-            self._connect_database("sqlite:///%s" % db_file)
+            self._connect_database(f"sqlite:///{db_file}")
 
         # Disable SQL logging. Turn it on for debugging.
         self.engine.echo = False
@@ -541,7 +541,7 @@ class Database(object, metaclass=Singleton):
         try:
             Base.metadata.create_all(self.engine)
         except SQLAlchemyError as e:
-            raise CuckooDatabaseError("Unable to create or connect to database: {0}".format(e))
+            raise CuckooDatabaseError(f"Unable to create or connect to database: {e}")
 
         # Get db session.
         self.Session = sessionmaker(bind=self.engine)
@@ -560,7 +560,7 @@ class Database(object, metaclass=Singleton):
                 tmp_session.commit()
             except SQLAlchemyError as e:
                 tmp_session.rollback()
-                raise CuckooDatabaseError("Unable to set schema version: {0}".format(e))
+                raise CuckooDatabaseError(f"Unable to set schema version: {e}")
             finally:
                 tmp_session.close()
         else:
@@ -569,9 +569,7 @@ class Database(object, metaclass=Singleton):
             tmp_session.close()
             if last.version_num != SCHEMA_VERSION and schema_check:
                 print(
-                    "DB schema version mismatch: found {0}, expected {1}. Try to apply all migrations".format(
-                        last.version_num, SCHEMA_VERSION
-                    )
+                    f"DB schema version mismatch: found {last.version_num}, expected {SCHEMA_VERSION}. Try to apply all migrations"
                 )
                 print(red("cd utils/db_migration/ && alembic upgrade head"))
                 sys.exit()
@@ -601,7 +599,7 @@ class Database(object, metaclass=Singleton):
         except ImportError as e:
             lib = e.message.split()[-1]
             raise CuckooDependencyError(
-                "Missing database driver, unable to " "import %s (install with `pip " "install %s`)" % (lib, lib)
+                f"Missing database driver, unable to import {lib} (install with `pip install {lib}`)"
             )
 
     def _get_or_create(self, session, model, **kwargs):
@@ -623,7 +621,7 @@ class Database(object, metaclass=Singleton):
         try:
             Base.metadata.drop_all(self.engine)
         except SQLAlchemyError as e:
-            raise CuckooDatabaseError("Unable to create or connect to database: {0}".format(e))
+            raise CuckooDatabaseError(f"Unable to create or connect to database: {e}")
 
     @classlock
     def clean_machines(self):
@@ -637,7 +635,7 @@ class Database(object, metaclass=Singleton):
             session.query(Machine).delete()
             session.commit()
         except SQLAlchemyError as e:
-            log.debug("Database error cleaning machines: {0}".format(e))
+            log.debug("Database error cleaning machines: %s", e)
             session.rollback()
         finally:
             session.close()
@@ -653,7 +651,7 @@ class Database(object, metaclass=Singleton):
             session.commit()
             return "success"
         except SQLAlchemyError as e:
-            log.info("Database error deleting machine: {0}".format(e))
+            log.info("Database error deleting machine: %s", e)
             session.rollback()
         finally:
             session.close()
@@ -693,7 +691,7 @@ class Database(object, metaclass=Singleton):
         try:
             session.commit()
         except SQLAlchemyError as e:
-            log.debug("Database error adding machine: {0}".format(e))
+            log.debug("Database error adding machine: %s", e)
             session.rollback()
         finally:
             session.close()
@@ -704,13 +702,13 @@ class Database(object, metaclass=Singleton):
         try:
             machine = session.query(Machine).filter_by(label=label).first()
             if machine is None:
-                log.debug("Database error setting interface: {0} not found".format(label))
+                log.debug("Database error setting interface: %s not found", label)
                 return None
             machine.interface = interface
             session.commit()
 
         except SQLAlchemyError as e:
-            log.debug("Database error setting interface: {0}".format(e))
+            log.debug("Database error setting interface: %s", e)
             session.rollback()
         finally:
             session.close()
@@ -732,7 +730,7 @@ class Database(object, metaclass=Singleton):
                 session.commit()
             return row.clock
         except SQLAlchemyError as e:
-            log.debug("Database error setting clock: {0}".format(e))
+            log.debug("Database error setting clock: %s", e)
             session.rollback()
         finally:
             session.close()
@@ -761,7 +759,7 @@ class Database(object, metaclass=Singleton):
 
             session.commit()
         except SQLAlchemyError as e:
-            log.debug("Database error setting status: {0}".format(e))
+            log.debug("Database error setting status: %s", e)
             session.rollback()
         finally:
             session.close()
@@ -784,7 +782,7 @@ class Database(object, metaclass=Singleton):
             row.machine_id = vm_id
             session.commit()
         except SQLAlchemyError as e:
-            log.debug("Database error setting status: {0}".format(e))
+            log.debug("Database error setting status: %s", e)
             session.rollback()
         finally:
             session.close()
@@ -827,7 +825,7 @@ class Database(object, metaclass=Singleton):
 
             return row
         except SQLAlchemyError as e:
-            log.debug("Database error fetching task: {0}".format(e))
+            log.debug("Database error fetching task: %s", e)
             log.debug(red("Ensure that your database schema version is correct"))
             session.rollback()
         finally:
@@ -851,7 +849,7 @@ class Database(object, metaclass=Singleton):
             session.refresh(guest)
             return guest.id
         except SQLAlchemyError as e:
-            log.debug("Database error logging guest start: {0}".format(e))
+            log.debug("Database error logging guest start: %s", e)
             session.rollback()
             return None
         finally:
@@ -868,7 +866,7 @@ class Database(object, metaclass=Singleton):
             guest = session.query(Guest).filter_by(task_id=task_id).first()
             return guest.status if guest else None
         except SQLAlchemyError as e:
-            log.exception("Database error logging guest start: {0}".format(e))
+            log.exception("Database error logging guest start: %s", e)
             session.rollback()
             return
         finally:
@@ -888,7 +886,7 @@ class Database(object, metaclass=Singleton):
                 session.commit()
                 session.refresh(guest)
         except SQLAlchemyError as e:
-            log.exception("Database error logging guest start: {0}".format(e))
+            log.exception("Database error logging guest start: %s", e)
             session.rollback()
             return None
         finally:
@@ -903,7 +901,7 @@ class Database(object, metaclass=Singleton):
             session.delete(guest)
             session.commit()
         except SQLAlchemyError as e:
-            log.debug("Database error logging guest remove: {0}".format(e))
+            log.debug("Database error logging guest remove: %s", e)
             session.rollback()
             return None
         finally:
@@ -919,7 +917,7 @@ class Database(object, metaclass=Singleton):
             session.query(Guest).get(guest_id).shutdown_on = datetime.now()
             session.commit()
         except SQLAlchemyError as e:
-            log.debug("Database error logging guest stop: {0}".format(e))
+            log.debug("Database error logging guest stop: %s", e)
             session.rollback()
         except TypeError:
             log.warning("Data inconsistency in guests table detected, it might be a crash leftover. Continue")
@@ -944,7 +942,7 @@ class Database(object, metaclass=Singleton):
                 machines = [machine for tag in tags for machine in machines if tag in machine.to_dict()["tags"]]
             return machines
         except SQLAlchemyError as e:
-            log.debug("Database error listing machines: {0}".format(e))
+            log.debug("Database error listing machines: %s", e)
             return []
         finally:
             session.close()
@@ -962,12 +960,12 @@ class Database(object, metaclass=Singleton):
         # Preventive checks.
         if label and platform:
             # Wrong usage.
-            log.error("You can select machine only by label or by platform.")
+            log.error("You can select machine only by label or by platform")
             session.close()
             return None
         elif label and tags:
             # Also wrong usage.
-            log.error("You can select machine only by label or by tags.")
+            log.error("You can select machine only by label or by tags")
             session.close()
             return None
 
@@ -985,12 +983,12 @@ class Database(object, metaclass=Singleton):
             # selection requirements.
             if not machines.count():
                 session.close()
-                raise CuckooOperationalError("No machines match selection criteria.")
+                raise CuckooOperationalError("No machines match selection criteria")
 
             # Get the first free machine.
             machine = machines.filter_by(locked=False).first()
         except SQLAlchemyError as e:
-            log.debug("Database error locking machine: {0}".format(e))
+            log.debug("Database error locking machine: %s", e)
             session.close()
             return None
 
@@ -1001,7 +999,7 @@ class Database(object, metaclass=Singleton):
                 session.commit()
                 session.refresh(machine)
             except SQLAlchemyError as e:
-                log.debug("Database error locking machine: {0}".format(e))
+                log.debug("Database error locking machine: %s", e)
                 session.rollback()
                 return None
             finally:
@@ -1021,7 +1019,7 @@ class Database(object, metaclass=Singleton):
         try:
             machine = session.query(Machine).filter_by(label=label).first()
         except SQLAlchemyError as e:
-            log.debug("Database error unlocking machine: {0}".format(e))
+            log.debug("Database error unlocking machine: %s", e)
             session.close()
             return None
 
@@ -1032,7 +1030,7 @@ class Database(object, metaclass=Singleton):
                 session.commit()
                 session.refresh(machine)
             except SQLAlchemyError as e:
-                log.debug("Database error locking machine: {0}".format(e))
+                log.debug("Database error locking machine: %s", e)
                 session.rollback()
                 return None
             finally:
@@ -1052,7 +1050,7 @@ class Database(object, metaclass=Singleton):
             machines_count = session.query(Machine).filter_by(locked=False).count()
             return machines_count
         except SQLAlchemyError as e:
-            log.debug("Database error counting machines: {0}".format(e))
+            log.debug("Database error counting machines: %s", e)
             return 0
         finally:
             session.close()
@@ -1067,7 +1065,7 @@ class Database(object, metaclass=Singleton):
             machines = session.query(Machine).filter_by(locked=False).all()
             return machines
         except SQLAlchemyError as e:
-            log.debug("Database error getting available machines: {0}".format(e))
+            log.debug("Database error getting available machines: %s", e)
             return []
         finally:
             session.close()
@@ -1082,7 +1080,7 @@ class Database(object, metaclass=Singleton):
         try:
             machine = session.query(Machine).filter_by(label=label).first()
         except SQLAlchemyError as e:
-            log.debug("Database error setting machine status: {0}".format(e))
+            log.debug("Database error setting machine status: %s", e)
             session.close()
             return
 
@@ -1093,7 +1091,7 @@ class Database(object, metaclass=Singleton):
                 session.commit()
                 session.refresh(machine)
             except SQLAlchemyError as e:
-                log.debug("Database error setting machine status: {0}".format(e))
+                log.debug("Database error setting machine status: %s", e)
                 session.rollback()
             finally:
                 session.close()
@@ -1112,7 +1110,7 @@ class Database(object, metaclass=Singleton):
         try:
             session.commit()
         except SQLAlchemyError as e:
-            log.debug("Database error adding error log: {0}".format(e))
+            log.debug("Database error adding error log: %s", e)
             session.rollback()
         finally:
             session.close()
@@ -1132,7 +1130,7 @@ class Database(object, metaclass=Singleton):
             try:
                 sample = session.query(Sample).filter_by(md5=file_md5).first()
             except SQLAlchemyError as e:
-                log.debug("Error querying sample for hash: {0}".format(e))
+                log.debug("Error querying sample for hash: %s", e)
 
             if not sample:
                 sample = Sample(
@@ -1156,11 +1154,11 @@ class Database(object, metaclass=Singleton):
                 try:
                     sample = session.query(Sample).filter_by(md5=file_md5).first()
                 except SQLAlchemyError as e:
-                    log.debug("Error querying sample for hash: {0}".format(e))
+                    log.debug("Error querying sample for hash: %s", e)
                     session.close()
                     return None
             except SQLAlchemyError as e:
-                log.debug("Database error adding task: {0}".format(e))
+                log.debug("Database error adding task: %s", e)
                 session.close()
                 return None
             finally:
@@ -1242,7 +1240,7 @@ class Database(object, metaclass=Singleton):
             try:
                 sample = session.query(Sample).filter_by(md5=file_md5).first()
             except SQLAlchemyError as e:
-                log.debug("Error querying sample for hash: {0}".format(e))
+                log.debug("Error querying sample for hash: %s", e)
 
             if not sample:
                 sample = Sample(
@@ -1267,12 +1265,12 @@ class Database(object, metaclass=Singleton):
                 try:
                     sample = session.query(Sample).filter_by(md5=file_md5).first()
                 except SQLAlchemyError as e:
-                    log.debug("Error querying sample for hash: {0}".format(e))
+                    log.debug("Error querying sample for hash: %s", e)
                     session.close()
                     return None
                 """
             except SQLAlchemyError as e:
-                log.debug("Database error adding task: {0}".format(e))
+                log.debug("Database error adding task: %s", e)
                 session.close()
                 return None
 
@@ -1340,7 +1338,7 @@ class Database(object, metaclass=Singleton):
                 try:
                     task.clock = datetime.strptime(clock, "%m-%d-%Y %H:%M:%S")
                 except ValueError:
-                    log.warning("The date you specified has an invalid format, using current timestamp.")
+                    log.warning("The date you specified has an invalid format, using current timestamp")
                     task.clock = datetime.utcfromtimestamp(0)
 
             else:
@@ -1357,7 +1355,7 @@ class Database(object, metaclass=Singleton):
             session.commit()
             task_id = task.id
         except SQLAlchemyError as e:
-            log.debug("Database error adding task: {0}".format(e))
+            log.debug("Database error adding task: %s", e)
             session.rollback()
             return None
         finally:
@@ -1418,7 +1416,7 @@ class Database(object, metaclass=Singleton):
         @return: cursor or None.
         """
         if not file_path or not os.path.exists(file_path):
-            log.warning("File does not exist: %s.", file_path)
+            log.warning("File does not exist: %s", file_path)
             return None
 
         # Convert empty strings and None values to a valid int
@@ -1539,7 +1537,7 @@ class Database(object, metaclass=Singleton):
                     if tmp_package and tmp_package in sandbox_packages:
                         package = tmp_package
                     else:
-                        log.info("Does sandbox packages need an update? Sflock identifies as: {} - {}".format(tmp_package, file))
+                        log.info("Does sandbox packages need an update? Sflock identifies as: %s - %s", tmp_package, file)
                     del f
 
                 if package == "dll":
@@ -1813,7 +1811,7 @@ class Database(object, metaclass=Singleton):
         try:
             session.commit()
         except SQLAlchemyError as e:
-            log.debug("Database error rescheduling task: {0}".format(e))
+            log.debug("Database error rescheduling task: %s", e)
             session.rollback()
             return False
         finally:
@@ -1863,7 +1861,7 @@ class Database(object, metaclass=Singleton):
             tasks = search.count()
             return tasks
         except SQLAlchemyError as e:
-            log.debug("Database error counting tasks: {0}".format(e))
+            log.debug("Database error counting tasks: %s", e)
             return []
         finally:
             session.close()
@@ -1888,7 +1886,7 @@ class Database(object, metaclass=Singleton):
                 else:
                     uniq = True
         except SQLAlchemyError as e:
-            log.debug("Database error counting tasks: {0}".format(e))
+            log.debug("Database error counting tasks: %s", e)
         finally:
             session.close()
 
@@ -1908,7 +1906,7 @@ class Database(object, metaclass=Singleton):
             else:
                 return []
         except SQLAlchemyError as e:
-            log.debug("Database error listing tasks: {0}".format(e))
+            log.debug("Database error listing tasks: %s", e)
             return []
         finally:
             session.close()
@@ -1940,7 +1938,7 @@ class Database(object, metaclass=Singleton):
                 parent_sample = session.query(Sample).filter(Sample.id == parent).first().to_dict()
 
         except SQLAlchemyError as e:
-            log.debug("Database error listing tasks: {0}".format(e))
+            log.debug("Database error listing tasks: %s", e)
         except TypeError:
             pass
         finally:
@@ -2011,9 +2009,9 @@ class Database(object, metaclass=Singleton):
             if added_before:
                 search = search.filter(Task.added_on < added_before)
             if options_like:
-                search = search.filter(Task.options.like("%{}%".format(options_like)))
+                search = search.filter(Task.options.like(f"%{options_like}%"))
             if tags_tasks_like:
-                search = search.filter(Task.tags_tasks.like("%{}%".format(tags_tasks_like)))
+                search = search.filter(Task.tags_tasks.like(f"%{tags_tasks_like}%"))
             if task_ids:
                 search = search.filter(Task.id.in_(task_ids))
             if order_by is not None:
@@ -2026,12 +2024,12 @@ class Database(object, metaclass=Singleton):
             return tasks
         except RuntimeError as e:
             # RuntimeError: number of values in row (1) differ from number of column processors (62)
-            log.debug("Database RuntimeError error: {e}")
+            log.debug(f"Database RuntimeError error: {e}")
         except AttributeError as e:
             # '_NoResultMetaData' object has no attribute '_indexes_for_keys'
-            log.debug("Database AttributeError error: {e}")
+            log.debug(f"Database AttributeError error: {e}")
         except SQLAlchemyError as e:
-            log.debug("Database error listing tasks: {0}".format(e))
+            log.debug("Database error listing tasks: %s", e)
         except Exception as e:
             # psycopg2.DatabaseError
             log.exception(e)
@@ -2050,7 +2048,7 @@ class Database(object, metaclass=Singleton):
             _max = session.query(func.max(Task.completed_on).label("max")).first()
             return int(_min[0].strftime("%s")), int(_max[0].strftime("%s"))
         except SQLAlchemyError as e:
-            log.debug("Database error counting tasks: {0}".format(e))
+            log.debug("Database error counting tasks: %s", e)
             return 0
         finally:
             session.close()
@@ -2068,7 +2066,7 @@ class Database(object, metaclass=Singleton):
             else:
                 return []
         except SQLAlchemyError as e:
-            log.debug("Database error listing tasks: {0}".format(e))
+            log.debug("Database error listing tasks: %s", e)
             return []
         finally:
             session.close()
@@ -2087,7 +2085,7 @@ class Database(object, metaclass=Singleton):
                 res.append(asample[0])
             res.sort()
         except SQLAlchemyError as e:
-            log.debug("Database error getting file_types: {0}".format(e))
+            log.debug("Database error getting file_types: %s", e)
             return 0
         finally:
             session.close()
@@ -2103,7 +2101,7 @@ class Database(object, metaclass=Singleton):
             tasks_dict_count = session.query(Task.status, func.count(Task.status)).group_by(Task.status).all()
             return dict(tasks_dict_count)
         except SQLAlchemyError as e:
-            log.debug("Database error counting all tasks: {0}".format(e))
+            log.debug("Database error counting all tasks: %s", e)
             return 0
         finally:
             session.close()
@@ -2125,7 +2123,7 @@ class Database(object, metaclass=Singleton):
             tasks_count = unfiltered.count()
             return tasks_count
         except SQLAlchemyError as e:
-            log.debug("Database error counting tasks: {0}".format(e))
+            log.debug("Database error counting tasks: %s", e)
             return 0
         finally:
             session.close()
@@ -2143,7 +2141,7 @@ class Database(object, metaclass=Singleton):
             else:
                 task = session.query(Task).get(task_id)
         except SQLAlchemyError as e:
-            log.debug("Database error viewing task: {0}".format(e))
+            log.debug("Database error viewing task: %s", e)
             return None
         else:
             if task:
@@ -2164,7 +2162,7 @@ class Database(object, metaclass=Singleton):
             session.delete(task)
             session.commit()
         except SQLAlchemyError as e:
-            log.debug("Database error deleting task: {0}".format(e))
+            log.debug("Database error deleting task: %s", e)
             session.rollback()
             return False
         finally:
@@ -2177,7 +2175,7 @@ class Database(object, metaclass=Singleton):
         try:
             search = session.query(Task).filter(Task.id.in_(ids)).delete(synchronize_session=False)
         except SQLAlchemyError as e:
-            log.debug("Database error deleting task: {0}".format(e))
+            log.debug("Database error deleting task: %s", e)
             session.rollback()
             return False
         finally:
@@ -2196,7 +2194,7 @@ class Database(object, metaclass=Singleton):
         except AttributeError:
             return None
         except SQLAlchemyError as e:
-            log.debug("Database error viewing task: {0}".format(e))
+            log.debug("Database error viewing task: %s", e)
             return None
         else:
             if sample:
@@ -2227,7 +2225,7 @@ class Database(object, metaclass=Singleton):
             elif parent:
                 sample = session.query(Sample).filter_by(parent=parent).all()
         except SQLAlchemyError as e:
-            log.debug("Database error searching sample: {0}".format(e))
+            log.debug("Database error searching sample: %s", e)
             return None
         else:
             if sample:
@@ -2277,7 +2275,7 @@ class Database(object, metaclass=Singleton):
 
                 if sample is None:
                     tasks = results_db.analysis.find(
-                        {"CAPE.payloads." + sizes_mongo.get(len(sample_hash), ""): sample_hash},
+                        {f"CAPE.payloads.{sizes_mongo.get(len(sample_hash), '')}": sample_hash},
                         {"CAPE.payloads": 1, "_id": 0, "info.id": 1},
                     )
                     if tasks:
@@ -2301,7 +2299,7 @@ class Database(object, metaclass=Singleton):
                     for category in ("dropped", "procdump"):
                         # we can't filter more if query isn't sha256
                         tasks = results_db.analysis.find(
-                            {category + "." + sizes_mongo.get(len(sample_hash), ""): sample_hash},
+                            {f"{category}.{sizes_mongo.get(len(sample_hash), '')}": sample_hash},
                             {category: 1, "_id": 0, "info.id": 1},
                         )
                         if tasks:
@@ -2352,7 +2350,7 @@ class Database(object, metaclass=Singleton):
             except AttributeError:
                 pass
             except SQLAlchemyError as e:
-                log.debug("Database error viewing task: {0}".format(e))
+                log.debug("Database error viewing task: %s", e)
             finally:
                 session.close()
 
@@ -2365,7 +2363,7 @@ class Database(object, metaclass=Singleton):
         try:
             sample_count = session.query(Sample).count()
         except SQLAlchemyError as e:
-            log.debug("Database error counting samples: {0}".format(e))
+            log.debug("Database error counting samples: %s", e)
             return 0
         finally:
             session.close()
@@ -2381,7 +2379,7 @@ class Database(object, metaclass=Singleton):
         try:
             machine = session.query(Machine).options(joinedload("tags")).filter(Machine.name == name).first()
         except SQLAlchemyError as e:
-            log.debug("Database error viewing machine: {0}".format(e))
+            log.debug("Database error viewing machine: %s", e)
             return None
         else:
             if machine:
@@ -2400,7 +2398,7 @@ class Database(object, metaclass=Singleton):
         try:
             machine = session.query(Machine).options(joinedload("tags")).filter(Machine.label == label).first()
         except SQLAlchemyError as e:
-            log.debug("Database error viewing machine by label: {0}".format(e))
+            log.debug("Database error viewing machine by label: %s", e)
             return None
         else:
             if machine:
@@ -2419,7 +2417,7 @@ class Database(object, metaclass=Singleton):
         try:
             errors = session.query(Error).filter_by(task_id=task_id).all()
         except SQLAlchemyError as e:
-            log.debug("Database error viewing errors: {0}".format(e))
+            log.debug("Database error viewing errors: %s", e)
             return []
         finally:
             session.close()
@@ -2440,7 +2438,7 @@ class Database(object, metaclass=Singleton):
                 if source_url:
                     source_url = source_url[0]
         except SQLAlchemyError as e:
-            log.debug("Database error listing tasks: {0}".format(e))
+            log.debug("Database error listing tasks: %s", e)
         except TypeError:
             pass
         finally:

--- a/lib/cuckoo/core/guest.py
+++ b/lib/cuckoo/core/guest.py
@@ -39,7 +39,7 @@ def analyzer_zipfile(platform):
 
     if not os.path.exists(root):
         log.error("No valid analyzer found at path: %s", root)
-        raise CuckooGuestError("No valid analyzer found for %s platform!" % platform)
+        raise CuckooGuestError(f"No valid analyzer found for {platform} platform!")
 
     # Walk through everything inside the analyzer's folder and write
     # them to the zip archive.
@@ -101,7 +101,7 @@ class GuestManager(object):
     def get(self, method, *args, **kwargs):
         """Simple wrapper around requests.get()."""
         do_raise = kwargs.pop("do_raise", True)
-        url = "http://%s:%s%s" % (self.ipaddr, self.port, method)
+        url = f"http://{self.ipaddr}:{self.port}{method}"
         with requests.Session() as session:
             session.trust_env = False
             session.proxies = None
@@ -112,7 +112,7 @@ class GuestManager(object):
                 raise CuckooGuestError(
                     "CAPE Agent failed without error status, please try "
                     "upgrading to the latest version of agent.py (>= 0.10) and "
-                    "notify us if the issue persists."
+                    "notify us if the issue persists"
                 )
 
         do_raise and r.raise_for_status()
@@ -120,7 +120,7 @@ class GuestManager(object):
 
     def post(self, method, *args, **kwargs):
         """Simple wrapper around requests.post()."""
-        url = "http://%s:%s%s" % (self.ipaddr, self.port, method)
+        url = f"http://{self.ipaddr}:{self.port}{method}"
         session = requests.Session()
         session.trust_env = False
         session.proxies = None
@@ -131,7 +131,7 @@ class GuestManager(object):
             raise CuckooGuestError(
                 "CAPE Agent failed without error status, please try "
                 "upgrading to the latest version of agent.py (>= 0.10) and "
-                "notify us if the issue persists."
+                "notify us if the issue persists"
             )
 
         r.raise_for_status()
@@ -153,7 +153,7 @@ class GuestManager(object):
 
             if time.time() > end:
                 raise CuckooGuestCriticalTimeout(
-                    "Machine %s: the guest initialization hit the critical timeout, analysis aborted." % self.vmid
+                    f"Machine {self.vmid}: the guest initialization hit the critical timeout, analysis aborted"
                 )
 
     def query_environ(self):
@@ -176,7 +176,7 @@ class GuestManager(object):
 
     def determine_system_drive(self):
         if self.platform == "windows":
-            return "%s/" % self.environ["SYSTEMDRIVE"]
+            return f"{self.environ['SYSTEMDRIVE']}/"
         return "/"
 
     def determine_temp_path(self):
@@ -204,9 +204,9 @@ class GuestManager(object):
         for key, value in options.items():
             # Encode datetime objects the way xmlrpc encodes them.
             if isinstance(value, datetime.datetime):
-                config.append("%s = %s" % (key, value.strftime("%Y%m%dT%H:%M:%S")))
+                config.append("{key} = {value.strftime('%Y%m%dT%H:%M:%S')}")
             else:
-                config.append("%s = %s" % (key, value))
+                config.append(f"{key} = {value}")
 
         data = {
             "filepath": os.path.join(self.analyzer_path, "analysis.conf"),
@@ -218,7 +218,7 @@ class GuestManager(object):
         :param options: options
         :return:
         """
-        log.info("Uploading support files to guest (id={}, ip={})".format(self.vmid, self.ipaddr))
+        log.info("Uploading support files to guest (id=%s, ip=%s)", self.vmid, self.ipaddr)
         basedir = os.path.dirname(options["target"])
 
         for dirpath, _, files in os.walk(basedir):
@@ -273,7 +273,7 @@ class GuestManager(object):
                 "We were unable to detect Agent in the "
                 "Guest VM, are you sure you have set it up correctly? Please "
                 "go through the documentation once more and otherwise inform "
-                "the Cuckoo Developers of your issue."
+                "the Cuckoo Developers of your issue"
             )
             db.guest_set_status(self.task_id, "failed")
             return
@@ -317,7 +317,7 @@ class GuestManager(object):
 
         if "execpy" in features:
             data = {
-                "filepath": "%s/analyzer.py" % self.analyzer_path,
+                "filepath": os.path.join(self.analyzer_path, "analyzer.py"),
                 "async": "yes",
                 "cwd": self.analyzer_path,
             }
@@ -325,7 +325,7 @@ class GuestManager(object):
         else:
             # Execute the analyzer that we just uploaded.
             data = {
-                "command": "%s %s\\analyzer.py" % (sys.executable, self.analyzer_path),
+                "command": f"{sys.executable} {self.analyzer_path}\\analyzer.py",
                 "async": "yes",
                 "cwd": self.analyzer_path,
             }

--- a/lib/cuckoo/core/log.py
+++ b/lib/cuckoo/core/log.py
@@ -54,7 +54,7 @@ class TaskHandler(logging.Handler):
         if not task:
             return
 
-        task[1].write("%s\n" % self.format(record))
+        task[1].write(f"{self.format(record)}\n")
 
 
 class ConsoleHandler(logging.StreamHandler):

--- a/lib/cuckoo/core/plugins.py
+++ b/lib/cuckoo/core/plugins.py
@@ -596,10 +596,7 @@ class RunSignatures(object):
         for key, value in stats.items():
             if value:
                 self.results["statistics"]["signatures"].append(
-                    {
-                        "name": key,
-                        "time": float(f"{value.seconds}.{value.microseconds // 1000: 03d}")
-                    }
+                    {"name": key, "time": float(f"{value.seconds}.{value.microseconds // 1000: 03d}")}
                 )
         # Compat loop for old-style (non evented) signatures.
         if complete_list:

--- a/lib/cuckoo/core/plugins.py
+++ b/lib/cuckoo/core/plugins.py
@@ -43,7 +43,7 @@ def import_plugin(name):
     try:
         module = __import__(name, globals(), locals(), ["dummy"])
     except (ImportError, SyntaxError) as e:
-        print('Unable to import plugin "{0}": {1}'.format(name, e))
+        print(f'Unable to import plugin "{name}": {e}')
         return
     else:
         # ToDo remove for release
@@ -54,7 +54,7 @@ def import_plugin(name):
 
 
 def import_package(package):
-    prefix = package.__name__ + "."
+    prefix = f"{package.__name__}."
     for _, name, ispkg in pkgutil.iter_modules(package.__path__, prefix):
         if ispkg:
             continue
@@ -119,8 +119,8 @@ class RunAuxiliary(object):
             for module in auxiliary_list:
                 try:
                     current = module()
-                except Exception:
-                    log.exception("Failed to load the auxiliary module " '"{0}":'.format(module))
+                except Exception as e:
+                    log.exception('Failed to load the auxiliary module "%s": %s', module, e)
                     return
 
                 module_name = inspect.getmodule(current).__name__
@@ -130,7 +130,7 @@ class RunAuxiliary(object):
                 try:
                     options = self.cfg.get(module_name)
                 except CuckooOperationalError:
-                    log.debug("Auxiliary module %s not found in " "configuration file", module_name)
+                    log.debug("Auxiliary module %s not found in configuration file", module_name)
                     continue
 
                 if not options.enabled:
@@ -157,7 +157,7 @@ class RunAuxiliary(object):
         enabled = []
         for module in self.enabled:
             try:
-                getattr(module, "cb_%s" % name, default)(*args, **kwargs)
+                getattr(module, f"cb_{name}", default)(*args, **kwargs)
             except NotImplementedError:
                 pass
             except CuckooDisableModule:
@@ -209,8 +209,8 @@ class RunProcessing(object):
         # Initialize the specified processing module.
         try:
             current = module(self.results)
-        except Exception:
-            log.exception("Failed to load the processing module " '"{0}":'.format(module))
+        except Exception as e:
+            log.exception('Failed to load the processing module "%s": %s', module, e)
             return
 
         # Extract the module name.
@@ -238,13 +238,13 @@ class RunProcessing(object):
         try:
             # Run the processing module and retrieve the generated data to be
             # appended to the general results container.
-            log.debug('Executing processing module "%s" on analysis at ' '"%s"', current.__class__.__name__, self.analysis_path)
+            log.debug('Executing processing module "%s" on analysis at "%s"', current.__class__.__name__, self.analysis_path)
             pretime = datetime.now()
             data = current.run()
             posttime = datetime.now()
             timediff = posttime - pretime
             self.results["statistics"]["processing"].append(
-                {"name": current.__class__.__name__, "time": float("%d.%03d" % (timediff.seconds, timediff.microseconds / 1000))}
+                {"name": current.__class__.__name__, "time": float(f"{timediff.seconds}.{timediff.microseconds // 1000: 03d}")}
             )
 
             # If succeeded, return they module's key name and the data to be
@@ -253,9 +253,9 @@ class RunProcessing(object):
         except CuckooDependencyError as e:
             log.warning('The processing module "%s" has missing dependencies: %s', current.__class__.__name__, e)
         except CuckooProcessingError as e:
-            log.warning('The processing module "%s" returned the following ' "error: %s", current.__class__.__name__, e)
-        except Exception:
-            log.exception('Failed to run the processing module "%s":', current.__class__.__name__)
+            log.warning('The processing module "%s" returned the following error: %s', current.__class__.__name__, e)
+        except Exception as e:
+            log.exception('Failed to run the processing module "%s": %s', current.__class__.__name__, e)
 
         return None
 
@@ -309,9 +309,7 @@ class RunProcessing(object):
                     if not hasattr(self.results, "debug"):
                         self.results.setdefault("debug", dict()).setdefault("errors", list())
                     self.results["debug"]["errors"].append(
-                        "Behavioral log {0} too big to be processed, skipped. Increase analysis_size_limit in cuckoo.conf".format(
-                            file_name
-                        )
+                        f"Behavioral log {file_name} too big to be processed, skipped. Increase analysis_size_limit in cuckoo.conf"
                     )
                     continue
         else:
@@ -409,9 +407,7 @@ class RunSignatures(object):
                 # version, skip this signature.
                 if StrictVersion(version) < StrictVersion(current.minimum.split("-")[0]):
                     log.debug(
-                        "You are running an older incompatible version "
-                        'of Cuckoo, the signature "%s" requires '
-                        "minimum version %s",
+                        'You are running an older incompatible version of Cuckoo, the signature "%s" requires minimum version %s',
                         current.name,
                         current.minimum,
                     )
@@ -428,9 +424,7 @@ class RunSignatures(object):
                 # version, skip this signature.
                 if StrictVersion(version) > StrictVersion(current.maximum.split("-")[0]):
                     log.debug(
-                        "You are running a newer incompatible version "
-                        'of Cuckoo, the signature "%s" requires '
-                        "maximum version %s",
+                        'You are running a newer incompatible version of Cuckoo, the signature "%s" requires maximum version %s',
                         current.name,
                         current.maximum,
                     )
@@ -453,8 +447,8 @@ class RunSignatures(object):
         # Initialize the current signature.
         try:
             current = signature(self.results)
-        except Exception:
-            log.exception("Failed to load signature " '"{0}":'.format(signature))
+        except Exception as e:
+            log.exception('Failed to load signature "%s": %s', signature, e)
             return
 
         # If the signature is disabled, skip it.
@@ -478,7 +472,7 @@ class RunSignatures(object):
             self.results["statistics"]["signatures"].append(
                 {
                     "name": current.name,
-                    "time": float("%d.%03d" % (timediff.seconds, timediff.microseconds / 1000)),
+                    "time": float(f"{timediff.seconds}.{timediff.microseconds // 1000: 03d}"),
                 }
             )
 
@@ -488,8 +482,8 @@ class RunSignatures(object):
                 return current.as_result()
         except NotImplementedError:
             return None
-        except Exception:
-            log.exception('Failed to run signature "%s":', current.name)
+        except Exception as e:
+            log.exception('Failed to run signature "%s": %s', current.name, e)
 
         return None
 
@@ -518,12 +512,12 @@ class RunSignatures(object):
         except Exception as e:
             print(e)
         overlay = self._load_overlay()
-        log.debug("Applying signature overlays for signatures: %s", ", ".join(list(overlay.keys())))
+        log.debug("Applying signature overlays for signatures: %s", ", ".join(overlay))
         for signature in complete_list + evented_list:
             self._apply_overlay(signature, overlay)
 
         if evented_list and "behavior" in self.results:
-            log.debug("Running %u evented signatures", len(evented_list))
+            log.debug("Running %d evented signatures", len(evented_list))
             for sig in evented_list:
                 stats[sig.name] = timedelta()
                 if sig == evented_list[-1]:
@@ -554,7 +548,7 @@ class RunSignatures(object):
                         except NotImplementedError:
                             result = False
                         except Exception as e:
-                            log.exception("Failed to run signature {}: {}".format(sig.name, e))
+                            log.exception("Failed to run signature %s: %s", sig.name, e)
                             result = False
 
                         # If the signature returns None we can carry on, the
@@ -583,8 +577,8 @@ class RunSignatures(object):
                     stats[sig.name] += timediff
                 except NotImplementedError:
                     continue
-                except Exception:
-                    log.exception('Failed run on_complete() method for signature "%s":', sig.name)
+                except Exception as e:
+                    log.exception('Failed run on_complete() method for signature "%s": %s', sig.name, e)
                     continue
                 else:
                     if result is True:
@@ -604,7 +598,7 @@ class RunSignatures(object):
                 self.results["statistics"]["signatures"].append(
                     {
                         "name": key,
-                        "time": float("%d.%03d" % (value.seconds, value.microseconds / 1000)),
+                        "time": float(f"{value.seconds}.{value.microseconds // 1000: 03d}")
                     }
                 )
         # Compat loop for old-style (non evented) signatures.
@@ -686,8 +680,8 @@ class RunReporting:
         # Initialize current reporting module.
         try:
             current = module()
-        except Exception:
-            log.exception('Failed to load the reporting module "{0}":'.format(module))
+        except Exception as e:
+            log.exception('Failed to load the reporting module "%s": %s', module, e)
             return
 
         # Extract the module name.
@@ -730,7 +724,7 @@ class RunReporting:
             self.results["statistics"]["reporting"].append(
                 {
                     "name": current.__class__.__name__,
-                    "time": float("%d.%03d" % (timediff.seconds, timediff.microseconds / 1000)),
+                    "time": float(f"{timediff.seconds}.{timediff.microseconds // 1000: 03d}"),
                 }
             )
 
@@ -738,8 +732,8 @@ class RunReporting:
             log.warning('The reporting module "%s" has missing dependencies: %s', current.__class__.__name__, e)
         except CuckooReportError as e:
             log.warning('The reporting module "%s" returned the following error: %s', current.__class__.__name__, e)
-        except Exception:
-            log.exception('Failed to run the reporting module "%s":', current.__class__.__name__)
+        except Exception as e:
+            log.exception('Failed to run the reporting module "%s": %s', current.__class__.__name__, e)
 
     def run(self):
         """Generates all reports.
@@ -782,16 +776,16 @@ class GetFeeds(object):
 
         try:
             current = feed()
-            log.debug('Loading feed "{0}"'.format(current.name))
-        except Exception:
-            log.exception('Failed to load feed "{0}":'.format(current.name))
+            log.debug('Loading feed "%s"', current.name)
+        except Exception as e:
+            log.exception('Failed to load feed "%s": %s', current.name, e)
             return
 
         if current.update():
             try:
                 current.modify()
                 current.run(modified=True)
-                log.debug('"{0}" has been updated'.format(current.name))
+                log.debug('"%s" has been updated', current.name)
             except NotImplementedError:
                 current.run(modified=False)
             except Exception:

--- a/lib/cuckoo/core/resultserver.py
+++ b/lib/cuckoo/core/resultserver.py
@@ -69,7 +69,7 @@ def netlog_sanitize_fname(path):
     path = path.replace(b"\\", b"/")
     dir_part, name = os.path.split(path)
     if dir_part not in RESULT_DIRECTORIES:
-        raise CuckooOperationalError("Netlog client requested banned path: %r" % path)
+        raise CuckooOperationalError(f"Netlog client requested banned path: {path}")
     if any(c in BANNED_PATH_CHARS for c in name):
         for c in BANNED_PATH_CHARS:
             path.replace(bytes([c]), b"X")
@@ -97,7 +97,7 @@ class HandlerContext(object):
         self.buf = b""
 
     def __repr__(self):
-        return "<Context for %s>" % self.command
+        return f"<Context for {self.command}>"
 
     def cancel(self):
         """Cancel this context; gevent might complain about this with an
@@ -119,7 +119,7 @@ class HandlerContext(object):
 
             if e.errno != errno.ECONNRESET:
                 raise
-            log.debug("Task #%s had connection reset for %r, error: %s", self.task_id, self, str(e))
+            log.debug("Task #%s had connection reset for %r, error: %s", self.task_id, self, e)
             return b""
         except Exception as e:
             print(e)
@@ -171,7 +171,7 @@ class WriteLimiter(object):
             self.remain -= write
         if size and size != write:
             if not self.warned:
-                log.warning("Uploaded file length larger than upload_max_size, stopping upload.")
+                log.warning("Uploaded file length larger than upload_max_size, stopping upload")
                 self.fd.write(b"... (truncated)")
                 self.warned = True
 
@@ -203,14 +203,14 @@ class FileUpload(ProtocolHandler):
         else:
             filepath, pids, ppids, metadata, category, duplicated = None, [], [], b"", b"", False
 
-        log.debug("Task #%s: File upload for %r", self.task_id, dump_path)
+        log.debug("Task #%s: File upload for %s", self.task_id, dump_path)
         if not duplicated:
             file_path = os.path.join(self.storagepath, dump_path.decode())
 
             try:
                 self.fd = open_exclusive(file_path)
             except OSError as e:
-                log.debug("File upload error for %r (task #%s)", dump_path, self.task_id)
+                log.debug("File upload error for %s (task #%s)", dump_path, self.task_id)
                 if e.errno == errno.EEXIST:
                     raise CuckooOperationalError(
                         f"Analyzer for task #{self.task_id} tried to overwrite an existing file: {file_path}"
@@ -252,10 +252,10 @@ class LogHandler(ProtocolHandler):
         try:
             self.fd = open_exclusive(self.logpath, bufsize=1)
         except OSError:
-            log.error("Task #%s: attempted to reopen live log analysis.log.", self.task_id)
+            log.error("Task #%s: attempted to reopen live log analysis.log", self.task_id)
             return
 
-        log.debug("Task #%s: live log analysis.log initialized.", self.task_id)
+        log.debug("Task #%s: live log analysis.log initialized", self.task_id)
 
     def handle(self):
         if self.fd:
@@ -265,16 +265,16 @@ class LogHandler(ProtocolHandler):
 class BsonStore(ProtocolHandler):
     def init(self):
         if self.version is None:
-            log.warning("Agent is sending BSON files without PID parameter, " "you should probably update it")
+            log.warning("Agent is sending BSON files without PID parameter, you should probably update it")
             self.fd = None
             return
 
-        self.fd = open(os.path.join(self.handler.storagepath, "logs", "%d.bson" % self.version), "wb")
+        self.fd = open(os.path.join(self.handler.storagepath, "logs", f"{self.version}.bson"), "wb")
 
     def handle(self):
         """Read a BSON stream, attempting at least basic validation, and
         log failures."""
-        log.debug("Task #%s is sending a BSON stream. For pid %d" % (self.task_id, self.version))
+        log.debug("Task #%s is sending a BSON stream. For pid %d", self.task_id, self.version)
         if self.fd:
             self.handler.sock.settimeout(None)
             return self.handler.copy_to_fd(self.fd)
@@ -329,7 +329,7 @@ class GeventResultServerWorker(gevent.server.StreamServer):
                 log.debug("Stopped tracking machine %s for task #%s", ipaddr, task_id)
             ctxs = self.handlers.pop(task_id, set())
             for ctx in ctxs:
-                log.debug("Cancel %s for task %r", ctx, task_id)
+                log.debug("Cancel %s for task %s", ctx, task_id)
                 ctx.cancel()
 
     def create_folders(self):
@@ -392,7 +392,7 @@ class GeventResultServerWorker(gevent.server.StreamServer):
                 # protocol and a different task for that IP address may have
                 # been registered
                 if self.tasks.get(ipaddr) != task_id:
-                    log.warning("Task #%s for IP %s was cancelled during " "negotiation", task_id, ipaddr)
+                    log.warning("Task #%s for IP %s was cancelled during negotiation", task_id, ipaddr)
                     return
                 s = self.handlers.setdefault(task_id, set())
                 s.add(ctx)
@@ -408,7 +408,7 @@ class GeventResultServerWorker(gevent.server.StreamServer):
                 ctx.cancel()
                 if ctx.buf:
                     # This is usually not a good sign
-                    log.warning("Task #%s with protocol %s has unprocessed " "data before getting disconnected", task_id, protocol)
+                    log.warning("Task #%s with protocol %s has unprocessed data before getting disconnected", task_id, protocol)
         finally:
             task_log_stop(task_id)
 
@@ -421,7 +421,7 @@ class GeventResultServerWorker(gevent.server.StreamServer):
             command, version = header, None
         klass = self.commands.get(command)
         if not klass:
-            log.warning("Task #%s: unknown netlog protocol requested (%r), " "terminating connection.", task_id, command)
+            log.warning("Task #%s: unknown netlog protocol requested (%s), terminating connection", task_id, command)
             return
         ctx.command = command
         return klass(task_id, ctx, version)
@@ -442,18 +442,18 @@ class ResultServer(metaclass=Singleton):
             sock.bind((ip, port))
         except (OSError, socket.error) as e:
             if e.errno == errno.EADDRINUSE:
-                raise CuckooCriticalError("Cannot bind ResultServer on port %d " "because it was in use, bailing." % port)
+                raise CuckooCriticalError(f"Cannot bind ResultServer on port {port} because it was in use, bailing")
             elif e.errno == errno.EADDRNOTAVAIL:
                 raise CuckooCriticalError(
-                    "Unable to bind ResultServer on %s:%s %s. This "
+                    f"Unable to bind ResultServer on {ip}:{port} {e}. This "
                     "usually happens when you start Cuckoo without "
                     "bringing up the virtual interface associated with "
                     "the ResultServer IP address. Please refer to "
                     "https://cuckoo.sh/docs/faq/#troubles-problem "
-                    "for more information." % (ip, port, e)
+                    "for more information"
                 )
             else:
-                raise CuckooCriticalError("Unable to bind ResultServer on %s:%s: %s" % (ip, port, e))
+                raise CuckooCriticalError(f"Unable to bind ResultServer on {ip}:{port} {e}")
 
         # We allow user to specify port 0 to get a random port, report it back
         # here

--- a/lib/cuckoo/core/rooter.py
+++ b/lib/cuckoo/core/rooter.py
@@ -57,7 +57,7 @@ def _load_socks5_operational():
 
 def rooter(command, *args, **kwargs):
     if not os.path.exists(cfg.cuckoo.rooter):
-        log.critical("Unable to passthrough root command (%s) as the rooter " "unix socket doesn't exist.", command)
+        log.critical("Unable to passthrough root command (%s) as the rooter unix socket doesn't exist", command)
         return
 
     ret = None
@@ -72,7 +72,7 @@ def rooter(command, *args, **kwargs):
         try:
             s.connect(cfg.cuckoo.rooter)
         except socket.error as e:
-            log.critical("Unable to passthrough root command as we're unable to connect to the rooter unix socket: %s.", e)
+            log.critical("Unable to passthrough root command as we're unable to connect to the rooter unix socket: %s", e)
             return
 
         s.send(

--- a/lib/cuckoo/core/scheduler.py
+++ b/lib/cuckoo/core/scheduler.py
@@ -92,8 +92,7 @@ class AnalysisManager(threading.Thread):
         # analysis or previous results will be overwritten and lost.
         if os.path.exists(self.storage):
             log.error(
-                "Task #%s: Analysis results folder already exists at path '%s', "
-                "analysis aborted", self.task.id, self.storage
+                "Task #%s: Analysis results folder already exists at path '%s', analysis aborted", self.task.id, self.storage
             )
             return False
 
@@ -113,8 +112,9 @@ class AnalysisManager(threading.Thread):
 
         if sha256 != sample.sha256:
             log.error(
-                "Task #%s: Target file has been modified after submission: "
-                "'%s'", self.task.id, convert_to_printable(self.task.target)
+                "Task #%s: Target file has been modified after submission: '%s'",
+                self.task.id,
+                convert_to_printable(self.task.target),
             )
             return False
 
@@ -124,8 +124,9 @@ class AnalysisManager(threading.Thread):
         """Store a copy of the file being analyzed."""
         if not os.path.exists(self.task.target):
             log.error(
-                "Task #%s: The file to analyze does not exist at path '%s', "
-                "analysis aborted", self.task.id, convert_to_printable(self.task.target)
+                "Task #%s: The file to analyze does not exist at path '%s', analysis aborted",
+                self.task.id,
+                convert_to_printable(self.task.target),
             )
             return False
 
@@ -142,7 +143,9 @@ class AnalysisManager(threading.Thread):
             except (IOError, shutil.Error) as e:
                 log.error(
                     "Task #%s: Unable to store file from '%s' to '%s', analysis aborted",
-                    self.task.id, self.task.target, self.binary
+                    self.task.id,
+                    self.task.target,
+                    self.binary,
                 )
                 return False
 
@@ -168,10 +171,7 @@ class AnalysisManager(threading.Thread):
             else:
                 shutil.copy(self.binary, new_binary_path)
         except (AttributeError, OSError) as e:
-            log.error(
-                "Task #%s: Unable to create symlink/copy from '%s' to '%s': %s",
-                self.task.id, self.binary, self.storage, e
-            )
+            log.error("Task #%s: Unable to create symlink/copy from '%s' to '%s': %s", self.task.id, self.binary, self.storage, e)
 
         return True
 
@@ -198,14 +198,16 @@ class AnalysisManager(threading.Thread):
             # If no machine is available at this moment, wait for one second and try again.
             if not machine:
                 machine_lock.release()
-                log.debug(
-                    "Task #%s: no machine available yet. Verify that arch value is set in hypervisor config", self.task.id
-                )
+                log.debug("Task #%s: no machine available yet. Verify that arch value is set in hypervisor config", self.task.id)
                 time.sleep(1)
             else:
                 log.info(
                     "Task #%s: acquired machine %s (label=%s, arch=%s, platform=%s)",
-                    self.task.id, machine.name, machine.label, machine.arch, machine.platform
+                    self.task.id,
+                    machine.name,
+                    machine.label,
+                    machine.arch,
+                    machine.platform,
                 )
                 break
 
@@ -287,7 +289,9 @@ class AnalysisManager(threading.Thread):
 
         log.info(
             "Task #%s: Starting analysis of %s '%s'",
-            self.task.id, self.task.category.upper(), convert_to_printable(self.task.target)
+            self.task.id,
+            self.task.category.upper(),
+            convert_to_printable(self.task.target),
         )
 
         # Initialize the analysis folders.
@@ -422,7 +426,9 @@ class AnalysisManager(threading.Thread):
             except CuckooMachineError as e:
                 log.error(
                     "Task #%s: Unable to release machine %s, reason %s. You might need to restore it manually",
-                    self.task.id, self.machine.label, e
+                    self.task.id,
+                    self.machine.label,
+                    e,
                 )
 
         return succeeded

--- a/lib/cuckoo/core/scheduler.py
+++ b/lib/cuckoo/core/scheduler.py
@@ -92,8 +92,8 @@ class AnalysisManager(threading.Thread):
         # analysis or previous results will be overwritten and lost.
         if os.path.exists(self.storage):
             log.error(
-                "Task #{0}: Analysis results folder already exists at path '{1}', "
-                "analysis aborted".format(self.task.id, self.storage)
+                "Task #%s: Analysis results folder already exists at path '%s', "
+                "analysis aborted", self.task.id, self.storage
             )
             return False
 
@@ -102,7 +102,7 @@ class AnalysisManager(threading.Thread):
         try:
             create_folder(folder=self.storage)
         except CuckooOperationalError:
-            log.error("Task #{0}: Unable to create analysis folder {1}".format(self.task.id, self.storage))
+            log.error("Task #%s: Unable to create analysis folder %s", self.task.id, self.storage)
             return False
 
         return True
@@ -113,8 +113,8 @@ class AnalysisManager(threading.Thread):
 
         if sha256 != sample.sha256:
             log.error(
-                "Task #{0}: Target file has been modified after submission: "
-                "'{1}'".format(self.task.id, convert_to_printable(self.task.target))
+                "Task #%s: Target file has been modified after submission: "
+                "'%s'", self.task.id, convert_to_printable(self.task.target)
             )
             return False
 
@@ -124,8 +124,8 @@ class AnalysisManager(threading.Thread):
         """Store a copy of the file being analyzed."""
         if not os.path.exists(self.task.target):
             log.error(
-                "Task #{0}: The file to analyze does not exist at path '{1}', "
-                "analysis aborted".format(self.task.id, convert_to_printable(self.task.target))
+                "Task #%s: The file to analyze does not exist at path '%s', "
+                "analysis aborted", self.task.id, convert_to_printable(self.task.target)
             )
             return False
 
@@ -133,7 +133,7 @@ class AnalysisManager(threading.Thread):
         copy_path = os.path.join(CUCKOO_ROOT, "storage", "binaries", sha256)
 
         if os.path.exists(self.binary):
-            log.info("Task #{0}: File already exists at '{1}'".format(self.task.id, self.binary))
+            log.info("Task #%s: File already exists at '%s'", self.task.id, self.binary)
         else:
             # TODO: do we really need to abort the analysis in case we are not able to store a copy of the file?
             try:
@@ -141,9 +141,8 @@ class AnalysisManager(threading.Thread):
                 shutil.copy(self.task.target, self.binary)
             except (IOError, shutil.Error) as e:
                 log.error(
-                    "Task #{0}: Unable to store file from '{1}' to '{2}', analysis aborted".format(
-                        self.task.id, self.task.target, self.binary
-                    )
+                    "Task #%s: Unable to store file from '%s' to '%s', analysis aborted",
+                    self.task.id, self.task.target, self.binary
                 )
                 return False
 
@@ -170,9 +169,8 @@ class AnalysisManager(threading.Thread):
                 shutil.copy(self.binary, new_binary_path)
         except (AttributeError, OSError) as e:
             log.error(
-                "Task #{0}: Unable to create symlink/copy from '{1}' to '{2}': {3}".format(
-                    self.task.id, self.binary, self.storage, e
-                )
+                "Task #%s: Unable to create symlink/copy from '%s' to '%s': %s",
+                self.task.id, self.binary, self.storage, e
             )
 
         return True
@@ -201,14 +199,13 @@ class AnalysisManager(threading.Thread):
             if not machine:
                 machine_lock.release()
                 log.debug(
-                    "Task #{0}: no machine available yet. Verify that arch value is set in hypervisor config".format(self.task.id)
+                    "Task #%s: no machine available yet. Verify that arch value is set in hypervisor config", self.task.id
                 )
                 time.sleep(1)
             else:
                 log.info(
-                    "Task #{}: acquired machine {} (label={}, arch={}, platform={})".format(
-                        self.task.id, machine.name, machine.label, machine.arch, machine.platform
-                    )
+                    "Task #%s: acquired machine %s (label=%s, arch=%s, platform=%s)",
+                    self.task.id, machine.name, machine.label, machine.arch, machine.platform
                 )
                 break
 
@@ -289,9 +286,8 @@ class AnalysisManager(threading.Thread):
         self.socks5s = _load_socks5_operational()
 
         log.info(
-            "Task #{0}: Starting analysis of {1} '{2}'".format(
-                self.task.id, self.task.category.upper(), convert_to_printable(self.task.target)
-            )
+            "Task #%s: Starting analysis of %s '%s'",
+            self.task.id, self.task.category.upper(), convert_to_printable(self.task.target)
         )
 
         # Initialize the analysis folders.
@@ -310,7 +306,7 @@ class AnalysisManager(threading.Thread):
         # At this point we can tell the ResultServer about it.
         except CuckooOperationalError as e:
             machine_lock.release()
-            log.error("Task #{0}: Cannot acquire machine: {1}".format(self.task.id, e), exc_info=True)
+            log.error("Task #%s: Cannot acquire machine: %s", self.task.id, e, exc_info=True)
             return False
 
         # Generate the analysis configuration file.
@@ -379,7 +375,7 @@ class AnalysisManager(threading.Thread):
                     else:
                         machinery.dump_memory(self.machine.label, dump_path)
                 except NotImplementedError:
-                    log.error("The memory dump functionality is not available for the current machine manager.")
+                    log.error("The memory dump functionality is not available for the current machine manager")
 
                 except CuckooMachineError as e:
                     log.error(e, exc_info=True)
@@ -389,7 +385,7 @@ class AnalysisManager(threading.Thread):
                 machinery.stop(self.machine.label)
 
             except CuckooMachineError as e:
-                log.warning("Task #{0}: Unable to stop machine {1}: {2}".format(self.task.id, self.machine.label, e))
+                log.warning("Task #%s: Unable to stop machine %s: %s", self.task.id, self.machine.label, e)
 
             # Mark the machine in the database as stopped. Unless this machine
             # has been marked as dead, we just keep it as "started" in the
@@ -425,8 +421,8 @@ class AnalysisManager(threading.Thread):
 
             except CuckooMachineError as e:
                 log.error(
-                    "Task #{0}: Unable to release machine {1}, reason "
-                    "{2}. You might need to restore it manually.".format(self.task.id, self.machine.label, e)
+                    "Task #%s: Unable to release machine %s, reason %s. You might need to restore it manually",
+                    self.task.id, self.machine.label, e
                 )
 
         return succeeded
@@ -453,7 +449,7 @@ class AnalysisManager(threading.Thread):
             # turn thrown an exception in the analysisinfo processing module.
             self.task = self.db.view_task(self.task.id) or self.task
 
-            log.debug("Task #{0}: Released database task with status {1}".format(self.task.id, success))
+            log.debug("Task #%s: Released database task with status %s", self.task.id, success)
 
             # We make a symbolic link ("latest") which links to the latest
             # analysis - this is useful for debugging purposes. This is only
@@ -473,19 +469,19 @@ class AnalysisManager(threading.Thread):
 
                     os.symlink(self.storage, latest)
                 except OSError as e:
-                    log.warning("Task #{0}: Error pointing latest analysis symlink: {1}".format(self.task.id, e))
+                    log.warning("Task #%s: Error pointing latest analysis symlink: %s", self.task.id, e)
                 finally:
                     latest_symlink_lock.release()
 
-            log.info("Task #{0}: analysis procedure completed".format(self.task.id))
+            log.info("Task #%s: analysis procedure completed", self.task.id)
         except Exception as e:
-            log.exception("Task #{0}: Failure in AnalysisManager.run: {1}".format(self.task.id, e))
+            log.exception("Task #%s: Failure in AnalysisManager.run: %s", self.task.id, e)
 
         active_analysis_count -= 1
 
     def _rooter_response_check(self):
         if self.rooter_response and self.rooter_response["exception"] is not None:
-            raise CuckooCriticalError("Error execution rooter command: %s" % self.rooter_response["exception"])
+            raise CuckooCriticalError(f"Error execution rooter command: {self.rooter_response['exception']}")
 
     def route_network(self):
         """Enable network routing if desired."""
@@ -511,7 +507,7 @@ class AnalysisManager(threading.Thread):
         elif self.route in self.socks5s:
             self.interface = ""
         else:
-            log.warning("Unknown network routing destination specified, ignoring routing for this analysis: %r", self.route)
+            log.warning("Unknown network routing destination specified, ignoring routing for this analysis: %s", self.route)
             self.interface = None
             self.rt_table = None
 
@@ -520,7 +516,7 @@ class AnalysisManager(threading.Thread):
         if self.interface and not rooter("nic_available", self.interface):
             log.error(
                 "The network interface '%s' configured for this analysis is "
-                "not available at the moment, switching to route=none mode.",
+                "not available at the moment, switching to route=none mode",
                 self.interface,
             )
             self.route = "none"
@@ -562,7 +558,7 @@ class AnalysisManager(threading.Thread):
 
         # check if the interface is up
         if HAVE_NETWORKIFACES and routing.routing.verify_interface and self.interface and self.interface not in network_interfaces:
-            raise CuckooNetworkError("Network interface {} not found".format(self.interface))
+            raise CuckooNetworkError(f"Network interface {self.interface} not found")
 
         if self.interface:
             self.rooter_response = rooter("forward_enable", self.machine.interface, self.interface, self.machine.ip)
@@ -654,7 +650,7 @@ class Scheduler:
             machine_lock = threading.Lock()
 
         log.info(
-            'Using "%s" machine manager with max_analysis_count=%d, ' "max_machines_count=%d, and max_vmstartup_count=%d",
+            'Using "%s" machine manager with max_analysis_count=%d, max_machines_count=%d, and max_vmstartup_count=%d',
             machinery_name,
             self.cfg.cuckoo.max_analysis_count,
             self.cfg.cuckoo.max_machines_count,
@@ -668,11 +664,11 @@ class Scheduler:
         machinery = plugin()
 
         # Find its configuration file.
-        conf = os.path.join(CUCKOO_ROOT, "conf", "%s.conf" % machinery_name)
+        conf = os.path.join(CUCKOO_ROOT, "conf", f"{machinery_name}.conf")
 
         if not os.path.exists(conf):
             raise CuckooCriticalError(
-                "The configuration file for machine " 'manager "{0}" does not exist at path:' " {1}".format(machinery_name, conf)
+                f'The configuration file for machine manager "{machinery_name}" does not exist at path: {conf}'
             )
 
         # Provide a dictionary with the configuration options to the
@@ -683,22 +679,22 @@ class Scheduler:
         try:
             machinery.initialize(machinery_name)
         except CuckooMachineError as e:
-            raise CuckooCriticalError("Error initializing machines: %s" % e)
+            raise CuckooCriticalError(f"Error initializing machines: {e}")
 
         # At this point all the available machines should have been identified
         # and added to the list. If none were found, Cuckoo needs to abort the
         # execution.
         if not len(machinery.machines()):
-            raise CuckooCriticalError("No machines available.")
+            raise CuckooCriticalError("No machines available")
         else:
-            log.info("Loaded %s machine/s", len(machinery.machines()))
+            log.info("Loaded %d machine/s", len(machinery.machines()))
 
         if len(machinery.machines()) > 1 and self.db.engine.name == "sqlite":
             log.warning(
                 "As you've configured Cuckoo to execute parallel "
                 "analyses, we recommend you to switch to a MySQL "
                 "a PostgreSQL database as SQLite might cause some "
-                "issues."
+                "issues"
             )
 
         # Drop all existing packet forwarding rules for each VM. Just in case
@@ -712,7 +708,7 @@ class Scheduler:
                     "full internet access or route it through a VPN! "
                     "Please define a default network interface for the "
                     "machinery or define a network interface for each "
-                    "VM.",
+                    "VM",
                     machine.name,
                 )
                 continue
@@ -735,7 +731,7 @@ class Scheduler:
         """Start scheduler."""
         self.initialize()
 
-        log.info("Waiting for analysis tasks.")
+        log.info("Waiting for analysis tasks")
 
         # To handle stop analyzing when we need to restart process without break tasks
         signal.signal(signal.SIGHUP, self.set_stop_analyzing)
@@ -797,8 +793,7 @@ class Scheduler:
                     if task:
                         break
                 if task:
-
-                    log.debug("Task #{0}: Processing task".format(task.id))
+                    log.debug("Task #%s: Processing task", task.id)
                     self.total_analysis_count += 1
                     # Initialize and start the analysis manager.
                     analysis = AnalysisManager(task, errors)

--- a/lib/cuckoo/core/startup.py
+++ b/lib/cuckoo/core/startup.py
@@ -54,7 +54,7 @@ def check_working_directory():
     @raise CuckooStartupError: if directories are not properly configured.
     """
     if not os.path.exists(CUCKOO_ROOT):
-        raise CuckooStartupError("You specified a non-existing root directory: {0}".format(CUCKOO_ROOT))
+        raise CuckooStartupError(f"You specified a non-existing root directory: {CUCKOO_ROOT}")
 
     cwd = os.path.join(os.getcwd(), "cuckoo.py")
     if not os.path.exists(cwd):
@@ -104,7 +104,7 @@ def check_configs():
 
     for config in configs:
         if not os.path.exists(config):
-            raise CuckooStartupError("Config file does not exist at path: {0}".format(config))
+            raise CuckooStartupError(f"Config file does not exist at path: {config}")
 
     if cuckoo.resultserver.ip in ("127.0.0.1", "localhost"):
         log.error("Bad resultserver address. You need to listen on virtual machines range. Ex: 10.0.0.1 not 127.0.0.1")
@@ -218,11 +218,11 @@ def init_tasks():
     for task in tasks:
         if cuckoo.cuckoo.reschedule:
             db.reschedule(task.id)
-            log.info("Rescheduled task with ID {0} and target {1}".format(task.id, task.target))
+            log.info("Rescheduled task with ID %s and target %s", task.id, task.target)
         else:
             # ToDo here?
             db.set_status(task.id, TASK_FAILED_ANALYSIS)
-            log.info("Updated running task ID {0} status to failed_analysis".format(task.id))
+            log.info("Updated running task ID %s status to failed_analysis", task.id)
 
 
 def init_modules():
@@ -243,7 +243,7 @@ def init_modules():
     import_package(modules.feeds)
 
     # Import machine manager.
-    import_plugin("modules.machinery." + cuckoo.cuckoo.machinery)
+    import_plugin(f"modules.machinery.{cuckoo.cuckoo.machinery}")
 
     for category, entries in list_plugins().items():
         log.debug('Imported "%s" modules:', category)
@@ -279,7 +279,7 @@ def init_yara():
                 if not filename.endswith((".yar", ".yara")):
                     continue
                 filepath = os.path.join(category_root, filename)
-                rules["rule_%s_%d" % (category, len(rules))] = filepath
+                rules[f"rule_{category}_{len(rules)}"] = filepath
                 indexed.append(filename)
 
             # Need to define each external variable that will be used in the
@@ -291,19 +291,19 @@ def init_yara():
                 File.yara_rules[category] = yara.compile(filepaths=rules, externals=externals)
                 break
             except yara.SyntaxError as e:
-                bad_rule = str(e).split(".yar")[0] + ".yar"
-                log.debug(f"Trying to delete bad rule: {bad_rule}")
+                bad_rule = f"{str(e).split('.yar', 1)[0]}.yar"
+                log.debug("Trying to delete bad rule: %s", bad_rule)
                 if os.path.basename(bad_rule) in indexed:
                     for k, v in rules.items():
                         if v == bad_rule:
                             del rules[k]
                             indexed.remove(os.path.basename(bad_rule))
-                            print("Deleted broken yara rule: {}".format(bad_rule))
+                            print(f"Deleted broken yara rule: {bad_rule}")
                             break
                 else:
                     break
             except yara.Error as e:
-                print("There was a syntax error in one or more Yara rules: %s" % e)
+                print(f"There was a syntax error in one or more Yara rules: {e}")
                 log.error("There was a syntax error in one or more Yara rules: %s" % e)
                 break
 
@@ -356,7 +356,7 @@ def init_rooter():
                 "The rooter is required but we can't connect to it as the "
                 "rooter is not actually running. "
                 "(In order to disable the use of rooter, please set route "
-                "and internet to none in routing.conf)."
+                "and internet to none in routing.conf)"
             )
 
         if e.strerror == "Permission denied":
@@ -364,10 +364,10 @@ def init_rooter():
                 "The rooter is required but we can't connect to it due to "
                 "incorrect permissions. Did you assign it the correct group? "
                 "(In order to disable the use of rooter, please set route "
-                "and internet to none in routing.conf)."
+                "and internet to none in routing.conf)"
             )
 
-        raise CuckooStartupError("Unknown rooter error: %s" % e)
+        raise CuckooStartupError(f"Unknown rooter error: {e}")
 
     rooter("cleanup_rooter")
 
@@ -390,7 +390,7 @@ def init_routing():
                 continue
 
             if not hasattr(routing, name):
-                raise CuckooStartupError("Could not find socks5 configuration for %s" % name)
+                raise CuckooStartupError(f"Could not find socks5 configuration for {name}")
 
             entry = routing.get(name)
             socks5s[entry.name] = entry
@@ -402,18 +402,17 @@ def init_routing():
                 continue
 
             if not hasattr(routing, name):
-                raise CuckooStartupError("Could not find VPN configuration for %s" % name)
+                raise CuckooStartupError(f"Could not find VPN configuration for {name}")
 
             entry = routing.get(name)
             # add = 1
             # if not rooter("nic_available", entry.interface):
             # raise CuckooStartupError(
-            #   "The network interface that has been configured for "
-            #    "VPN %s is not available." % entry.name
+            #   f"The network interface that has been configured for VPN {entry.name} is not available"
             # )
             #    add = 0
             if not rooter("rt_available", entry.rt_table):
-                raise CuckooStartupError("The routing table that has been configured for VPN %s is not available." % entry.name)
+                raise CuckooStartupError(f"The routing table that has been configured for VPN {entry.name} is not available")
             vpns[entry.name] = entry
 
             # Disable & enable NAT on this network interface. Disable it just
@@ -445,10 +444,10 @@ def init_routing():
     # Check whether the dirty line exists if it has been defined.
     if routing.routing.internet != "none":
         if not rooter("nic_available", routing.routing.internet):
-            raise CuckooStartupError("The network interface that has been configured as dirty line is not available.")
+            raise CuckooStartupError("The network interface that has been configured as dirty line is not available")
 
         if not rooter("rt_available", routing.routing.rt_table):
-            raise CuckooStartupError("The routing table that has been configured for dirty line interface is not available.")
+            raise CuckooStartupError("The routing table that has been configured for dirty line interface is not available")
 
         # Disable & enable NAT on this network interface. Disable it just
         # in case we still had the same rule from a previous run.
@@ -463,7 +462,7 @@ def init_routing():
     # Check if tor interface exists, if yes then enable nat
     if routing.tor.enabled and routing.tor.interface:
         if not rooter("nic_available", routing.tor.interface):
-            raise CuckooStartupError("The network interface that has been configured as tor line is not available.")
+            raise CuckooStartupError("The network interface that has been configured as tor line is not available")
 
         # Disable & enable NAT on this network interface. Disable it just
         # in case we still had the same rule from a previous run.
@@ -480,7 +479,7 @@ def init_routing():
     # Check if inetsim interface exists, if yes then enable nat
     if routing.inetsim.enabled and routing.inetsim.interface:
         if not rooter("nic_available", routing.inetsim.interface):
-            raise CuckooStartupError("The network interface that has been configured as inetsim line is not available.")
+            raise CuckooStartupError("The network interface that has been configured as inetsim line is not available")
 
         # Disable & enable NAT on this network interface. Disable it just
         # in case we still had the same rule from a previous run.


### PR DESCRIPTION
Cleanup for files in lib/cuckoo/core

1. Use f-strings for non-logging strings
2. Use % format for logging strings
3. Standardisation - Remove last full-stops for logging and printing strings