### PR TITLE
json.dumps in python 3+ does not support encoding

### DIFF
--- a/modules/reporting/compressresults.py
+++ b/modules/reporting/compressresults.py
@@ -37,7 +37,7 @@ class CompressResults(Report):
         for keyword in ("CAPE", "procdump"):
             if keyword in results:
                 try:
-                    cape_json = json.dumps(results[keyword], encoding="latin-1", ensure_ascii=False).encode()
+                    cape_json = json.dumps(results[keyword], ensure_ascii=False).encode()
                     compressed_data = zlib.compress(cape_json)
                     results[keyword] = Binary(compressed_data)
                 except UnicodeDecodeError as e:


### PR DESCRIPTION
Full error
```
ERROR: Failed to run the reporting module "CompressResults":
Traceback (most recent call last):
  File "/opt/CAPEv2/utils/../lib/cuckoo/core/plugins.py", line 703, in process
    current.run(self.results)
  File "/opt/CAPEv2/utils/../modules/reporting/compressresults.py", line 38, in run
    cape_json = json.dumps(results[keyword], encoding='latin-1', ensure_ascii=False).encode('utf8')
  File "/usr/lib/python3.8/json/__init__.py", line 234, in dumps
    return cls(
TypeError: __init__() got an unexpected keyword argument 'encoding'
```