### PR TITLE
Fix quarantine submission unicode bug

### DIFF
--- a/web/submission/views.py
+++ b/web/submission/views.py
@@ -338,7 +338,8 @@ def index(request, resubmit_hash=False):
 
                 # Moving sample from django temporary file to Cuckoo temporary storage to
                 # let it persist between reboot (if user like to configure it in that way).
-                tmp_path = store_temp_file(sample.read(), sample.name)
+                filename = sanitize_filename(sample.name)
+                tmp_path = store_temp_file(sample.read(), filename)
 
                 path = unquarantine(tmp_path)
                 try:


### PR DESCRIPTION
when submission a quarantine that have unicode string may cause the bug, dynamic analysis cannot be performed.