### PR TITLE
Convert to f-string for modules/auxiliary and modules/machinery

### DIFF
--- a/modules/auxiliary/sniffer.py
+++ b/modules/auxiliary/sniffer.py
@@ -195,9 +195,7 @@ class Sniffer(Auxiliary):
                 log.exception("Failed to start sniffer (interface=%s, host=%s, dump path=%s)", interface, host, file_path)
                 return
 
-            log.info(
-                "Started sniffer with PID %d (interface=%s, host=%s, dump path=%s)", self.proc.pid, interface, host, file_path
-            )
+            log.info("Started sniffer with PID %d (interface=%s, host=%s, dump path=%s)", self.proc.pid, interface, host, file_path)
 
     def stop(self):
         """Stop sniffing.

--- a/modules/auxiliary/sniffer.py
+++ b/modules/auxiliary/sniffer.py
@@ -32,7 +32,7 @@ class Sniffer(Auxiliary):
         remote = self.options.get("remote", False)
         remote_host = self.options.get("host", "")
         if remote:
-            file_path = "/tmp/tcp.dump.%d" % self.task.id
+            file_path = f"/tmp/tcp.dump.{self.task.id}"
         else:
             file_path = os.path.join(CUCKOO_ROOT, "storage", "analyses", str(self.task.id), "dump.pcap")
         host = self.machine.ip
@@ -55,7 +55,7 @@ class Sniffer(Auxiliary):
             resultserver_port = str(cfg.resultserver.port)
 
         if not os.path.exists(tcpdump):
-            log.error('Tcpdump does not exist at path "%s", network ' "capture aborted", tcpdump)
+            log.error('Tcpdump does not exist at path "%s", network capture aborted', tcpdump)
             return
 
         # https://github.com/cuckoosandbox/cuckoo/pull/2842/files
@@ -159,25 +159,25 @@ class Sniffer(Auxiliary):
             except ImportError:
                 DEVNULL = open(os.devnull, "wb")
 
-            f = open("/tmp/%d.sh" % self.task.id, "w")
+            f = open(f"/tmp/{self.task.id}.sh", "w")
             if f:
-                f.write(" ".join(pargs) + " & PID=$!")
+                f.write(f"{' '.join(pargs)} & PID=$!")
                 f.write("\n")
-                f.write("echo $PID > /tmp/%d.pid" % self.task.id)
+                f.write(f"echo $PID > /tmp/{self.task.id}.pid")
                 f.write("\n")
                 f.close()
 
             remote_output = subprocess.check_output(
-                ["scp", "-q", "/tmp/%d.sh" % self.task.id, remote_host + ":/tmp/%d.sh" % self.task.id], stderr=DEVNULL
+                ["scp", "-q", f"/tmp/{self.task.id}.sh", remote_host + f":/tmp/{self.task.id}.sh"], stderr=DEVNULL
             )
             remote_output = subprocess.check_output(
-                ["ssh", remote_host, "nohup", "/bin/bash", "/tmp/%d.sh" % self.task.id, ">", "/tmp/log", "2>", "/tmp/err"],
+                ["ssh", remote_host, "nohup", "/bin/bash", f"/tmp/{self.task.id}.sh", ">", "/tmp/log", "2>", "/tmp/err"],
                 stderr=subprocess.STDOUT,
             )
 
-            self.pid = subprocess.check_output(["ssh", remote_host, "cat", "/tmp/%d.pid" % self.task.id], stderr=DEVNULL).strip()
+            self.pid = subprocess.check_output(["ssh", remote_host, "cat", f"/tmp/{self.task.id}.pid"], stderr=DEVNULL).strip()
             log.info(
-                "Started remote sniffer @ %s with (interface=%s, host=%s, " "dump path=%s, pid=%s)",
+                "Started remote sniffer @ %s with (interface=%s, host=%s, dump path=%s, pid=%s)",
                 remote_host,
                 interface,
                 host,
@@ -185,18 +185,18 @@ class Sniffer(Auxiliary):
                 self.pid,
             )
             remote_output = subprocess.check_output(
-                ["ssh", remote_host, "rm", "-f", "/tmp/%d.pid" % self.task.id, "/tmp/%d.sh" % self.task.id], stderr=DEVNULL
+                ["ssh", remote_host, "rm", "-f", f"/tmp/{self.task.id}.pid", f"/tmp/{self.task.id}.sh"], stderr=DEVNULL
             )
 
         else:
             try:
                 self.proc = subprocess.Popen(pargs, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             except (OSError, ValueError):
-                log.exception("Failed to start sniffer (interface=%s, host=%s, " "dump path=%s)", interface, host, file_path)
+                log.exception("Failed to start sniffer (interface=%s, host=%s, dump path=%s)", interface, host, file_path)
                 return
 
             log.info(
-                "Started sniffer with PID %d (interface=%s, host=%s, " "dump path=%s)", self.proc.pid, interface, host, file_path
+                "Started sniffer with PID %d (interface=%s, host=%s, dump path=%s)", self.proc.pid, interface, host, file_path
             )
 
     def stop(self):
@@ -215,10 +215,10 @@ class Sniffer(Auxiliary):
 
             remote_output = subprocess.check_output(remote_args, stderr=DEVNULL)
 
-            file_path = os.path.join(CUCKOO_ROOT, "storage", "analyses", "%s" % self.task.id, "dump.pcap")
-            file_path2 = "/tmp/tcp.dump.%d" % self.task.id
+            file_path = os.path.join(CUCKOO_ROOT, "storage", "analyses", str(self.task.id), "dump.pcap")
+            file_path2 = f"/tmp/tcp.dump.{self.task.id}"
 
-            remote_output = subprocess.check_output(["scp", "-q", remote_host + ":" + file_path2, file_path], stderr=DEVNULL)
+            remote_output = subprocess.check_output(["scp", "-q", f"{remote_host}:{file_path2}", file_path], stderr=DEVNULL)
             remote_output = subprocess.check_output(["ssh", remote_host, "rm", "-f", file_path2], stderr=DEVNULL)
             return
 
@@ -231,7 +231,7 @@ class Sniffer(Auxiliary):
                         log.debug("Killing sniffer")
                         self.proc.kill()
                 except OSError as e:
-                    log.debug("Error killing sniffer: %s. Continue", e)
+                    log.debug("Error killing sniffer: %s, continuing", e)
                     pass
                 except Exception as e:
                     log.exception("Unable to stop the sniffer with pid %d: %s", self.proc.pid, e)

--- a/modules/machinery/esx.py
+++ b/modules/machinery/esx.py
@@ -56,7 +56,7 @@ class ESX(LibVirtMachinery):
             self.auth = [[libvirt.VIR_CRED_AUTHNAME, libvirt.VIR_CRED_NOECHOPROMPT], self._auth_callback, None]
             return libvirt.openAuth(self.dsn, self.auth, 0)
         except libvirt.libvirtError as libvex:
-            raise CuckooCriticalError("libvirt returned an exception on connection: %s" % libvex)
+            raise CuckooCriticalError(f"libvirt returned an exception on connection: {libvex}")
 
     def _disconnect(self, conn):
         """

--- a/modules/machinery/kvm.py
+++ b/modules/machinery/kvm.py
@@ -36,4 +36,4 @@ class KVM(LibVirtMachinery):
             if iface:
                 self.db.set_machine_interface(label, iface)
             else:
-                print("Can't get iface for {}".format(label))
+                print(f"Can't get iface for {label}")

--- a/modules/machinery/multi.py
+++ b/modules/machinery/multi.py
@@ -21,7 +21,7 @@ def import_plugin(name):
     try:
         module = __import__(name, globals(), locals(), ["dummy"], 0)
     except ImportError as e:
-        raise CuckooCriticalError("Unable to import plugin " '"{0}": {1}'.format(name, e))
+        raise CuckooCriticalError(f'Unable to import plugin "{name}": {e}')
 
     for name, value in inspect.getmembers(module):
         if inspect.isclass(value):
@@ -40,7 +40,7 @@ class MultiMachinery(Machinery):
         if getattr(self, "options", None) is None:
             # First time being called, gather the configs of our sub-machineries
             for machinery_name in options.get("multi").get("machinery").split(","):
-                machinery = {"config": Config(machinery_name), "module": import_plugin("modules.machinery." + machinery_name)()}
+                machinery = {"config": Config(machinery_name), "module": import_plugin(f"modules.machinery.{machinery_name}")()}
                 machinery_label = machinery["module"].LABEL
                 machinery["module"].set_options(machinery["config"])
                 machinery_machines = machinery["config"].get(machinery_name)["machines"]

--- a/modules/machinery/physical.py
+++ b/modules/machinery/physical.py
@@ -52,8 +52,8 @@ class Physical(Machinery):
             elif status == self.ERROR:
                 raise CuckooMachineError(
                     "Unknown error occurred trying to obtain the status of "
-                    "physical machine %s. Please turn it on and check the "
-                    "Cuckoo Agent." % machine.label
+                    f"physical machine {machine.label}. Please turn it on "
+                    " and check the Cuckoo Agent"
                 )
 
     def _get_machine(self, label):
@@ -66,7 +66,7 @@ class Physical(Machinery):
             if label == m.label:
                 return m
 
-        raise CuckooMachineError("No machine with label: %s." % label)
+        raise CuckooMachineError(f"No machine with label: {label}")
 
     def isTaskigDone(self, hostID):
         """This function checks if there are any running tasks for host ID in fog
@@ -74,7 +74,7 @@ class Physical(Machinery):
         @return: Returns true if there is an active task and false if there are none
         """
         try:
-            searchURL = "http://" + self.options.fog.hostname + "/fog/task/active"
+            searchURL = f"http://{self.options.fog.hostname}/fog/task/active"
             r = requests.get(searchURL, headers=headers)
             tasks = r.json()["tasks"]
             flag = True
@@ -83,7 +83,7 @@ class Physical(Machinery):
                     flag = False
             return flag
         except Exception:
-            raise CuckooMachineError("Error while checking for fog task state for hostID " + str(hostID) + ": " + sys.exc_info()[0])
+            raise CuckooMachineError(f"Error while checking for fog task state for hostID {hostID}: {sys.exc_info()[0]}")
 
     def start(self, label):
         """Start a physical machine.
@@ -92,14 +92,14 @@ class Physical(Machinery):
         @raise CuckooMachineError: if unable to start.
         """
         # Check to ensure a given machine is running
-        log.debug("Checking if machine %r is running.", label)
+        log.debug("Checking if machine %s is running", label)
         status = self._status(label)
         if status == self.RUNNING:
-            log.debug("Machine already running: %s.", label)
+            log.debug("Machine already running: %s", label)
         elif status == self.STOPPED:
             self._wait_status(label, self.RUNNING)
         else:
-            raise CuckooMachineError("Error occurred while starting: " "%s (STATUS=%s)" % (label, status))
+            raise CuckooMachineError(f"Error occurred while starting: {label} (STATUS={status})")
 
     def stop(self, label):
 
@@ -111,17 +111,17 @@ class Physical(Machinery):
         hostID = 0
 
         if self._status(label) == self.RUNNING:
-            log.debug("Rebooting machine: %s.", label)
+            log.debug("Rebooting machine: %s", label)
             machine = self._get_machine(label)
 
-            r_hosts = requests.get("http://" + self.options.fog.hostname + "/fog/host", headers=headers)
+            r_hosts = requests.get(f"http://{self.options.fog.hostname}/fog/host", headers=headers)
             hosts = r_hosts.json()["hosts"]
 
             for host in hosts:
                 if machine.name == host["name"]:
-                    print(host["id"] + ": " + host["name"])
+                    print(f"{host['id']}: {host['name']}")
                     hostID = host["id"]
-                    r_types = requests.get("http://" + self.options.fog.hostname + "/fog/tasktype", headers=headers)
+                    r_types = requests.get(f"http://{self.options.fog.hostname}/fog/tasktype", headers=headers)
                     types = r_types.json()
 
                     for t in types["tasktypes"]:
@@ -132,12 +132,12 @@ class Physical(Machinery):
                     payload = json.dumps({"taskTypeID": taskID_Deploy, "shutdown": "", "wol": "true"}).encode()
 
                     r_deploy = requests.post(
-                        "http://" + self.options.fog.hostname + "/fog/host/" + hostID + "/task", headers=headers, data=payload
+                        f"http://{self.options.fog.hostname}/fog/host/{hostID}/task", headers=headers, data=payload
                     )
 
                     try:
                         requests.post(
-                            "http://{0}:{1}".format(machine.ip, CUCKOO_GUEST_PORT) + "/execute",
+                            f"http://{machine.ip}:{CUCKOO_GUEST_PORT}/execute",
                             data={"command": "shutdown -r -f -t 0"},
                         )
                     except Exception:
@@ -146,17 +146,17 @@ class Physical(Machinery):
 
         # We are waiting until we are able to connect to the agent again since we dont know how long it will take to restore the machine
         while not self.isTaskigDone(hostID):
-            log.debug("Restore operation for " + machine.name + " still running.")
+            log.debug("Restore operation for %s still running", machine.name)
             sleep(10)
 
         # After the restore operation is done we are waiting until it is up again and we can connect to the agent
-        url = "http://{0}:{1}".format(machine.ip, CUCKOO_GUEST_PORT)
+        url = f"http://{machine.ip}:{CUCKOO_GUEST_PORT}"
 
         connection_succesful = False
 
         while not connection_succesful:
             try:
-                r = requests.get(url + "/status")
+                r = requests.get(f"{url} /status")
                 print(r.text)
                 connection_succesful = True
             except Exception:
@@ -182,17 +182,17 @@ class Physical(Machinery):
         # For physical machines, the agent can either be contacted or not.
         # However, there is some information to be garnered from potential
         # exceptions.
-        log.debug("Getting status for machine: %s.", label)
+        log.debug("Getting status for machine: %s", label)
         machine = self._get_machine(label)
 
         # The status is only used to determine whether the Guest is running
         # or whether it is in a stopped status, therefore the timeout can most
         # likely be fairly arbitrary. TODO This is a temporary fix as it is
         # not compatible with the new Cuckoo Agent, but it will have to do.
-        url = "http://{0}:{1}".format(machine.ip, CUCKOO_GUEST_PORT)
+        url = f"http://{machine.ip}:{CUCKOO_GUEST_PORT}"
 
         try:
-            r = requests.get(url + "/status")
+            r = requests.get(f"{url}/status")
             print(r.text)
             return self.RUNNING
         except Exception:
@@ -209,25 +209,24 @@ class Physical(Machinery):
         # TODO Handle exceptions such as not being able to connect.
 
         # Parse the HTML.
-        r = requests.get("http://" + self.options.fog.hostname + "/fog/status", headers=headers, verify=False)
+        r = requests.get(f"http://{self.options.fog.hostname}/fog/status", headers=headers, verify=False)
 
         if r.status_code != 200:
-            raise CuckooCriticalError("The FOG server answered with the status code " + str(r.status_code))
+            raise CuckooCriticalError(f"The FOG server answered with the status code {r.status_code}")
 
-        r_hosts = requests.get("http://" + self.options.fog.hostname + "/fog/host", headers=headers, verify=False)
+        r_hosts = requests.get(f"http://{self.options.fog.hostname}/fog/host", headers=headers, verify=False)
         hosts = r_hosts.json()["hosts"]
         hostnames = []
         for host in hosts:
             hostnames.append(host["name"])
-            print("Host " + host["name"] + " has MAC " + host["macs"][0])
+            print(f"Host {host['name']} has MAC {host['macs'][0]}")
 
             # Check whether all our machines are available on FOG.
         for machine in self.machines():
             if machine.label not in hostnames:
                 raise CuckooMachineError(
-                    "The physical machine %s has not been defined in FOG, "
-                    "please investigate and configure the configuration "
-                    "correctly." % machine.label
+                    f"The physical machine {machine.label} has not been defined in FOG, "
+                    "please investigate and configure the configuration correctly"
                 )
 
     def fog_queue_task(self, hostname):
@@ -240,7 +239,7 @@ class Physical(Machinery):
         """Start a machine that's currently shutdown."""
         machine = self._get_machine(label)
 
-        r_hosts = requests.get("http://" + self.options.fog.hostname + "/fog/host", headers=headers, verify=False)
+        r_hosts = requests.get(f"http://{self.options.fog.hostname}/fog/host", headers=headers, verify=False)
         hosts = r_hosts.json()["hosts"]
         for host in hosts:
             if label == host["name"]:
@@ -248,20 +247,20 @@ class Physical(Machinery):
 
         ip = machine.ip
         parts = ip.split(".")
-        broadcastip = parts[0] + "." + parts[1] + "." + parts[2] + ".255"
+        broadcastip = f"{'.'.join(parts[:3])}.255"
 
         if len(macaddr) == 0:
-            log.debug("No Machine with hostname %s found." % label)
+            log.debug("No Machine with hostname %s found", label)
             return
 
         packet = self.create_magic_packet(macaddr)
         if packet is False:
-            log.debug("Sending Wake on Lan message has failed.")
+            log.debug("Sending Wake on Lan message has failed")
 
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
-        log.debug("Sending Wake on Lan message for %s (%s) to Broadcast IP %s." % (label, macaddr, broadcastip))
+        log.debug("Sending Wake on Lan message for %s (%s) to Broadcast IP %s", label, macaddr, broadcastip)
         sock.sendto(packet, (broadcastip, 54545))
         sock.close()
 
@@ -272,7 +271,7 @@ class Physical(Machinery):
             sep = macaddress[2]
             macaddress = macaddress.replace(sep, "")
         else:
-            log.debug("Incorrect MAC address format: %s" % macaddress)
+            log.debug("Incorrect MAC address format: %s", macaddress)
             return False
 
         # Pad the synchronization stream

--- a/modules/machinery/physical.py
+++ b/modules/machinery/physical.py
@@ -156,7 +156,7 @@ class Physical(Machinery):
 
         while not connection_succesful:
             try:
-                r = requests.get(f"{url} /status")
+                r = requests.get(f"{url}/status")
                 print(r.text)
                 connection_succesful = True
             except Exception:

--- a/modules/machinery/qemu.py
+++ b/modules/machinery/qemu.py
@@ -340,7 +340,7 @@ class QEMU(Machinery):
         if not self.options.qemu.path:
             raise CuckooCriticalError("QEMU binary path missing, please add it to the config file")
         if not os.path.exists(self.options.qemu.path):
-            raise CuckooCriticalError('QEMU binary not found at specified path "%s"' % self.options.qemu.path)
+            raise CuckooCriticalError(f'QEMU binary not found at specified path "{self.options.qemu.path}"')
 
         self.qemu_dir = os.path.dirname(self.options.qemu.path)
         self.qemu_img = os.path.join(self.qemu_dir, "qemu-img")
@@ -355,23 +355,23 @@ class QEMU(Machinery):
                 if vm_config.get("platform", "").strip() != "linux":
                     continue
                 if vm_config.get("image", False) and not os.path.exists(vm_config["image"]):
-                    log.error(f"Missed harddrive file for VM: {vm_label}")
+                    log.error("Missed harddrive file for VM: %s", vm_label)
                 if vm_config.get("kernel", False) and not magic.from_file(vm_config["kernel"]).startswith(("Linux kernel", "ELF")):
-                    log.error(f"Bad Kernel file for VM: {vm_label} - {vm_config['kernel']}")
+                    log.error("Bad Kernel file for VM: %s - %s", vm_label, vm_config["kernel"])
                 if vm_config.get("initrd", False) and not magic.from_file(vm_config["initrd"]).startswith("gzip"):
-                    log.error(f"Bad initrd file for VM: {vm_label} - {vm_config['initrd']}")
+                    log.error("Bad initrd file for VM: %s - %s", vm_label, vm_config["initrd"])
                 if vm_config.get("snapshot", False) and vm_config.get("image", False):
                     try:
                         snalshot_list = subprocess.check_output(
                             [self.qemu_img, "snapshot", "-l", vm_config["image"]], universal_newlines=True
                         )
                         if vm_config["snapshot"] not in snalshot_list:
-                            log.error(f"Snapshot: {vm_config['snapshot']} doesn't exist for VM: {vm_label}")
+                            log.error("Snapshot: %s doesn't exist for VM: %s", vm_config["snapshot"], vm_label)
                     except Exception as e:
-                        log.debug(f"Can't check snapshot list for VM:{vm_label} - {e}")
+                        log.debug("Can't check snapshot list for VM: %s - %s", vm_label, e)
 
                 if vm_config.get("interface", False) and HAVE_NETWORKIFACES and vm_config["interface"] not in network_interfaces:
-                    log.error(f"Missed TAP network interface {vm_config['interface']}")
+                    log.error("Missed TAP network interface %s", vm_config["interface"])
             except Exception as e:
                 log.exception(e)
 
@@ -380,7 +380,7 @@ class QEMU(Machinery):
         @param label: virtual machine label.
         @raise CuckooMachineError: if unable to start.
         """
-        log.debug("Starting vm %s" % label)
+        log.debug("Starting vm %s", label)
 
         vm_info = self.db.view_machine_by_label(label)
         vm_options = getattr(self.options, vm_info.name)
@@ -388,7 +388,7 @@ class QEMU(Machinery):
         if vm_options.snapshot:
             snapshot_path = vm_options.image
         else:
-            snapshot_path = os.path.join(os.path.dirname(vm_options.image), "snapshot_%s.qcow2" % vm_info.name)
+            snapshot_path = os.path.join(os.path.dirname(vm_options.image), f"snapshot_{vm_info.name}.qcow2")
             if os.path.exists(snapshot_path):
                 os.remove(snapshot_path)
 
@@ -405,7 +405,7 @@ class QEMU(Machinery):
                 if err:
                     raise OSError(err)
             except OSError as e:
-                raise CuckooMachineError("QEMU failed starting the machine: %s" % e)
+                raise CuckooMachineError(f"QEMU failed starting the machine: {e}")
 
         vm_arch = getattr(vm_options, "arch", "default")
         arch_config = dict(QEMU_ARGS[vm_arch])
@@ -442,20 +442,20 @@ class QEMU(Machinery):
         if hasattr(vm_options, "cpu") and vm_options.cpu:
             final_cmdline += ["-cpu", vm_options.cpu]
 
-        log.debug("Executing QEMU %r", final_cmdline)
+        log.debug("Executing QEMU %s", final_cmdline)
 
         try:
             proc = subprocess.Popen(final_cmdline, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             self.state[vm_info.name] = proc
         except OSError as e:
-            raise CuckooMachineError("QEMU failed starting the machine: %s" % e)
+            raise CuckooMachineError(f"QEMU failed starting the machine: {e}")
 
     def stop(self, label):
         """Stops a virtual machine.
         @param label: virtual machine label.
         @raise CuckooMachineError: if unable to stop.
         """
-        log.debug(f"Stopping vm {label}")
+        log.debug("Stopping vm %s", label)
 
         vm_info = self.db.view_machine_by_label(label)
 
@@ -471,7 +471,7 @@ class QEMU(Machinery):
                 time.sleep(1)
                 stop_me += 1
             else:
-                log.debug(f"Stopping vm {label} timeouted. Killing")
+                log.debug("Stopping vm %s timed out, killing", label)
                 proc.terminate()
                 time.sleep(1)
 

--- a/modules/machinery/virtualbox.py
+++ b/modules/machinery/virtualbox.py
@@ -86,9 +86,7 @@ class VirtualBox(Machinery):
             if err:
                 raise OSError(err)
         except OSError as e:
-            raise CuckooMachineError(
-                f"VBoxManage failed starting the machine in {self.options.virtualbox.mode.upper()} mode: {e}"
-            )
+            raise CuckooMachineError(f"VBoxManage failed starting the machine in {self.options.virtualbox.mode.upper()} mode: {e}")
         self._wait_status(label, self.RUNNING)
 
     def stop(self, label):

--- a/modules/machinery/virtualbox.py
+++ b/modules/machinery/virtualbox.py
@@ -38,9 +38,9 @@ class VirtualBox(Machinery):
         """
         # VirtualBox specific checks.
         if not self.options.virtualbox.path:
-            raise CuckooCriticalError("VirtualBox VBoxManage path missing, " "please add it to the config file")
+            raise CuckooCriticalError("VirtualBox VBoxManage path missing, please add it to the config file")
         if not os.path.exists(self.options.virtualbox.path):
-            raise CuckooCriticalError("VirtualBox VBoxManage not found at " 'specified path "%s"' % self.options.virtualbox.path)
+            raise CuckooCriticalError(f'VirtualBox VBoxManage not found at specified path "{self.options.virtualbox.path}"')
 
         # Base checks.
         super(VirtualBox, self)._initialize_check()
@@ -50,27 +50,27 @@ class VirtualBox(Machinery):
         @param label: virtual machine name.
         @raise CuckooMachineError: if unable to start.
         """
-        log.debug("Starting vm %s" % label)
+        log.debug("Starting vm %s", label)
 
         if self._status(label) == self.RUNNING:
-            raise CuckooMachineError("Trying to start an already " "started vm %s" % label)
+            raise CuckooMachineError(f"Trying to start an already started vm {label}")
 
         vm_info = self.db.view_machine_by_label(label)
         virtualbox_args = [self.options.virtualbox.path, "snapshot", label]
         if vm_info.snapshot:
-            log.debug("Using snapshot {0} for virtual machine " "{1}".format(vm_info.snapshot, label))
+            log.debug("Using snapshot %s for virtual machine %s", vm_info.snapshot, label)
             virtualbox_args.extend(["restore", vm_info.snapshot])
         else:
-            log.debug("Using current snapshot for virtual machine " "{0}".format(label))
+            log.debug("Using current snapshot for virtual machine %s", label)
             virtualbox_args.extend(["restorecurrent"])
 
         try:
             if subprocess.call(
                 virtualbox_args, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True
             ):
-                raise CuckooMachineError("VBoxManage exited with error " "restoring the machine's snapshot")
+                raise CuckooMachineError("VBoxManage exited with error restoring the machine's snapshot")
         except OSError as e:
-            raise CuckooMachineError("VBoxManage failed restoring the " "machine: %s" % e)
+            raise CuckooMachineError(f"VBoxManage failed restoring the machine: {e}")
 
         self._wait_status(label, self.SAVED)
 
@@ -87,7 +87,7 @@ class VirtualBox(Machinery):
                 raise OSError(err)
         except OSError as e:
             raise CuckooMachineError(
-                "VBoxManage failed starting the machine " "in %s mode: %s" % (self.options.virtualbox.mode.upper(), e)
+                f"VBoxManage failed starting the machine in {self.options.virtualbox.mode.upper()} mode: {e}"
             )
         self._wait_status(label, self.RUNNING)
 
@@ -96,10 +96,10 @@ class VirtualBox(Machinery):
         @param label: virtual machine name.
         @raise CuckooMachineError: if unable to stop.
         """
-        log.debug("Stopping vm %s" % label)
+        log.debug("Stopping vm %s", label)
 
         if self._status(label) in [self.POWEROFF, self.ABORTED]:
-            raise CuckooMachineError("Trying to stop an already stopped " "vm %s" % label)
+            raise CuckooMachineError(f"Trying to stop an already stopped vm {label}")
 
         try:
             proc = subprocess.Popen(
@@ -117,13 +117,13 @@ class VirtualBox(Machinery):
                     time.sleep(1)
                     stop_me += 1
                 else:
-                    log.debug("Stopping vm %s timeouted. Killing" % label)
+                    log.debug("Stopping vm %s timed out, killing", label)
                     proc.terminate()
 
             if proc.returncode != 0 and stop_me < int(cfg.timeouts.vm_state):
-                log.debug("VBoxManage exited with error " "powering off the machine")
+                log.debug("VBoxManage exited with error powering off the machine")
         except OSError as e:
-            raise CuckooMachineError("VBoxManage failed powering off the " "machine: %s" % e)
+            raise CuckooMachineError(f"VBoxManage failed powering off the machine: {e}")
         self._wait_status(label, [self.POWEROFF, self.ABORTED, self.SAVED])
 
     def _list(self):
@@ -140,14 +140,14 @@ class VirtualBox(Machinery):
             )
             output, _ = proc.communicate()
         except OSError as e:
-            raise CuckooMachineError("VBoxManage error listing " "installed machines: %s" % e)
+            raise CuckooMachineError(f"VBoxManage error listing installed machines: {e}")
 
         machines = []
         for line in output.split("\n"):
             try:
                 label = line.split('"')[1]
                 if label == "<inaccessible>":
-                    log.warning("Found an inaccessible virtual machine, " "please check its state.")
+                    log.warning("Found an inaccessible virtual machine, please check its state")
                 else:
                     machines.append(label)
             except IndexError:
@@ -160,7 +160,7 @@ class VirtualBox(Machinery):
         @param label: virtual machine name.
         @return: status string.
         """
-        log.debug("Getting status for %s" % label)
+        log.debug("Getting status for %s", label)
         status = None
         try:
             proc = subprocess.Popen(
@@ -176,7 +176,7 @@ class VirtualBox(Machinery):
                 # It's quite common for virtualbox crap utility to exit with:
                 # VBoxManage: error: Details: code E_ACCESSDENIED (0x80070005)
                 # So we just log to debug this.
-                log.debug("VBoxManage returns error checking status for " "machine %s: %s", label, err)
+                log.debug("VBoxManage returns error checking status for machine %s: %s", label, err)
                 status = self.ERROR
         except OSError as e:
             log.warning("VBoxManage failed to check status for machine %s: %s", label, e)
@@ -186,14 +186,14 @@ class VirtualBox(Machinery):
                 state = re.match(r"VMState=\"(\w+)\"", line, re.M | re.I)
                 if state:
                     status = state.group(1)
-                    log.debug("Machine %s status %s" % (label, status))
+                    log.debug("Machine %s status %s", label, status)
                     status = status.lower()
         # Report back status.
         if status:
             self.set_status(label, status)
             return status
         else:
-            raise CuckooMachineError("Unable to get status for %s" % label)
+            raise CuckooMachineError(f"Unable to get status for {label}")
 
     def dump_memory(self, label, path):
         """Takes a memory dump.
@@ -214,9 +214,9 @@ class VirtualBox(Machinery):
                 # It's quite common for virtualbox crap utility to exit with:
                 # VBoxManage: error: Details: code E_ACCESSDENIED (0x80070005)
                 # So we just log to debug this.
-                log.debug("VBoxManage returns error checking status for " "machine %s: %s", label, err)
+                log.debug("VBoxManage returns error checking status for machine %s: %s", label, err)
         except OSError as e:
-            raise CuckooMachineError("VBoxManage failed return it's version: %s" % (e))
+            raise CuckooMachineError(f"VBoxManage failed return it's version: {e}")
 
         if output[:1] == str(5):
             # VirtualBox version 5.x
@@ -233,6 +233,6 @@ class VirtualBox(Machinery):
                 stderr=subprocess.PIPE,
                 close_fds=True,
             )
-            log.info("Successfully generated memory dump for virtual machine " "with label %s to path %s", label, path)
+            log.info("Successfully generated memory dump for virtual machine with label %s to path %s", label, path)
         except OSError as e:
-            raise CuckooMachineError("VBoxManage failed to take a memory " "dump of the machine with label %s: %s" % (label, e))
+            raise CuckooMachineError(f"VBoxManage failed to take a memory dump of the machine with label {label}: {e}")

--- a/modules/machinery/vmware.py
+++ b/modules/machinery/vmware.py
@@ -27,10 +27,10 @@ class VMware(Machinery):
         @raise CuckooMachineError: if configuration is missing or wrong.
         """
         if not self.options.vmware.path:
-            raise CuckooMachineError("VMware vmrun path missing, " "please add it to vmware.conf")
+            raise CuckooMachineError("VMware vmrun path missing, please add it to vmware.conf")
 
         if not os.path.exists(self.options.vmware.path):
-            raise CuckooMachineError("VMware vmrun not found in " "specified path %s" % self.options.vmware.path)
+            raise CuckooMachineError(f"VMware vmrun not found in specified path {self.options.vmware.path}")
         # Consistency checks.
         for machine in self.machines():
             vmx_path = machine.label
@@ -49,10 +49,10 @@ class VMware(Machinery):
         """
         # b".vms"? someone can test?
         if not vmx_path.endswith(".vmx"):
-            raise CuckooMachineError("Wrong configuration: vm path not " "ending with .vmx: %s)" % vmx_path)
+            raise CuckooMachineError(f"Wrong configuration: vm path not ending with .vmx: {vmx_path}")
 
         if not os.path.exists(vmx_path):
-            raise CuckooMachineError("Vm file %s not found" % vmx_path)
+            raise CuckooMachineError(f"Vm file {vmx_path} not found")
 
     def _check_snapshot(self, vmx_path, snapshot):
         """Checks snapshot existance.
@@ -69,13 +69,13 @@ class VMware(Machinery):
             )
             output, _ = p.communicate()
         except OSError as e:
-            raise CuckooMachineError("Unable to get snapshot list for %s. " "Reason: %s" % (vmx_path, e))
+            raise CuckooMachineError(f"Unable to get snapshot list for {vmx_path}: {e}")
         else:
             if output:
                 return snapshot in output
             else:
                 raise CuckooMachineError(
-                    "Unable to get snapshot list for %s. " "No output from " "`vmrun listSnapshots`" % vmx_path
+                    f"Unable to get snapshot list for {vmx_path}, no output from `vmrun listSnapshots`"
                 )
 
     def start(self, vmx_path):
@@ -87,13 +87,13 @@ class VMware(Machinery):
 
         # Preventive check
         if self._is_running(vmx_path):
-            raise CuckooMachineError("Machine %s is already running" % vmx_path)
+            raise CuckooMachineError(f"Machine {vmx_path} is already running")
 
         self._revert(vmx_path, snapshot)
 
         time.sleep(3)
 
-        log.debug("Starting vm %s" % vmx_path)
+        log.debug("Starting vm %s", vmx_path)
         try:
             p = subprocess.Popen(
                 [self.options.vmware.path, "start", vmx_path, self.options.vmware.mode],
@@ -104,17 +104,17 @@ class VMware(Machinery):
             if self.options.vmware.mode.lower() == "gui":
                 output, _ = p.communicate()
                 if output:
-                    raise CuckooMachineError("Unable to start machine " "%s: %s" % (vmx_path, output))
+                    raise CuckooMachineError(f"Unable to start machine {vmx_path}: {output}")
         except OSError as e:
             mode = self.options.vmware.mode.upper()
-            raise CuckooMachineError("Unable to start machine %s in %s " "mode: %s" % (vmx_path, mode, e))
+            raise CuckooMachineError(f"Unable to start machine {vmx_path} in {mode} mode: {e}")
 
     def stop(self, vmx_path):
         """Stops a virtual machine.
         @param vmx_path: path to vmx file
         @raise CuckooMachineError: if unable to stop.
         """
-        log.debug("Stopping vm %s" % vmx_path)
+        log.debug("Stopping vm %s", vmx_path)
         if self._is_running(vmx_path):
             try:
                 if subprocess.call(
@@ -123,9 +123,9 @@ class VMware(Machinery):
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,
                 ):
-                    raise CuckooMachineError("Error shutting down " "machine %s" % vmx_path)
+                    raise CuckooMachineError(f"Error shutting down machine {vmx_path}")
             except OSError as e:
-                raise CuckooMachineError("Error shutting down machine " "%s: %s" % (vmx_path, e))
+                raise CuckooMachineError(f"Error shutting down machine {vmx_path}: {e}")
         else:
             log.warning("Trying to stop an already stopped machine: %s", vmx_path)
 
@@ -135,7 +135,7 @@ class VMware(Machinery):
         @param snapshot: snapshot name
         @raise CuckooMachineError: if unable to revert
         """
-        log.debug("Revert snapshot for vm %s" % vmx_path)
+        log.debug("Revert snapshot for vm %s", vmx_path)
         try:
             if subprocess.call(
                 [self.options.vmware.path, "revertToSnapshot", vmx_path, snapshot],
@@ -143,9 +143,9 @@ class VMware(Machinery):
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
             ):
-                raise CuckooMachineError("Unable to revert snapshot for " "machine %s: vmrun exited with " "error" % vmx_path)
+                raise CuckooMachineError(f"Unable to revert snapshot for machine {vmx_path}: vmrun exited with error")
         except OSError as e:
-            raise CuckooMachineError("Unable to revert snapshot for " "machine %s: %s" % (vmx_path, e))
+            raise CuckooMachineError(f"Unable to revert snapshot for machine {vmx_path}: {e}")
 
     def _is_running(self, vmx_path):
         """Checks if virtual machine is running.
@@ -158,12 +158,12 @@ class VMware(Machinery):
             )
             output, error = p.communicate()
         except OSError as e:
-            raise CuckooMachineError("Unable to check running status for %s. " "Reason: %s" % (vmx_path, e))
+            raise CuckooMachineError(f"Unable to check running status for {vmx_path}: {e}")
         else:
             if output:
                 return vmx_path in output
             else:
-                raise CuckooMachineError("Unable to check running status " "for %s. No output from " "`vmrun list`" % vmx_path)
+                raise CuckooMachineError(f"Unable to check running status for {vmx_path}, no output from `vmrun list`")
 
     def _snapshot_from_vmx(self, vmx_path):
         """Get snapshot for a given vmx file.
@@ -176,9 +176,7 @@ class VMware(Machinery):
         """Take a memory dump of the machine."""
         if not os.path.exists(vmx_path):
             raise CuckooMachineError(
-                "Can't find .vmx file {0}. Ensure to configure a fully qualified path in vmware.conf (key = vmx_path)".format(
-                    vmx_path
-                )
+                f"Can't find .vmx file {vmx_path}. Ensure to configure a fully qualified path in vmware.conf (key = vmx_path)"
             )
 
         try:
@@ -189,7 +187,7 @@ class VMware(Machinery):
                 stderr=subprocess.PIPE,
             )
         except OSError as e:
-            raise CuckooMachineError("vmrun failed to take a memory dump of the machine with label %s: %s" % (vmx_path, e))
+            raise CuckooMachineError(f"vmrun failed to take a memory dump of the machine with label {vmx_path}: {e}")
 
         vmwarepath, _ = os.path.split(vmx_path)
         latestvmem = max(glob.iglob(os.path.join(vmwarepath, "*.vmem")), key=os.path.getctime)
@@ -207,6 +205,6 @@ class VMware(Machinery):
                 stderr=subprocess.PIPE,
             )
         except OSError as e:
-            raise CuckooMachineError("vmrun failed to delete the temporary snapshot in %s: %s" % (vmx_path, e))
+            raise CuckooMachineError(f"vmrun failed to delete the temporary snapshot in {vmx_path}: {e}")
 
-        log.info("Successfully generated memory dump for virtual machine with label %s ", vmx_path)
+        log.info("Successfully generated memory dump for virtual machine with label %s", vmx_path)

--- a/modules/machinery/vmware.py
+++ b/modules/machinery/vmware.py
@@ -74,9 +74,7 @@ class VMware(Machinery):
             if output:
                 return snapshot in output
             else:
-                raise CuckooMachineError(
-                    f"Unable to get snapshot list for {vmx_path}, no output from `vmrun listSnapshots`"
-                )
+                raise CuckooMachineError(f"Unable to get snapshot list for {vmx_path}, no output from `vmrun listSnapshots`")
 
     def start(self, vmx_path):
         """Start a virtual machine.

--- a/modules/machinery/vmwarerest.py
+++ b/modules/machinery/vmwarerest.py
@@ -108,9 +108,7 @@ class VMwareREST(Machinery):
     def get_power_for_vm(self, id):
         vmmoid = self.get_vmmoid(id)
         if vmmoid:
-            status = s.get(
-                f"https://{self.host}:{self.port}/api/vms/{vmmoid}/power", auth=(self.username, self.password)
-            )
+            status = s.get(f"https://{self.host}:{self.port}/api/vms/{vmmoid}/power", auth=(self.username, self.password))
             return status
         log.info("There was a problem querying power status for vm %s", id)
 

--- a/modules/machinery/vmwarerest.py
+++ b/modules/machinery/vmwarerest.py
@@ -25,24 +25,24 @@ class VMwareREST(Machinery):
         @raise CuckooMachineError: if configuration is missing or wrong.
         """
         if not self.options.vmwarerest.host:
-            raise CuckooMachineError("VMwareREST hostname/IP address missing, " "please add it to vmwarerest.conf")
+            raise CuckooMachineError("VMwareREST hostname/IP address missing, please add it to vmwarerest.conf")
         self.host = self.options.vmwarerest.host
         if not self.options.vmwarerest.port:
-            raise CuckooMachineError("VMwareREST server port address missing, " "please add it to vmwarerest.conf")
+            raise CuckooMachineError("VMwareREST server port address missing, please add it to vmwarerest.conf")
         self.port = str(self.options.vmwarerest.port)
         if not self.options.vmwarerest.username:
-            raise CuckooMachineError("VMwareREST username missing, " "please add it to vmwarerest.conf")
+            raise CuckooMachineError("VMwareREST username missing, please add it to vmwarerest.conf")
         self.username = self.options.vmwarerest.username
         if not self.options.vmwarerest.password:
-            raise CuckooMachineError("VMwareREST password missing, " "please add it to vmwarerest.conf")
+            raise CuckooMachineError("VMwareREST password missing, please add it to vmwarerest.conf")
         self.password = self.options.vmwarerest.password
 
         super(VMwareREST, self)._initialize_check()
 
-        log.info("VMwareREST machinery module initialised (%s:%s).", self.host, self.port)
+        log.info("VMwareREST machinery module initialised (%s:%s)", self.host, self.port)
 
     def get_vms(self):
-        vms = s.get("https://" + self.host + ":" + str(self.port) + "/api/vms", auth=(self.username, self.password))
+        vms = s.get(f"https://{self.host}:{self.port}/api/vms", auth=(self.username, self.password))
         if "Authentication failed" in vms.text:
             log.info("Authentication failed, please check credentials in vmwarerest.conf")
             return None
@@ -52,7 +52,7 @@ class VMwareREST(Machinery):
         vms = self.get_vms()
         if vms:
             for vm in vms:
-                if vm["path"].endswith(id + ".vmx"):
+                if vm["path"].endswith(f"{id}.vmx"):
                     return vm["id"]
         log.info("There was a problem getting vmmoid for vm %s", id)
 
@@ -60,7 +60,7 @@ class VMwareREST(Machinery):
         vmmoid = self.get_vmmoid(id)
         if vmmoid:
             status = s.put(
-                "https://" + self.host + ":" + self.port + "/api/vms/" + vmmoid,
+                f"https://{self.host}:{self.port}/api/vms/{vmmoid}",
                 data=json.dumps({}),
                 auth=(self.username, self.password),
             )
@@ -72,7 +72,7 @@ class VMwareREST(Machinery):
     def get_vm_settings(self, id):
         vmmoid = self.get_vmmoid(id)
         if vmmoid:
-            status = s.get("https://" + self.host + ":" + self.port + "/api/vms/" + vmmoid, auth=(self.username, self.password))
+            status = s.get(f"https://{self.host}:{self.port}/api/vms/{vmmoid}", auth=(self.username, self.password))
             return status
         log.info("There was a problem getting settings for vm %s", id)
 
@@ -81,7 +81,7 @@ class VMwareREST(Machinery):
         if vmmoid:
             log.info("Powering on vm %s", id)
             status = s.put(
-                "https://" + self.host + ":" + self.port + "/api/vms/" + vmmoid + "/power",
+                f"https://{self.host}:{self.port}/api/vms/{vmmoid}/power",
                 auth=(self.username, self.password),
                 data="on",
                 headers={"content-type": "application/vnd.vmware.vmw.rest-v1+json"},
@@ -97,7 +97,7 @@ class VMwareREST(Machinery):
         if vmmoid:
             log.info("Powering off vm %s", id)
             status = s.put(
-                "https://" + self.host + ":" + self.port + "/api/vms/" + vmmoid + "/power",
+                f"https://{self.host}:{self.port}/api/vms/{vmmoid}/power",
                 auth=(self.username, self.password),
                 data="off",
                 headers={"content-type": "application/vnd.vmware.vmw.rest-v1+json"},
@@ -109,32 +109,32 @@ class VMwareREST(Machinery):
         vmmoid = self.get_vmmoid(id)
         if vmmoid:
             status = s.get(
-                "https://" + self.host + ":" + self.port + "/api/vms/" + vmmoid + "/power", auth=(self.username, self.password)
+                f"https://{self.host}:{self.port}/api/vms/{vmmoid}/power", auth=(self.username, self.password)
             )
             return status
         log.info("There was a problem querying power status for vm %s", id)
 
     def start(self, id):
-        log.info("Starting vm %s" % id)
+        log.info("Starting vm %s", id)
         self.stop(id)
         self.poweron_vm(id)
 
     def stop(self, id):
         if self._is_running(id):
-            log.info("Stopping vm %s" % id)
+            log.info("Stopping vm %s", id)
             self.poweroff_vm(id)
 
     def _revert(self, id, snapshot):
-        log.info("Revert snapshot for vm %s: %s" % (id, snapshot))
+        log.info("Revert snapshot for vm %s: %s", id, snapshot)
         self.poweroff_vm(id)
 
     def _is_running(self, id):
-        log.info("Checking vm %s" % id)
+        log.info("Checking vm %s", id)
         power_state = self.get_power_for_vm(id)
 
         if power_state and "poweredOn" in power_state.text:
-            log.info("Vm %s is running" % id)
+            log.info("Vm %s is running", id)
             return id
         else:
-            log.info("Vm %s is not running" % id)
+            log.info("Vm %s is not running", id)
             return

--- a/modules/machinery/vmwareserver.py
+++ b/modules/machinery/vmwareserver.py
@@ -24,7 +24,7 @@ class VMwareServer(Machinery):
         @raise CuckooMachineError: if configuration is missing or wrong.
         """
         if not self.options.vmwareserver.path:
-            raise CuckooMachineError("VMware vmrun path missing, " "please add it to vmwareserver.conf")
+            raise CuckooMachineError("VMware vmrun path missing, please add it to vmwareserver.conf")
 
         # Base checks.
         super(VMwareServer, self)._initialize_check()
@@ -35,10 +35,10 @@ class VMwareServer(Machinery):
         @raise CuckooMachineError: if file not found or not ending with .vmx
         """
         if not vmx_path.endswith(".vmx"):
-            raise CuckooMachineError("Wrong configuration: vm path not " "ending with .vmx: %s)" % vmx_path)
+            raise CuckooMachineError(f"Wrong configuration: vm path not ending with .vmx: {vmx_path}")
 
         if not os.path.exists(vmx_path):
-            raise CuckooMachineError("Vm file %s not found" % vmx_path)
+            raise CuckooMachineError(f"Vm file {vmx_path} not found")
 
     def _check_snapshot(self, vmx_path, snapshot):
         """Checks snapshot existance.
@@ -48,30 +48,21 @@ class VMwareServer(Machinery):
         """
 
         check_string = (
-            self.options.vmwareserver.path
-            + " -T ws-shared -h "
-            + self.options.vmwareserver.vmware_url
-            + " -u "
-            + self.options.vmwareserver.username
-            + " -p "
-            + self.options.vmwareserver.password
-            + " listSnapshots "
-            + '"'
-            + vmx_path
-            + '"'
+            f"{self.options.vmwareserver.path} -T ws-shared -h {self.options.vmwareserver.vmware_url} -u {self.options.vmwareserver.username} "
+            f'-p {self.options.vmwareserver.password} listSnapshots "{vmx_path}"'
         )
 
         try:
             p = subprocess.Popen(check_string, universal_newlines=True, shell=True)
             output, _ = p.communicate()
         except OSError as e:
-            raise CuckooMachineError("Unable to get snapshot list for %s. " "Reason: %s" % (vmx_path, e))
+            raise CuckooMachineError(f"Unable to get snapshot list for {vmx_path}: {e}")
         else:
             if output:
                 return snapshot in output
             else:
                 raise CuckooMachineError(
-                    "Unable to get snapshot list for %s. " "No output from " "`vmrun listSnapshots`" % vmx_path
+                    f"Unable to get snapshot list for {vmx_path}, no output from `vmrun listSnapshots`"
                 )
 
     def start(self, vmx_path):
@@ -84,7 +75,7 @@ class VMwareServer(Machinery):
 
         # Check if the machine is already running, stop if so.
         if self._is_running(vmx_path):
-            log.debug("Machine %s is already running, attempting to stop..." % vmx_path)
+            log.debug("Machine %s is already running, attempting to stop...", vmx_path)
             self.stop(vmx_path)
             time.sleep(3)
 
@@ -93,30 +84,21 @@ class VMwareServer(Machinery):
         time.sleep(3)
 
         start_string = (
-            self.options.vmwareserver.path
-            + " -T ws-shared -h "
-            + self.options.vmwareserver.vmware_url
-            + " -u "
-            + self.options.vmwareserver.username
-            + " -p "
-            + self.options.vmwareserver.password
-            + " start "
-            + '"'
-            + vmx_path
-            + '"'
+            f"{self.options.vmwareserver.path} -T ws-shared -h {self.options.vmwareserver.vmware_url} -u {self.options.vmwareserver.username} "
+            f'-p {self.options.vmwareserver.password} start "{vmx_path}"'
         )
 
-        log.debug("Starting vm %s" % vmx_path)
+        log.debug("Starting vm %s", vmx_path)
 
         try:
             p = subprocess.Popen(start_string, universal_newlines=True, shell=True)
             if self.options.vmwareserver.mode.lower() == "gui":
                 output, _ = p.communicate()
                 if output:
-                    raise CuckooMachineError("Unable to start machine " "%s: %s" % (vmx_path, output))
+                    raise CuckooMachineError(f"Unable to start machine {vmx_path}: {output}")
         except OSError as e:
             mode = self.options.vmwareserver.mode.upper()
-            raise CuckooMachineError("Unable to start machine %s in %s " "mode: %s" % (vmx_path, mode, e))
+            raise CuckooMachineError(f"Unable to start machine {vmx_path} in {mode} mode: {e}")
 
     def stop(self, vmx_path):
         """Stops a virtual machine.
@@ -125,28 +107,19 @@ class VMwareServer(Machinery):
         """
 
         stop_string = (
-            self.options.vmwareserver.path
-            + " -T ws-shared -h "
-            + self.options.vmwareserver.vmware_url
-            + " -u "
-            + self.options.vmwareserver.username
-            + " -p "
-            + self.options.vmwareserver.password
-            + " stop "
-            + '"'
-            + vmx_path
-            + '" hard'
+            f"{self.options.vmwareserver.path} -T ws-shared -h {self.options.vmwareserver.vmware_url} -u {self.options.vmwareserver.username} "
+            f'-p {self.options.vmwareserver.password} stop "{vmx_path}" hard'
         )
 
-        log.debug("Stopping vm %s" % vmx_path)
-        # log.debug("Stop string: %s" % stop_string)
+        log.debug("Stopping vm %s", vmx_path)
+        # log.debug("Stop string: %s", stop_string)
 
         if self._is_running(vmx_path):
             try:
                 if subprocess.call(stop_string, universal_newlines=True, shell=True):
-                    raise CuckooMachineError("Error shutting down " "machine %s" % vmx_path)
+                    raise CuckooMachineError(f"Error shutting down machine {vmx_path}")
             except OSError as e:
-                raise CuckooMachineError("Error shutting down machine " "%s: %s" % (vmx_path, e))
+                raise CuckooMachineError(f"Error shutting down machine {vmx_path}: {e}")
         else:
 
             log.warning("Trying to stop an already stopped machine: %s", vmx_path)
@@ -157,31 +130,21 @@ class VMwareServer(Machinery):
         @param snapshot: snapshot name
         @raise CuckooMachineError: if unable to revert
         """
-        log.debug("Revert snapshot for vm %s: %s" % (vmx_path, snapshot))
+        log.debug("Revert snapshot for vm %s: %s", vmx_path, snapshot)
 
         revert_string = (
-            self.options.vmwareserver.path
-            + " -T ws-shared -h "
-            + self.options.vmwareserver.vmware_url
-            + " -u "
-            + self.options.vmwareserver.username
-            + " -p "
-            + self.options.vmwareserver.password
-            + " revertToSnapshot "
-            + '"'
-            + vmx_path
-            + '" '
-            + snapshot
+            f"{self.options.vmwareserver.path} -T ws-shared -h {self.options.vmwareserver.vmware_url} -u {self.options.vmwareserver.username} "
+            f'-p {self.options.vmwareserver.password} revertToSnapshot "{vmx_path}" snapshot'
         )
 
-        # log.debug("Revert string: %s" % revert_string)
+        # log.debug("Revert string: %s", revert_string)
 
         try:
             if subprocess.call(revert_string, universal_newlines=True, shell=True):
-                raise CuckooMachineError("Unable to revert snapshot for " "machine %s: vmrun exited with " "error" % vmx_path)
+                raise CuckooMachineError(f"Unable to revert snapshot for machine {vmx_path}: vmrun exited with error")
 
         except OSError as e:
-            raise CuckooMachineError("Unable to revert snapshot for " "machine %s: %s" % (vmx_path, e))
+            raise CuckooMachineError(f"Unable to revert snapshot for machine {vmx_path}: {e}")
 
     def _is_running(self, vmx_path):
         """Checks if virtual machine is running.
@@ -189,31 +152,22 @@ class VMwareServer(Machinery):
         @return: running status
         """
         list_string = (
-            self.options.vmwareserver.path
-            + " -T ws-shared -h "
-            + self.options.vmwareserver.vmware_url
-            + " -u "
-            + self.options.vmwareserver.username
-            + " -p "
-            + self.options.vmwareserver.password
-            + " list "
-            + '"'
-            + vmx_path
-            + '"'
+            f"{self.options.vmwareserver.path} -T ws-shared -h {self.options.vmwareserver.vmware_url} -u {self.options.vmwareserver.username} "
+            f'-p {self.options.vmwareserver.password} list "{vmx_path}"'
         )
 
-        # log.debug("List string: %s" % list_string)
+        # log.debug("List string: %s", list_string)
 
         try:
             p = subprocess.Popen(list_string, universal_newlines=True, stdout=subprocess.PIPE, shell=True)
             output, error = p.communicate()
         except OSError as e:
-            raise CuckooMachineError("Unable to check running status for %s. " "Reason: %s" % (vmx_path, e))
+            raise CuckooMachineError(f"Unable to check running status for {vmx_path}: {e}")
         else:
             if output:
                 return vmx_path in output
             else:
-                raise CuckooMachineError("Unable to check running status " "for %s. No output from " "`vmrun list`" % vmx_path)
+                raise CuckooMachineError(f"Unable to check running status for {vmx_path}. No output from `vmrun list`")
 
     def _snapshot_from_vmx(self, vmx_path):
         """Get snapshot for a given vmx file.

--- a/modules/machinery/vmwareserver.py
+++ b/modules/machinery/vmwareserver.py
@@ -61,9 +61,7 @@ class VMwareServer(Machinery):
             if output:
                 return snapshot in output
             else:
-                raise CuckooMachineError(
-                    f"Unable to get snapshot list for {vmx_path}, no output from `vmrun listSnapshots`"
-                )
+                raise CuckooMachineError(f"Unable to get snapshot list for {vmx_path}, no output from `vmrun listSnapshots`")
 
     def start(self, vmx_path):
         """Start a virtual machine.

--- a/modules/machinery/vsphere.py
+++ b/modules/machinery/vsphere.py
@@ -40,7 +40,7 @@ class vSphere(Machinery):
 
     def __init__(self):
         if not HAVE_PYVMOMI:
-            raise CuckooDependencyError("Couldn't import pyVmomi. Please install " "using 'pip3 install --upgrade pyvmomi'")
+            raise CuckooDependencyError("Couldn't import pyVmomi. Please install using 'pip3 install --upgrade pyvmomi'")
 
         super(vSphere, self).__init__()
 
@@ -64,22 +64,22 @@ class vSphere(Machinery):
         if self.options.vsphere.host:
             self.connect_opts["host"] = self.options.vsphere.host
         else:
-            raise CuckooCriticalError("vSphere host address setting not found, " "please add it to the config file.")
+            raise CuckooCriticalError("vSphere host address setting not found, please add it to the config file")
 
         if self.options.vsphere.port:
             self.connect_opts["port"] = self.options.vsphere.port
         else:
-            raise CuckooCriticalError("vSphere port setting not found, " "please add it to the config file.")
+            raise CuckooCriticalError("vSphere port setting not found, please add it to the config file")
 
         if self.options.vsphere.user:
             self.connect_opts["user"] = self.options.vsphere.user
         else:
-            raise CuckooCriticalError("vSphere username setting not found, " "please add it to the config file.")
+            raise CuckooCriticalError("vSphere username setting not found, please add it to the config file")
 
         if self.options.vsphere.pwd:
             self.connect_opts["pwd"] = self.options.vsphere.pwd
         else:
-            raise CuckooCriticalError("vSphere password setting not found, " "please add it to the config file.")
+            raise CuckooCriticalError("vSphere password setting not found, please add it to the config file")
 
         # Workaround for PEP-0476 issues in recent Python versions
         if self.options.vsphere.unverified_ssl:
@@ -96,27 +96,21 @@ class vSphere(Machinery):
                 for machine in self.machines():
                     if not machine.snapshot:
                         raise CuckooCriticalError(
-                            "Snapshot name not specified "
-                            "for machine {0}, please add "
-                            "it to the config file.".format(machine.label)
+                            f"Snapshot name not specified for machine {machine.label}, please add it to the config file"
                         )
                     vm = self._get_virtual_machine_by_label(conn, machine.label)
                     if not vm:
                         raise CuckooCriticalError(
-                            "Unable to find machine {0} "
-                            "on vSphere host, please "
-                            "update your configuration.".format(machine.label)
+                            f"Unable to find machine {machine.label} on vSphere host, please update your configuration"
                         )
                     state = self._get_snapshot_power_state(vm, machine.snapshot)
                     if not state:
                         raise CuckooCriticalError(
-                            "Unable to find snapshot {0} "
-                            "for machine {1}, please "
-                            "update your configuration.".format(machine.snapshot, machine.label)
+                            f"Unable to find snapshot {machine.snapshot} for machine {machine.label}, please update your configuration"
                         )
                     if state != self.RUNNING:
                         raise CuckooCriticalError(
-                            "Snapshot for machine {0} not " "in powered-on state, please " "create one.".format(machine.label)
+                            f"Snapshot for machine {machine.label} not in powered-on state, please create one"
                         )
 
         except CuckooCriticalError:
@@ -138,7 +132,7 @@ class vSphere(Machinery):
             if vm:
                 self._revert_snapshot(vm, name)
             else:
-                raise CuckooMachineError("Machine {0} not found on host".format(label))
+                raise CuckooMachineError(f"Machine {label} not found on host")
 
     def stop(self, label):
         """Stop a machine.
@@ -150,14 +144,14 @@ class vSphere(Machinery):
             if vm:
                 self._stop_virtual_machine(vm)
             else:
-                raise CuckooMachineError("Machine {0} not found on host".format(label))
+                raise CuckooMachineError(f"Machine {label} not found on host")
 
     def dump_memory(self, label, path):
         """Take a memory dump of a machine.
         @param path: path to where to store the memory dump
         @raise CuckooMachineError: if error taking the memory dump
         """
-        name = "cuckoo_memdump_{0}".format(random.randint(100000, 999999))
+        name = f"cuckoo_memdump_{random.randint(100000, 999999)}"
         with SmartConnection(**self.connect_opts) as conn:
             vm = self._get_virtual_machine_by_label(conn, label)
             if vm:
@@ -165,7 +159,7 @@ class vSphere(Machinery):
                 self._download_snapshot(conn, vm, name, path)
                 self._delete_snapshot(vm, name)
             else:
-                raise CuckooMachineError("Machine {0} not found on host".format(label))
+                raise CuckooMachineError(f"Machine {label} not found on host")
 
     def _list(self):
         """List virtual machines on vSphere host"""
@@ -182,7 +176,7 @@ class vSphere(Machinery):
         with SmartConnection(**self.connect_opts) as conn:
             vm = self._get_virtual_machine_by_label(conn, label)
             if not vm:
-                raise CuckooMachineError("Machine {0} not found on server".format(label))
+                raise CuckooMachineError(f"Machine {label} not found on server")
 
             status = vm.runtime.powerState
             self.set_status(label, status)
@@ -194,7 +188,7 @@ class vSphere(Machinery):
         def traverseDCFolders(conn, nodes, path=""):
             for node in nodes:
                 if hasattr(node, "childEntity"):
-                    for child, childpath in traverseDCFolders(conn, node.childEntity, path + node.name + "/"):
+                    for child, childpath in traverseDCFolders(conn, node.childEntity, f"{path}{node.name}/"):
                         yield child, childpath
                 else:
                     yield node, path + node.name
@@ -234,38 +228,38 @@ class vSphere(Machinery):
 
     def _create_snapshot(self, vm, name):
         """Create named snapshot of virtual machine"""
-        log.info("Creating snapshot {0} for machine {1}".format(name, vm.summary.config.name))
+        log.info("Creating snapshot %s for machine %s", name, vm.summary.config.name)
         task = vm.CreateSnapshot_Task(name=name, description="Created by Cuckoo sandbox", memory=True, quiesce=False)
         try:
             self._wait_task(task)
         except CuckooMachineError as e:
-            raise CuckooMachineError("CreateSnapshot: {0}".format(e))
+            raise CuckooMachineError(f"CreateSnapshot: {e}")
 
     def _delete_snapshot(self, vm, name):
         """Remove named snapshot of virtual machine"""
         snapshot = self._get_snapshot_by_name(vm, name)
         if snapshot:
-            log.info("Removing snapshot {0} for machine {1}".format(name, vm.summary.config.name))
+            log.info("Removing snapshot %s for machine %s", name, vm.summary.config.name)
             task = snapshot.RemoveSnapshot_Task(removeChildren=True)
             try:
                 self._wait_task(task)
             except CuckooMachineError as e:
-                log.error("RemoveSnapshot: {0}".format(e))
+                log.error("RemoveSnapshot: %s", e)
         else:
-            raise CuckooMachineError("Snapshot {0} for machine {1} not found".format(name, vm.summary.config.name))
+            raise CuckooMachineError(f"Snapshot {name} for machine {vm.summary.config.name} not found")
 
     def _revert_snapshot(self, vm, name):
         """Revert virtual machine to named snapshot"""
         snapshot = self._get_snapshot_by_name(vm, name)
         if snapshot:
-            log.info("Reverting machine {0} to snapshot {1}".format(vm.summary.config.name, name))
+            log.info("Reverting machine %s to snapshot %s", vm.summary.config.name, name)
             task = snapshot.RevertToSnapshot_Task()
             try:
                 self._wait_task(task)
             except CuckooMachineError as e:
-                raise CuckooMachineError("RevertToSnapshot: {0}".format(e))
+                raise CuckooMachineError(f"RevertToSnapshot: {e}")
         else:
-            raise CuckooMachineError("Snapshot {0} for machine {1} not found".format(name, vm.summary.config.name))
+            raise CuckooMachineError(f"Snapshot {name} for machine {vm.summary.config.name} not found")
 
     def _download_snapshot(self, conn, vm, name, path):
         """Download snapshot file from host to local path"""
@@ -273,7 +267,7 @@ class vSphere(Machinery):
         # Get filespec to .vmsn file of named snapshot
         snapshot = self._get_snapshot_by_name(vm, name)
         if not snapshot:
-            raise CuckooMachineError("Snapshot {0} for machine {1} not found".format(name, vm.summary.config.name))
+            raise CuckooMachineError(f"Snapshot {name} for machine {vm.summary.config.name} not found")
 
         memorykey = datakey = filespec = None
         for s in vm.layoutEx.snapshot:
@@ -296,7 +290,7 @@ class vSphere(Machinery):
         if not filespec:
             raise CuckooMachineError("Could not find memory snapshot file")
 
-        log.info("Downloading memory dump {0} to {1}".format(filespec, path))
+        log.info("Downloading memory dump %s to %s", filespec, path)
 
         # Parse filespec to get datastore and file path
         datastore, filepath = re.match(r"\[([^\]]*)\] (.*)", filespec).groups()
@@ -304,7 +298,7 @@ class vSphere(Machinery):
         # Construct URL request
         params = {"dsName": datastore, "dcPath": self.VMtoDC.get(vm.summary.config.name, "ha-datacenter")}
         headers = {"Cookie": conn._stub.cookie}
-        url = "https://{0}:{1}/folder/{2}".format(self.connect_opts["host"], self.connect_opts["port"], filepath)
+        url = f"https://{self.connect_opts['host']}:{self.connect_opts['port']}/folder/{filepath}"
 
         # Stream download to specified local path
         try:
@@ -317,16 +311,16 @@ class vSphere(Machinery):
                     localfile.write(chunk)
 
         except Exception as e:
-            raise CuckooMachineError("Error downloading memory dump {0}: {1}".format(filespec, e))
+            raise CuckooMachineError(f"Error downloading memory dump {filespec}: {e}")
 
     def _stop_virtual_machine(self, vm):
         """Power off a virtual machine"""
-        log.info("Powering off virtual machine {0}".format(vm.summary.config.name))
+        log.info("Powering off virtual machine %s", vm.summary.config.name)
         task = vm.PowerOffVM_Task()
         try:
             self._wait_task(task)
         except CuckooMachineError as e:
-            log.error("PowerOffVM: {0}".format(e))
+            log.error("PowerOffVM: %s", e)
 
     def _wait_task(self, task):
         """Wait for a task to complete with timeout"""

--- a/modules/machinery/xenserver.py
+++ b/modules/machinery/xenserver.py
@@ -36,9 +36,7 @@ class XenServerMachinery(Machinery):
     ABORTED = "Suspended"
 
     def _initialize_check(self):
-        """Check XenServer configuration, initialize a Xen API connection, and
-        verify machine validity.
-        """
+        """Check XenServer configuration, initialize a Xen API connection, and verify machine validity."""
 
         self._sessions = {}
 
@@ -46,13 +44,13 @@ class XenServerMachinery(Machinery):
             raise CuckooDependencyError("Unable to import XenAPI")
 
         if not self.options.xenserver.user:
-            raise CuckooMachineError("XenServer username missing, please add " "it to xenserver.conf.")
+            raise CuckooMachineError("XenServer username missing, please add it to xenserver.conf")
 
         if not self.options.xenserver.password:
-            raise CuckooMachineError("XenServer password missing, please add " "it to xenserver.conf")
+            raise CuckooMachineError("XenServer password missing, please add it to xenserver.conf")
 
         if not self.options.xenserver.url:
-            raise CuckooMachineError("XenServer url missing, please add it to " "xenserver.conf")
+            raise CuckooMachineError("XenServer url missing, please add it to xenserver.conf")
 
         self._make_xenapi_session()
 
@@ -81,17 +79,14 @@ class XenServerMachinery(Machinery):
             sess = XenAPI.Session(self.options.xenserver.url)
         except Exception:
             raise CuckooMachineError(
-                "Could not connect to XenServer: invalid " "or incorrect url, please ensure the url " "is correct in xenserver.conf"
+                "Could not connect to XenServer: invalid or incorrect url, please ensure the url is correct in xenserver.conf"
             )
 
         try:
             sess.xenapi.login_with_password(self.options.xenserver.user, self.options.xenserver.password)
         except Exception:
             raise CuckooMachineError(
-                "Could not connect to XenServer: "
-                "incorrect credentials, please ensure "
-                "the user and password are correct in "
-                "xenserver.conf"
+                "Could not connect to XenServer: incorrect credentials, please ensure the user and password are correct in xenserver.conf"
             )
         self._sessions[tid] = sess
         return sess
@@ -126,16 +121,16 @@ class XenServerMachinery(Machinery):
             ref = self._get_vm_ref(uuid)
             vm = self._get_vm_record(ref)
         except XenAPI.Failure as e:
-            raise CuckooMachineError("Vm not found: %s: %s" % (uuid, e.details[0]))
+            raise CuckooMachineError(f"Vm not found: {uuid}: {e.details[0]}")
 
         if vm["is_a_snapshot"]:
-            raise CuckooMachineError("Vm is a snapshot: %s" % uuid)
+            raise CuckooMachineError(f"Vm is a snapshot: {uuid}")
 
         if vm["is_a_template"]:
-            raise CuckooMachineError("Vm is a template: %s" % uuid)
+            raise CuckooMachineError(f"Vm is a template: {uuid}")
 
         if vm["is_control_domain"]:
-            raise CuckooMachineError("Vm is a control domain: %s" % uuid)
+            raise CuckooMachineError(f"Vm is a control domain: {uuid}")
 
         return (ref, vm)
 
@@ -150,19 +145,19 @@ class XenServerMachinery(Machinery):
             snapshot_ref = self._get_vm_ref(snapshot_uuid)
             snapshot = self._get_vm_record(snapshot_ref)
         except Exception:
-            raise CuckooMachineError("Snapshot not found: %s" % snapshot_uuid)
+            raise CuckooMachineError(f"Snapshot not found: {snapshot_uuid}")
 
         if not snapshot["is_a_snapshot"]:
-            raise CuckooMachineError("Invalid snapshot: %s" % snapshot_uuid)
+            raise CuckooMachineError(f"Invalid snapshot: {snapshot_uuid}")
 
         try:
             parent = self._get_vm_record(snapshot["snapshot_of"])
         except Exception:
-            raise CuckooMachineError("Invalid snapshot: %s" % snapshot_uuid)
+            raise CuckooMachineError(f"Invalid snapshot: {snapshot_uuid}")
 
         parent_uuid = parent["uuid"]
         if parent_uuid != vm_uuid:
-            raise CuckooMachineError("Snapshot does not belong to specified " "vm: %s" % snapshot_uuid)
+            raise CuckooMachineError(f"Snapshot does not belong to specified vm: {snapshot_uuid}")
 
     def _check_disks_reset(self, vm):
         """Check whether each attached disk is set to reset on boot.
@@ -186,8 +181,8 @@ class XenServerMachinery(Machinery):
 
                 if vdi["on_boot"] != "reset" and vdi["read_only"] is False:
                     raise CuckooMachineError(
-                        "Vm %s contains invalid VDI %s: disk is not reset on "
-                        "boot. Please set the on-boot parameter to 'reset'." % (vm["uuid"], vdi["uuid"])
+                        f"Vm {vm['uuid']} contains invalid VDI {vdi['uuid']}: disk is not reset on "
+                        "boot. Please set the on-boot parameter to 'reset'"
                     )
 
     def _snapshot_from_vm_uuid(self, uuid):
@@ -214,7 +209,7 @@ class XenServerMachinery(Machinery):
         vm = self._get_vm_record(vm_ref)
 
         if not self._is_halted(vm):
-            raise CuckooMachineError("Vm is already running: %s", label)
+            raise CuckooMachineError(f"Vm is already running: {label}")
 
         snapshot = self._snapshot_from_vm_uuid(label)
         if snapshot:
@@ -224,19 +219,19 @@ class XenServerMachinery(Machinery):
                 self.session.xenapi.VM.revert(snapshot_ref)
                 log.debug("Revert completed for vm %s", label)
             except XenAPI.Failure as e:
-                raise CuckooMachineError("Unable to revert vm %s: %s" % (label, e.details[0]))
+                raise CuckooMachineError(f"Unable to revert vm {label}: {e.details[0]}")
 
             try:
                 log.debug("Resuming reverted vm %s", label)
                 self.session.xenapi.VM.resume(vm_ref, False, False)
             except XenAPI.Failure as e:
-                raise CuckooMachineError("Unable to resume vm %s: %s" % (label, e.details[0]))
+                raise CuckooMachineError(f"Unable to resume vm {label}: {e.details[0]}")
         else:
             log.debug("No snapshot found for vm, booting: %s", label)
             try:
                 self.session.xenapi.VM.start(vm_ref, False, False)
             except XenAPI.Failure as e:
-                raise CuckooMachineError("Unable to start vm %s: %s" % (label, e.details[0]))
+                raise CuckooMachineError(f"Unable to start vm {label}: {e.details[0]}")
 
         log.debug("Started vm: %s", label)
 
@@ -253,7 +248,7 @@ class XenServerMachinery(Machinery):
             try:
                 self.session.xenapi.VM.hard_shutdown(ref)
             except XenAPI.Failure as e:
-                raise CuckooMachineError("Error shutting down virtual machine:" " %s: %s" % (label, e.details[0]))
+                raise CuckooMachineError(f"Error shutting down virtual machine: {label}: {e.details[0]}")
 
     def _list(self):
         """List available virtual machines.


### PR DESCRIPTION
Changes done:
1) Convert strings to f-strings (other than for logging)
2) Standardise logging (no full-stop at the end)

All files have been run through `black -l 132`