### PR TITLE
Fix url not work

### DIFF
--- a/lib/cuckoo/core/database.py
+++ b/lib/cuckoo/core/database.py
@@ -1308,6 +1308,7 @@ class Database(object, metaclass=Singleton):
 
         elif isinstance(obj, URL):
             task = Task(obj.url)
+            tags = "x64,x86"
 
         task.category = obj.__class__.__name__.lower()
         task.timeout = timeout


### PR DESCRIPTION
Because deleted `Task.tags.is_(None)` in fetch() of database.py,causes the url not be filtered into cuckoo's tasks.I add a tags for url.