### PR TITLE
Reformat imports for modules folder

### DIFF
--- a/modules/machinery/proxmox.py
+++ b/modules/machinery/proxmox.py
@@ -7,14 +7,14 @@ import logging
 import sys
 import time
 
+from lib.cuckoo.common.abstracts import Machinery
+from lib.cuckoo.common.config import Config
+from lib.cuckoo.common.exceptions import CuckooCriticalError, CuckooMachineError
+
 try:
     from proxmoxer import ProxmoxAPI, ResourceException
 except ImportError:
     sys.exit("Missed dependency: pip3 install proxmoxer -U")
-
-from lib.cuckoo.common.abstracts import Machinery
-from lib.cuckoo.common.config import Config
-from lib.cuckoo.common.exceptions import CuckooCriticalError, CuckooMachineError
 
 # silence overly verbose INFO level logging default of proxmoxer module
 logging.getLogger("proxmoxer").setLevel(logging.WARNING)

--- a/modules/machinery/virtualbox.py
+++ b/modules/machinery/virtualbox.py
@@ -9,14 +9,14 @@ import os.path
 import subprocess
 import time
 
+from lib.cuckoo.common.abstracts import Machinery
+from lib.cuckoo.common.config import Config
+from lib.cuckoo.common.exceptions import CuckooCriticalError, CuckooMachineError
+
 try:
     import re2 as re
 except ImportError:
     import re
-
-from lib.cuckoo.common.abstracts import Machinery
-from lib.cuckoo.common.config import Config
-from lib.cuckoo.common.exceptions import CuckooCriticalError, CuckooMachineError
 
 log = logging.getLogger(__name__)
 cfg = Config()

--- a/modules/processing/analysisinfo.py
+++ b/modules/processing/analysisinfo.py
@@ -16,13 +16,6 @@ from lib.cuckoo.common.exceptions import CuckooProcessingError
 from lib.cuckoo.common.utils import get_options
 from lib.cuckoo.core.database import Database
 
-try:
-    import requests
-
-    HAVE_REQUEST = True
-except ImportError:
-    HAVE_REQUEST = False
-
 
 log = logging.getLogger(__name__)
 report_cfg = Config("reporting")

--- a/modules/processing/analysisinfo.py
+++ b/modules/processing/analysisinfo.py
@@ -16,7 +16,6 @@ from lib.cuckoo.common.exceptions import CuckooProcessingError
 from lib.cuckoo.common.utils import get_options
 from lib.cuckoo.core.database import Database
 
-
 log = logging.getLogger(__name__)
 report_cfg = Config("reporting")
 

--- a/modules/processing/antiransomware.py
+++ b/modules/processing/antiransomware.py
@@ -18,7 +18,6 @@ import logging
 
 from lib.cuckoo.common.abstracts import Processing
 from lib.cuckoo.common.config import Config
-from lib.cuckoo.common.constants import CUCKOO_ROOT
 
 log = logging.getLogger()
 # ToDo store list of exclude files if conf enable to store them

--- a/modules/processing/curtain.py
+++ b/modules/processing/curtain.py
@@ -1,19 +1,17 @@
 from __future__ import absolute_import
+import ast
+import base64
+import itertools
+import logging
 import os
+import xml.etree.ElementTree as ET
+
+from lib.cuckoo.common.abstracts import Processing
 
 try:
     import re2 as re
 except ImportError:
     import re
-
-import ast
-import base64
-import itertools
-import logging
-import xml.etree.ElementTree as ET
-
-from lib.cuckoo.common.abstracts import Processing
-from lib.cuckoo.common.exceptions import CuckooProcessingError
 
 log = logging.getLogger(__name__)
 

--- a/modules/processing/dumptls.py
+++ b/modules/processing/dumptls.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2010-2014 Cuckoo Foundation.
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
+
 import binascii
 import logging
 import os

--- a/modules/processing/maliciousmacrobot.py
+++ b/modules/processing/maliciousmacrobot.py
@@ -20,14 +20,14 @@ from lib.cuckoo.common.abstracts import Processing
 from lib.cuckoo.common.constants import CUCKOO_ROOT
 from lib.cuckoo.common.objects import File
 
-log = logging.getLogger(__name__)
-
 try:
     from mmbot import MaliciousMacroBot
 
     HAVE_MMBOT = True
 except Exception:
     HAVE_MMBOT = False
+
+log = logging.getLogger(__name__)
 
 
 class MMBot(Processing):

--- a/modules/processing/memory.py
+++ b/modules/processing/memory.py
@@ -6,14 +6,11 @@
 #  https://github.com/Cisco-Talos/pyrebox/blob/python3migration/pyrebox/volatility_glue.py
 
 # Vol3 docs - https://volatility3.readthedocs.io/en/latest/index.html
+
 from __future__ import absolute_import
 import logging
 import os
-
-try:
-    import re2 as re
-except ImportError:
-    import re
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from lib.cuckoo.common.abstracts import Processing
 from lib.cuckoo.common.config import Config
@@ -21,14 +18,16 @@ from lib.cuckoo.common.constants import CUCKOO_ROOT
 from lib.cuckoo.common.exceptions import CuckooProcessingError
 
 try:
-    from typing import Any, Dict, List, Optional, Tuple, Type, Union
+    import re2 as re
+except ImportError:
+    import re
 
+try:
     import volatility3.plugins
     import volatility3.symbols
     from volatility3 import framework
     from volatility3.cli.text_renderer import JsonRenderer
-    from volatility3.framework import automagic, configuration, constants, contexts, exceptions, interfaces, plugins
-    from volatility3.framework.configuration import requirements
+    from volatility3.framework import automagic, constants, contexts, interfaces, plugins
 
     # from volatility3.plugins.windows import pslist
     HAVE_VOLATILITY = True

--- a/modules/processing/network.py
+++ b/modules/processing/network.py
@@ -2,8 +2,13 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
+# Imports for the batch sort.
+# http://stackoverflow.com/questions/10665925/how-to-sort-huge-files-with-python
+# http://code.activestate.com/recipes/576755/
+
 from __future__ import absolute_import
 import binascii
+import heapq
 import logging
 import os
 import socket
@@ -12,23 +17,13 @@ import sys
 import tempfile
 import traceback
 from base64 import b64encode
-from collections import OrderedDict
+from collections import OrderedDict, namedtuple
 from hashlib import md5, sha1, sha256
+from itertools import islice
 from json import loads
 from urllib.parse import urlunparse
 
 import dns.resolver
-
-try:
-    import re2 as re
-except ImportError:
-    import re
-
-# required to work webgui
-CUCKOO_ROOT = os.path.join(os.path.abspath(os.path.dirname(__file__)), "..", "..")
-sys.path.append(CUCKOO_ROOT)
-
-
 from dns.reversename import from_address
 
 from data.safelist.domains import domain_passlist_re
@@ -38,8 +33,15 @@ from lib.cuckoo.common.dns import resolve
 from lib.cuckoo.common.exceptions import CuckooProcessingError
 from lib.cuckoo.common.irc import ircMessage
 from lib.cuckoo.common.objects import File
-from lib.cuckoo.common.safelist import is_safelisted_domain, is_safelisted_ip
+from lib.cuckoo.common.safelist import is_safelisted_domain
 from lib.cuckoo.common.utils import convert_to_printable
+
+# from lib.cuckoo.common.safelist import is_safelisted_ip
+
+try:
+    import re2 as re
+except ImportError:
+    import re
 
 try:
     import GeoIP
@@ -67,13 +69,9 @@ try:
 except ImportError:
     print("Missed dependency: pip3 install -U git+https://github.com/CAPESandbox/httpreplay")
 
-
-# Imports for the batch sort.
-# http://stackoverflow.com/questions/10665925/how-to-sort-huge-files-with-python
-# http://code.activestate.com/recipes/576755/
-import heapq
-from collections import namedtuple
-from itertools import islice
+# required to work webgui
+CUCKOO_ROOT = os.path.join(os.path.abspath(os.path.dirname(__file__)), "..", "..")
+sys.path.append(CUCKOO_ROOT)
 
 TLS_HANDSHAKE = 22
 

--- a/modules/processing/parsers/CAPE/BackOffPOS.py
+++ b/modules/processing/parsers/CAPE/BackOffPOS.py
@@ -1,7 +1,6 @@
 # coding=UTF-8
 
 from __future__ import absolute_import, print_function
-import sys
 from binascii import hexlify
 from hashlib import md5
 from struct import unpack_from

--- a/modules/processing/parsers/CAPE/BlackNix.py
+++ b/modules/processing/parsers/CAPE/BlackNix.py
@@ -1,7 +1,3 @@
-from __future__ import absolute_import
-import os
-import sys
-
 import pefile
 
 

--- a/modules/processing/parsers/CAPE/IcedID.py
+++ b/modules/processing/parsers/CAPE/IcedID.py
@@ -17,9 +17,6 @@
 # https://gist.github.com/sysopfb/93eb0090ef47c08e4e516cb045b48b96
 # https://www.group-ib.com/blog/icedid
 
-DESCRIPTION = "IcedID Stage 2 configuration parser."
-AUTHOR = "kevoreilly,threathive,sysopfb"
-
 import logging
 import os
 import struct
@@ -35,6 +32,9 @@ with open(yara_path, "r") as yara_rule:
     yara_rules = yara.compile(source=yara_rule.read())
 
 log = logging.getLogger(__name__)
+
+DESCRIPTION = "IcedID Stage 2 configuration parser."
+AUTHOR = "kevoreilly,threathive,sysopfb"
 
 
 def yara_scan(raw_data):

--- a/modules/processing/parsers/CAPE/PredatorPain.py_disabled
+++ b/modules/processing/parsers/CAPE/PredatorPain.py_disabled
@@ -1,12 +1,10 @@
-from __future__ import absolute_import
-from __future__ import print_function
-
-from binascii import unhexlify
+from __future__ import absolute_import, print_function
 from base64 import b64decode
-from Crypto.Cipher import AES
+from binascii import unhexlify
 
 # import pefile
 import pype32
+from Crypto.Cipher import AES
 from pbkdf2 import PBKDF2
 
 

--- a/modules/processing/parsers/CAPE/REvil.py
+++ b/modules/processing/parsers/CAPE/REvil.py
@@ -13,6 +13,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #!/usr/bin/python
+
 from __future__ import absolute_import
 import json
 import struct

--- a/modules/processing/parsers/CAPE/_VirusRat.py
+++ b/modules/processing/parsers/CAPE/_VirusRat.py
@@ -3,7 +3,6 @@ import re
 
 import database
 import ioc
-import pefile
 
 
 def run(md5, data):

--- a/modules/processing/parsers/CAPE/_jRat.py
+++ b/modules/processing/parsers/CAPE/_jRat.py
@@ -1,13 +1,9 @@
 from __future__ import absolute_import, print_function
-import os
 import re
-import string
-import sys
 from base64 import b64decode
 from io import StringIO
 from zipfile import ZipFile
 
-import commands
 import database
 from Crypto.Cipher import AES, DES3
 

--- a/modules/processing/parsers/CAPE/pyRattyExtractor.py
+++ b/modules/processing/parsers/CAPE/pyRattyExtractor.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, print_function
 import argparse
 import base64
 import os
-import sys
 import zipfile
 
 

--- a/modules/processing/parsers/CAPE/pySpyNote.py
+++ b/modules/processing/parsers/CAPE/pySpyNote.py
@@ -1,14 +1,9 @@
 #!/usr/bin/python
+
 from __future__ import absolute_import, print_function
 import argparse
-import base64
 import os
-import sys
-import urllib.error
-import urllib.parse
-import urllib.request
 import zipfile
-from sys import argv
 
 from androguard.core.bytecodes import apk, dvm
 

--- a/modules/processing/parsers/malduck/caliber.py
+++ b/modules/processing/parsers/malduck/caliber.py
@@ -1,7 +1,6 @@
 import logging
 
 from malduck.extractor import Extractor
-from malduck.pe import MemoryPEData
 
 log = logging.getLogger(__name__)
 

--- a/modules/processing/parsers/mwcp/Zloader.py
+++ b/modules/processing/parsers/mwcp/Zloader.py
@@ -13,8 +13,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-import re
-import string
 import struct
 
 import pefile

--- a/modules/processing/parsers/plugxconfig/plugx.py
+++ b/modules/processing/parsers/plugxconfig/plugx.py
@@ -28,13 +28,6 @@ from collections import OrderedDict, defaultdict
 from socket import inet_ntoa
 from struct import calcsize, unpack_from
 
-try:
-    import yara
-
-    has_yara = True
-except ImportError:
-    has_yara = False
-
 
 class PlugXConfig:
     """Locate and parse the PlugX configuration"""

--- a/modules/processing/procmemory.py
+++ b/modules/processing/procmemory.py
@@ -1,10 +1,14 @@
-from __future__ import absolute_import
-import os
-
 # Copyright (C) 2010-2015 Cuckoo Foundation.
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
+from __future__ import absolute_import
+import logging
+import os
+
+from lib.cuckoo.common.abstracts import Processing
+from lib.cuckoo.common.cape_utils import cape_name_from_yara
+from lib.cuckoo.common.objects import File, ProcDump
 
 try:
     import re2 as re
@@ -12,13 +16,6 @@ try:
     HAVE_RE2 = True
 except ImportError:
     HAVE_RE2 = False
-    import re
-
-import logging
-
-from lib.cuckoo.common.abstracts import Processing
-from lib.cuckoo.common.cape_utils import cape_name_from_yara
-from lib.cuckoo.common.objects import File, ProcDump
 
 log = logging.getLogger(__name__)
 

--- a/modules/processing/static.py
+++ b/modules/processing/static.py
@@ -12,7 +12,6 @@ import json
 import logging
 import math
 import os
-import re
 import struct
 from datetime import datetime
 from io import BytesIO
@@ -20,6 +19,17 @@ from subprocess import PIPE, Popen
 
 import requests
 from PIL import Image
+
+import lib.cuckoo.common.office.vbadeobf as vbadeobf
+from lib.cuckoo.common.abstracts import Processing
+from lib.cuckoo.common.cape_utils import generic_file_extractors
+from lib.cuckoo.common.config import Config
+from lib.cuckoo.common.constants import CUCKOO_ROOT
+from lib.cuckoo.common.icon import PEGroupIconDir
+from lib.cuckoo.common.objects import File, IsPEImage
+from lib.cuckoo.common.pdftools.pdfid import PDFiD, PDFiD2JSON
+from lib.cuckoo.common.structures import LnkEntry, LnkHeader
+from lib.cuckoo.common.utils import bytes2str, convert_to_printable, get_options, store_temp_file
 
 try:
     import re2 as re
@@ -72,16 +82,6 @@ try:
 except Exception:
     HAVE_WHOIS = False
 
-import lib.cuckoo.common.office.vbadeobf as vbadeobf
-from lib.cuckoo.common.abstracts import Processing
-from lib.cuckoo.common.cape_utils import generic_file_extractors
-from lib.cuckoo.common.config import Config
-from lib.cuckoo.common.constants import CUCKOO_ROOT
-from lib.cuckoo.common.icon import PEGroupIconDir
-from lib.cuckoo.common.objects import File, IsPEImage
-from lib.cuckoo.common.structures import LnkEntry, LnkHeader
-from lib.cuckoo.common.utils import bytes2str, get_options, store_temp_file
-
 try:
     import olefile
 
@@ -94,17 +94,13 @@ try:
     from oletools import oleobj
     from oletools.msodde import process_file as extract_dde
     from oletools.oleid import OleID
-    from oletools.olevba import (UnexpectedDataError, VBA_Parser, detect_autoexec, detect_hex_strings, detect_patterns,
-                                 detect_suspicious, filter_vba)
+    from oletools.olevba import UnexpectedDataError, VBA_Parser, detect_autoexec, detect_hex_strings, detect_suspicious, filter_vba
     from oletools.rtfobj import RtfObjParser, is_rtf
 
     HAVE_OLETOOLS = True
 except ImportError:
     print("Missed oletools dependency: pip3 install oletools")
     HAVE_OLETOOLS = False
-
-from lib.cuckoo.common.pdftools.pdfid import PDFiD, PDFiD2JSON
-from lib.cuckoo.common.utils import convert_to_printable
 
 try:
     from peepdf.JSAnalysis import analyseJS

--- a/modules/processing/strings.py
+++ b/modules/processing/strings.py
@@ -5,7 +5,10 @@
 from __future__ import absolute_import
 import os.path
 
-HAVE_RE2 = False
+from lib.cuckoo.common.abstracts import Processing
+from lib.cuckoo.common.exceptions import CuckooProcessingError
+from lib.cuckoo.common.utils import bytes2str
+
 try:
     import re2 as re
 
@@ -13,9 +16,7 @@ try:
 except ImportError:
     import re
 
-from lib.cuckoo.common.abstracts import Processing
-from lib.cuckoo.common.exceptions import CuckooProcessingError
-from lib.cuckoo.common.utils import bytes2str
+    HAVE_RE2 = False
 
 
 def extract_strings(path, nulltermonly, minchars):

--- a/modules/processing/suricata.py
+++ b/modules/processing/suricata.py
@@ -9,13 +9,11 @@ import logging
 import os
 import shutil
 import subprocess
-import sys
 import time
 
-try:
-    import re2 as re
-except ImportError:
-    import re
+from lib.cuckoo.common.abstracts import Processing
+from lib.cuckoo.common.objects import File
+from lib.cuckoo.common.utils import convert_to_printable
 
 try:
     import orjson
@@ -23,10 +21,6 @@ try:
     HAVE_ORJSON = True
 except ImportError:
     HAVE_ORJSON = False
-
-from lib.cuckoo.common.abstracts import Processing
-from lib.cuckoo.common.objects import File
-from lib.cuckoo.common.utils import convert_to_printable
 
 log = logging.getLogger(__name__)
 

--- a/modules/processing/sysmon.py
+++ b/modules/processing/sysmon.py
@@ -4,8 +4,6 @@ import os
 import re
 import xml.etree.ElementTree as ET
 
-import xmltodict
-
 from lib.cuckoo.common.abstracts import Processing
 from lib.cuckoo.common.exceptions import CuckooProcessingError
 

--- a/modules/processing/usage.py
+++ b/modules/processing/usage.py
@@ -7,17 +7,15 @@ import os
 
 from six.moves import zip
 
-HAVE_PYGAL = False
+from lib.cuckoo.common.abstracts import Processing
+from lib.cuckoo.common.constants import CUCKOO_ROOT
+
 try:
     import pygal
 
     HAVE_PYGAL = True
 except ImportError:
-    pass
-
-from lib.cuckoo.common.abstracts import Processing
-from lib.cuckoo.common.constants import CUCKOO_ROOT
-from lib.cuckoo.common.exceptions import CuckooProcessingError
+    HAVE_PYGAL = False
 
 
 class Usage(Processing):

--- a/modules/processing/virustotal.py
+++ b/modules/processing/virustotal.py
@@ -8,16 +8,16 @@ import os
 
 import requests
 
-try:
-    import re2 as re
-except ImportError:
-    import re
-
 from lib.cuckoo.common.abstracts import Processing
 from lib.cuckoo.common.config import Config
 from lib.cuckoo.common.exceptions import CuckooProcessingError
 from lib.cuckoo.common.objects import File
 from lib.cuckoo.common.utils import get_vt_consensus
+
+try:
+    import re2 as re
+except ImportError:
+    import re
 
 log = logging.getLogger(__name__)
 

--- a/modules/reporting/jsondump.py
+++ b/modules/reporting/jsondump.py
@@ -5,6 +5,9 @@
 from __future__ import absolute_import
 import os
 
+from lib.cuckoo.common.abstracts import Report
+from lib.cuckoo.common.exceptions import CuckooReportError
+
 try:
     import orjson
 
@@ -13,9 +16,6 @@ except ImportError:
     import json
 
     HAVE_ORJSON = False
-
-from lib.cuckoo.common.abstracts import Report
-from lib.cuckoo.common.exceptions import CuckooReportError
 
 
 class JsonDump(Report):

--- a/modules/reporting/maec41.py
+++ b/modules/reporting/maec41.py
@@ -24,11 +24,10 @@ try:
     from cybox.utils import Namespace
 
     HAVE_CYBOX = True
-except ImportError as e:
+except ImportError:
     HAVE_CYBOX = False
 
 try:
-    import maec.utils
     import mixbox
     from maec.bundle import AVClassification, Bundle, BundleReference, MalwareAction, ProcessTree
     from maec.package import Analysis, MalwareSubject, Package

--- a/modules/reporting/maec5.py
+++ b/modules/reporting/maec5.py
@@ -4,6 +4,7 @@
 # See the file 'docs/LICENSE' for copying permission.
 # MAEC 5.0 Cuckoo Report Module
 # https://maecproject.github.io/releases/5.0/MAEC_Vocabularies_Specification.pdf
+
 from __future__ import absolute_import
 import io
 import json

--- a/modules/reporting/mongodb.py
+++ b/modules/reporting/mongodb.py
@@ -13,9 +13,6 @@ from lib.cuckoo.common.abstracts import Report
 from lib.cuckoo.common.exceptions import CuckooDependencyError, CuckooReportError
 from lib.cuckoo.common.objects import File
 
-MONGOSIZELIMIT = 0x1000000
-MEGABYTE = 0x100000
-
 try:
     from bson.objectid import ObjectId
     from pymongo import TEXT, MongoClient
@@ -24,6 +21,9 @@ try:
     HAVE_MONGO = True
 except ImportError:
     HAVE_MONGO = False
+
+MONGOSIZELIMIT = 0x1000000
+MEGABYTE = 0x100000
 
 log = logging.getLogger(__name__)
 

--- a/modules/reporting/reporthtml.py
+++ b/modules/reporting/reporthtml.py
@@ -11,6 +11,7 @@ from lib.cuckoo.common.abstracts import Report
 from lib.cuckoo.common.constants import CUCKOO_ROOT
 from lib.cuckoo.common.exceptions import CuckooReportError
 from lib.cuckoo.common.objects import File
+from web.analysis.templatetags.analysis_tags import malware_config
 
 try:
     from jinja2 import TemplateAssertionError, TemplateNotFound, TemplateSyntaxError, UndefinedError
@@ -20,8 +21,6 @@ try:
     HAVE_JINJA2 = True
 except ImportError:
     HAVE_JINJA2 = False
-
-from web.analysis.templatetags.analysis_tags import malware_config
 
 
 class ReportHTML(Report):

--- a/modules/reporting/reporthtmlsummary.py
+++ b/modules/reporting/reporthtmlsummary.py
@@ -15,6 +15,7 @@ from lib.cuckoo.common.abstracts import Report
 from lib.cuckoo.common.constants import CUCKOO_ROOT
 from lib.cuckoo.common.exceptions import CuckooReportError
 from lib.cuckoo.common.objects import File
+from web.analysis.templatetags.analysis_tags import malware_config
 
 try:
     from jinja2 import TemplateAssertionError, TemplateNotFound, TemplateSyntaxError, UndefinedError
@@ -24,8 +25,6 @@ try:
     HAVE_JINJA2 = True
 except ImportError:
     HAVE_JINJA2 = False
-
-from web.analysis.templatetags.analysis_tags import malware_config
 
 
 class ReportHTMLSummary(Report):

--- a/modules/reporting/resubmitexe.py
+++ b/modules/reporting/resubmitexe.py
@@ -23,6 +23,7 @@ import requests
 from lib.cuckoo.common.abstracts import Report
 from lib.cuckoo.common.constants import CUCKOO_ROOT
 from lib.cuckoo.common.objects import File
+from lib.cuckoo.common.utils import sanitize_filename
 from lib.cuckoo.core.database import Database
 
 try:

--- a/modules/reporting/resubmitexe.py
+++ b/modules/reporting/resubmitexe.py
@@ -11,6 +11,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 from __future__ import absolute_import
 import datetime
 import logging
@@ -19,17 +20,15 @@ import os
 
 import requests
 
+from lib.cuckoo.common.abstracts import Report
+from lib.cuckoo.common.constants import CUCKOO_ROOT
+from lib.cuckoo.common.objects import File
+from lib.cuckoo.core.database import Database
+
 try:
     import re2 as re
 except ImportError:
     import re
-
-from lib.cuckoo.common.abstracts import Report
-from lib.cuckoo.common.constants import CUCKOO_ROOT
-from lib.cuckoo.common.exceptions import CuckooDependencyError, CuckooReportError
-from lib.cuckoo.common.objects import File
-from lib.cuckoo.common.utils import sanitize_filename, to_unicode
-from lib.cuckoo.core.database import Database
 
 log = logging.getLogger(__name__)
 

--- a/modules/reporting/retention.py
+++ b/modules/reporting/retention.py
@@ -16,7 +16,6 @@ from bson.objectid import ObjectId
 from lib.cuckoo.common.abstracts import Report
 from lib.cuckoo.common.config import Config
 from lib.cuckoo.common.constants import CUCKOO_ROOT
-from lib.cuckoo.common.exceptions import CuckooReportError
 from lib.cuckoo.core.database import TASK_REPORTED, Database, Task
 
 log = logging.getLogger(__name__)

--- a/modules/reporting/submitCAPE.py
+++ b/modules/reporting/submitCAPE.py
@@ -19,16 +19,8 @@ import os
 
 import requests
 
-try:
-    import re2 as re
-except ImportError:
-    import re
-
 from lib.cuckoo.common.abstracts import Report
 from lib.cuckoo.common.config import Config
-from lib.cuckoo.common.exceptions import CuckooDependencyError, CuckooReportError
-from lib.cuckoo.common.objects import File
-from lib.cuckoo.common.utils import to_unicode
 from lib.cuckoo.core.database import Database
 
 log = logging.getLogger(__name__)

--- a/modules/reporting/syslog.py
+++ b/modules/reporting/syslog.py
@@ -15,8 +15,6 @@ logname = syslog.log  # if yes, what logname? [Default: syslog.txt]
 """
 
 from __future__ import absolute_import
-import codecs
-import json
 import os
 import socket
 


### PR DESCRIPTION
- Removed unused imports
  - Imports that are used in comments are commented
- Standardisation: 1 newline / start of file before start of imports