### PR TITLE
Fix open_exclusive failed

### DIFF
--- a/lib/cuckoo/core/resultserver.py
+++ b/lib/cuckoo/core/resultserver.py
@@ -205,7 +205,9 @@ class FileUpload(ProtocolHandler):
             file_path = os.path.join(self.storagepath, dump_path.decode())
 
             try:
-                self.fd = open_exclusive(file_path)
+                #open_exclusive will failing if file_path already exists
+                if not os.path.exists(file_path):
+                    self.fd = open_exclusive(file_path)
             except OSError as e:
                 log.debug("File upload error for %s (task #%s)", dump_path, self.task_id)
                 if e.errno == errno.EEXIST:


### PR DESCRIPTION
Fix open_exclusive failed when file already exists
```bash
2022-01-19 01:11:41,103 [lib.cuckoo.core.resultserver] ERROR: Analyzer for task #144 tried to overwrite an existing file: /opt/CAPEv2/storage/analyses/144/procdump/e31e1c65f05c523221e67e578d912ecf8e11f8a84e05ac3a6173eba766a0c1f0
Traceback (most recent call last):
  File "/opt/CAPEv2/lib/cuckoo/core/resultserver.py", line 208, in handle
    self.fd = open_exclusive(file_path)
  File "/opt/CAPEv2/lib/cuckoo/common/files.py", line 37, in open_exclusive
    fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
FileExistsError: [Errno 17] File exists: '/opt/CAPEv2/storage/analyses/144/procdump/e31e1c65f05c523221e67e578d912ecf8e11f8a84e05ac3a6173eba766a0c1f0'
```