### PR TITLE
Allow environment variables to be referenced in config files.

### DIFF
--- a/lib/cuckoo/common/config.py
+++ b/lib/cuckoo/common/config.py
@@ -49,7 +49,14 @@ class _BaseConfig:
         return self.fullconfig
 
     def _read_files(self, files):
-        config = configparser.ConfigParser()
+        config = configparser.ConfigParser(
+            # Escape the percent signs so that ConfigParser doesn't try to do
+            # interpolation of the value as well.
+            dict(
+                (f"ENV:{key}", val.replace("%", "%%"))
+                for key, val in os.environ.items()
+            )
+        )
         try:
             config.read(files)
         except UnicodeDecodeError as e:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -139,3 +139,45 @@ class TestConfig:
         """
         with pytest.raises(OSError):
             Config.initialize((str(tmp_path / "custom"),))
+
+    def test_environment_interpolation(self, tmp_path, monkeypatch):
+        """Verify that environment variables are able to be referenced in config
+        files.
+        """
+        default_dir = tmp_path / "default"
+        default_dir.mkdir()
+        default_conf = default_dir / "conf" / "auxiliary.conf"
+        default_conf.parent.mkdir()
+        write_config(
+            default_conf,
+            """
+            [virustotaldl]
+            enabled = no
+            #dlintelkey = SomeKeyWithDLAccess
+            dlpath = /tmp/
+            """,
+        )
+        custom_dir = tmp_path / "custom"
+        custom_dir.mkdir()
+        custom_conf = custom_dir / "auxiliary.conf"
+        write_config(
+            custom_conf,
+            """
+            [virustotaldl]
+            enabled = yes
+            dlintelkey = %(ENV:DLINTELKEY)s
+            """,
+        )
+
+        custom_secret = "MyReallySecretKeyWithAPercent(%)InIt"
+        monkeypatch.setattr(lib.cuckoo.common.config, "CUCKOO_ROOT", str(default_dir))
+        monkeypatch.setenv("DLINTELKEY", custom_secret)
+        Config.initialize((str(custom_dir),))
+        config = Config("auxiliary")
+        section = config.get("virustotaldl")
+        # Inherited from default config
+        assert section.dlpath == "/tmp/"
+        # Overridden from custom config
+        assert section.enabled is True
+        # Overridden from custom config and uses environment variable
+        assert section.dlintelkey == custom_secret


### PR DESCRIPTION
Allow config files to use values that are formatted like
`%(ENV:SOME_ENVIRONMENT_VARIABLE)s`. In certain deployment strategies,
this makes it easier to deal with secrets since they don't need to be
stored on disk anywhere.

The test case that has been added gives a normal use case.

If there are concerns over allowing this, perhaps it could be an opt-in feature via a command-line argument.