### PR TITLE
Work around a bug in pip when doing a fresh install.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1431,6 +1431,9 @@ requests-oauthlib==1.3.0 \
     --hash=sha256:7f71572defaecd16372f9006f33c2ec8c077c3cfa6f5911a9a90202beb513f3d \
     --hash=sha256:b4261601a71fd721a8bd6d7aa1cc1d6a8a93b4a9f5e96626f8e4d91e8beeaa6a
     # via django-allauth
+requests==2.26.0 \
+    --hash=sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24 \
+    --hash=sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7
 requests[security,socks]==2.26.0 \
     --hash=sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24 \
     --hash=sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7


### PR DESCRIPTION
Steps to reproduce bug:
 - Create a fresh virtualenv
 - pip install -r requirements.txt
This results in:
```
ERROR: In --require-hashes mode, all requirements must have their
versions pinned with ==. These do not:
    requests from
https://files.pythonhosted.org/packages/2d/61/08076519c80041bc0ffa1a8af0cbd3bf3e2b62af10435d269a9d0f40564d/requests-2.27.1-py2.py3-none-any.whl#sha256=f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d
(from django-allauth==0.45.0->-r requirements.txt (line 101))
```
This is because of the bug in pip outlined in
https://github.com/pypa/pip/issues/9644.
django-allauth requires `requests` but we only had
`requests[security,socks]` in our requirements.txt and pip didn't see
that as satisfying the `requests` requirement, so it pulls down the
latest version of `requests`, which we don't have hashes for.

This just copies the lines for `requests` without the extras in order to
satisfy that dependency.