### PR TITLE
Allow custom config dirs that extend the default ones.

### DIFF
--- a/cuckoo.py
+++ b/cuckoo.py
@@ -12,11 +12,12 @@ import sys
 if sys.version_info[:2] < (3, 6):
     sys.exit("You are running an incompatible version of Python, please use >= 3.6")
 
+from lib.cuckoo.common.exceptions import CuckooCriticalError, CuckooDependencyError
+
 try:
     import bson
 
     from lib.cuckoo.common.constants import CUCKOO_ROOT, CUCKOO_VERSION
-    from lib.cuckoo.common.exceptions import CuckooCriticalError, CuckooDependencyError
     from lib.cuckoo.common.logo import logo
     from lib.cuckoo.core.resultserver import ResultServer
     from lib.cuckoo.core.scheduler import Scheduler
@@ -105,7 +106,7 @@ if __name__ == "__main__":
             cuckoo_main(max_analysis_count=args.max_analysis_count)
     except CuckooCriticalError as e:
         message = "{0}: {1}".format(e.__class__.__name__, e)
-        if len(log.handlers):
+        if any(filter(lambda hdlr: not isinstance(hdlr, logging.NullHandler), log.handlers)):
             log.critical(message)
         else:
             sys.stderr.write("{0}\n".format(message))

--- a/custom/.gitignore
+++ b/custom/.gitignore
@@ -1,0 +1,3 @@
+/*
+!/README.md
+!/.gitignore

--- a/custom/README.md
+++ b/custom/README.md
@@ -1,0 +1,10 @@
+Inside this directory, you may create a `conf` directory. Inside that
+directory, you may place files whose names are the
+same as those found in the top-level `conf` directory and whose contents
+override the default settings found in the latter.
+
+In addition, you may create directories under there whose names are the names
+of the files in the top-level `conf` directory with a `.d` appended to it (e.g.
+`custom/conf/reporting.conf.d/`. Any file in that directory whose name ends in
+`.conf` will be read (in lexicographic order). The last value read for a
+setting will be used.

--- a/docs/book/src/installation/host/configuration.rst
+++ b/docs/book/src/installation/host/configuration.rst
@@ -15,6 +15,15 @@ CAPE relies on six main configuration files:
 To get CAPE working you have to edit :ref:`auxiliary_conf`:, :ref:`cuckoo_conf` and :ref:`machinery_conf` at least.
 We suggest you to check all configs before starting, to be familiar with possibilities that you have and what you want to be done.
 
+Alternatively, you may create a `custom/conf/` directory and put files in there
+whose names are the same as those in the top-level `conf/` directory. These
+files only need to include settings that will override the defaults.
+
+To allow for further flexibility, you can also create a `custom/conf/<type>.conf.d/`
+(e.g. `custom/conf/reporting.conf.d/`) directory and place files in there. Any
+file in that directory whose name ends in `.conf` will be read (in lexicographic
+order). The last value read for a value will be the one that is used.
+
 .. _cuckoo_conf:
 
 cuckoo.conf
@@ -155,3 +164,17 @@ Please see latest version here:
 
 By setting those option to *on* or *off* you enable or disable the generation
 of such reports.
+
+Using environment variables in config files
+===========================================
+
+Any of the above config files may reference environment variables in their
+values by using ``%(ENV:VARIABLE_NAME)s``. For example, instead of putting a
+VirusTotal Intelligence API key in :ref:`auxiliary_conf`, you could use the
+following::
+
+    [virustotaldl]
+    enabled = yes
+    dlintelkey = %(ENV:DLINTELKEY)s
+
+assuming the ``DLINTELKEY`` environment variable contains the API key.

--- a/lib/cuckoo/common/config.py
+++ b/lib/cuckoo/common/config.py
@@ -4,10 +4,11 @@
 
 from __future__ import absolute_import
 import configparser
+import glob
 import os
 
 from lib.cuckoo.common.colors import bold, red
-from lib.cuckoo.common.constants import CUCKOO_ROOT
+from lib.cuckoo.common.constants import CUCKOO_ROOT, CUSTOM_CONF_DIR
 from lib.cuckoo.common.exceptions import CuckooOperationalError
 from lib.cuckoo.common.objects import Dictionary
 
@@ -29,35 +30,51 @@ def emit_options(options):
     return ",".join(f"{k}={v}" for k, v in sorted(options.items()))
 
 
-class Config:
+class _BaseConfig:
     """Configuration file parser."""
 
-    def __init__(self, file_name="cuckoo", cfg=None):
+    def get(self, section):
+        """Get option.
+        @param section: section to fetch.
+        @raise CuckooOperationalError: if section not found.
+        @return: option value.
         """
-        @param file_name: file name without extension.
-        @param cfg: configuration file path.
-        """
-        config = configparser.ConfigParser()
+        try:
+            return getattr(self, section)
+        except AttributeError as e:
+            raise CuckooOperationalError(
+                f"Option {section} is not found in configuration, error: {e}"
+            )
 
-        if cfg:
-            config.read(cfg)
-        else:
-            try:
-                config.read(os.path.join(CUCKOO_ROOT, "conf", f"{file_name}.conf"))
-            except UnicodeDecodeError as e:
-                print(
-                    bold(
-                        red(
-                            f"please fix your config file: {file_name}.conf - Pay attention for bytes c2 xa - {e.object}\n\n{e.reason}"
-                        )
+    def get_config(self):
+        return self.fullconfig
+
+    def _read_files(self, files):
+        config = configparser.ConfigParser(
+            # Escape the percent signs so that ConfigParser doesn't try to do
+            # interpolation of the value as well.
+            dict(
+                (f"ENV:{key}", val.replace("%", "%%"))
+                for key, val in os.environ.items()
+            )
+        )
+        try:
+            config.read(files)
+        except UnicodeDecodeError as e:
+            print(
+                bold(
+                    red(
+                        f"please fix your config file(s): {', '.join(files)} - "
+                        f"Pay attention for bytes c2 xa - {e.object}\n\n{e.reason}"
                     )
                 )
-                raise UnicodeDecodeError
+            )
+            raise UnicodeDecodeError
 
         self.fullconfig = config._sections
 
         for section in config.sections():
-            setattr(self, section, Dictionary())
+            dct = Dictionary()
             for name, _ in config.items(section):
                 try:
                     # Ugly fix to avoid '0' and '1' to be parsed as a
@@ -74,18 +91,49 @@ class Config:
                     except ValueError:
                         value = config.get(section, name)
 
-                setattr(getattr(self, section), name, value)
+                setattr(dct, name, value)
+            setattr(self, section, dct)
 
-    def get(self, section):
-        """Get option.
-        @param section: section to fetch.
-        @raise CuckooOperationalError: if section not found.
-        @return: option value.
-        """
-        try:
-            return getattr(self, section)
-        except AttributeError as e:
-            raise CuckooOperationalError(f"Option {section} is not found in configuration, error: {e}")
 
-    def get_config(self):
-        return self.fullconfig
+class ConfigMeta(type):
+    """Only create one instance of a Config for each (non-analysis) config file."""
+
+    configs = {}
+
+    def __call__(cls, fname_base="cuckoo"):
+        if fname_base not in cls.configs:
+            cls.configs[fname_base] = super(ConfigMeta, cls).__call__(
+                fname_base=fname_base
+            )
+        return cls.configs[fname_base]
+
+    @classmethod
+    def reset(cls):
+        """This should really only be needed for testing."""
+        cls.configs.clear()
+
+
+class Config(_BaseConfig, metaclass=ConfigMeta):
+    def __init__(self, fname_base="cuckoo"):
+        files = self._get_files_to_read(fname_base)
+        self._read_files(files)
+
+    def _get_files_to_read(self, fname_base):
+        files = [
+            os.path.join(CUCKOO_ROOT, "conf", f"{fname_base}.conf"),
+            os.path.join(CUSTOM_CONF_DIR, f"{fname_base}.conf"),
+        ]
+        files.extend(
+            sorted(
+                glob.glob(
+                    os.path.join(CUSTOM_CONF_DIR, f"{fname_base}.conf.d", "*.conf")
+                )
+            )
+        )
+        return files
+
+
+class AnalysisConfig(_BaseConfig):
+    def __init__(self, cfg="analysis.conf"):
+        files = (cfg,)
+        self._read_files(files)

--- a/lib/cuckoo/common/config.py
+++ b/lib/cuckoo/common/config.py
@@ -34,10 +34,10 @@ class _BaseConfig:
     """Configuration file parser."""
 
     def get(self, section):
-        """Get option.
+        """Get options for the given section.
         @param section: section to fetch.
         @raise CuckooOperationalError: if section not found.
-        @return: option value.
+        @return: dict of option key/values.
         """
         try:
             return getattr(self, section)
@@ -76,6 +76,8 @@ class _BaseConfig:
         for section in config.sections():
             dct = Dictionary()
             for name, _ in config.items(section):
+                if name.startswith('env:'):
+                    continue
                 try:
                     # Ugly fix to avoid '0' and '1' to be parsed as a
                     # boolean value.

--- a/lib/cuckoo/common/constants.py
+++ b/lib/cuckoo/common/constants.py
@@ -8,6 +8,9 @@ import os
 _current_dir = os.path.abspath(os.path.dirname(__file__))
 CUCKOO_ROOT = os.path.normpath(os.path.join(_current_dir, "..", "..", ".."))
 
+CUSTOM_ROOT = os.path.join(CUCKOO_ROOT, "custom")
+CUSTOM_CONF_DIR = os.path.join(CUSTOM_ROOT, "conf")
+
 ANALYSIS_BASE_PATH = os.path.join(CUCKOO_ROOT, "storage")
 
 CUCKOO_VERSION = "2.2-CAPE"

--- a/lib/cuckoo/core/plugins.py
+++ b/lib/cuckoo/core/plugins.py
@@ -14,7 +14,7 @@ from datetime import datetime, timedelta
 from distutils.version import StrictVersion
 
 from lib.cuckoo.common.abstracts import Auxiliary, Feed, LibVirtMachinery, Machinery, Processing, Report, Signature
-from lib.cuckoo.common.config import Config
+from lib.cuckoo.common.config import AnalysisConfig, Config
 from lib.cuckoo.common.constants import CUCKOO_ROOT, CUCKOO_VERSION
 from lib.cuckoo.common.exceptions import (CuckooDependencyError, CuckooDisableModule, CuckooOperationalError, CuckooProcessingError,
                                           CuckooReportError)
@@ -702,7 +702,7 @@ class RunReporting:
         # Give it the the relevant reporting.conf section.
         current.set_options(options)
         # Load the content of the analysis.conf file.
-        current.cfg = Config(cfg=current.conf_path)
+        current.cfg = AnalysisConfig(current.conf_path)
 
         try:
             log.debug('Executing reporting module "%s"', current.__class__.__name__)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,17 +3,18 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 from __future__ import absolute_import, print_function
-import os
-import tempfile
+import configparser
+import textwrap
 
 import pytest
 
-from lib.cuckoo.common.config import Config
+import lib.cuckoo.common.config
+from lib.cuckoo.common.config import AnalysisConfig, Config, ConfigMeta
 from lib.cuckoo.common.exceptions import CuckooOperationalError
 
 
 @pytest.fixture
-def config():
+def analysis_config(tmp_path):
     CONF_EXAMPLE = """
 [cuckoo]
 debug = off
@@ -25,31 +26,191 @@ use_sniffer = no
 tcpdump = /usr/sbin/tcpdump
 interface = vboxnet0
 """
-    path = tempfile.mkstemp()[1]
-    with open(path, mode="w") as file:
-        file.write(CONF_EXAMPLE)
+    path = tmp_path / "analysis.conf"
+    with open(path, mode="w") as fil:
+        fil.write(CONF_EXAMPLE)
+    yield AnalysisConfig(path)
 
-    yield Config(cfg=path)
-    print(path)
-    os.remove(path)
+
+@pytest.fixture(autouse=True)
+def reset():
+    ConfigMeta.reset()
+
+
+class TestAnalysisConfig:
+    def test_get_option_exist(self, analysis_config):
+        """Fetch an option of each type from default config file."""
+        assert analysis_config.get("cuckoo")["debug"] is False
+        assert analysis_config.get("cuckoo")["tcpdump"] == "/usr/sbin/tcpdump"
+        assert analysis_config.get("cuckoo")["critical_timeout"] == 600
+
+    def test_dotted_syntax(self, analysis_config):
+        assert analysis_config.cuckoo.delete_original is False
+
+    def test_config_file_not_found(self):
+        assert AnalysisConfig("foo")
+
+    def test_get_option_not_found(self, analysis_config):
+        with pytest.raises(CuckooOperationalError):
+            analysis_config.get("foo")
+
+    def test_get_option_not_found_in_file_not_found(self):
+        analysis_config = AnalysisConfig("bar")
+        with pytest.raises(CuckooOperationalError):
+            analysis_config.get("foo")
+
+    def test_analysis_configs_are_not_reused(self, tmp_path, analysis_config):
+        analysis_config2 = AnalysisConfig(str(tmp_path / "analysis.conf"))
+        assert analysis_config is not analysis_config2
+
+
+def write_config(path, content):
+    with open(path, mode="w") as fil:
+        fil.write(textwrap.dedent(content))
+
+
+@pytest.fixture
+def custom_conf_dir(monkeypatch, tmp_path):
+    custom_dir = tmp_path / "custom"
+    custom_dir.mkdir()
+    monkeypatch.setattr(lib.cuckoo.common.config, "CUSTOM_CONF_DIR", str(custom_dir))
+    yield custom_dir
+
+
+@pytest.fixture
+def default_config(monkeypatch, tmp_path):
+    default_dir = tmp_path / "default"
+    default_dir.mkdir()
+    default_conf = default_dir / "conf" / "cuckoo.conf"
+    default_conf.parent.mkdir()
+    write_config(
+        default_conf,
+        """
+        [cuckoo]
+        debug = false
+        analysis_timeout = 120
+        """,
+    )
+    monkeypatch.setattr(lib.cuckoo.common.config, "CUCKOO_ROOT", str(default_dir))
+    yield default_conf
 
 
 class TestConfig:
-    def test_get_option_exist(self, config):
-
+    def test_option_override(self, custom_conf_dir, default_config):
         """Fetch an option of each type from default config file."""
+        custom_conf = custom_conf_dir / "cuckoo.conf"
+        write_config(
+            custom_conf,
+            """
+            [cuckoo]
+            debug = true
+            """,
+        )
+        config = Config("cuckoo")
+
+        # This was overridden in the custom config.
+        assert config.get("cuckoo")["debug"] is True
+        # This was inherited from the default config.
+        assert config.get("cuckoo")["analysis_timeout"] == 120
+
+    def test_nonexistent_custom_file(self, custom_conf_dir, default_config):
+        """Verify that there are no problems when the file to be processed does not
+        exist in the custom config dir.
+        """
+        config = Config("cuckoo")
         assert config.get("cuckoo")["debug"] is False
-        assert config.get("cuckoo")["tcpdump"] == "/usr/sbin/tcpdump"
-        assert config.get("cuckoo")["critical_timeout"] == 600
+        assert config.get("cuckoo")["analysis_timeout"] == 120
 
-    def test_config_file_not_found(self, config):
-        assert Config("foo")
+    def test_subdirs(self, custom_conf_dir):
+        api_conf = custom_conf_dir / "api.conf"
+        write_config(
+            api_conf,
+            """
+            [api]
+            ratelimit = no
+            """,
+        )
+        api_conf_d_dir = custom_conf_dir / "api.conf.d"
+        api_conf_d_dir.mkdir()
+        host_specific_conf = api_conf_d_dir / "01_host_specific.conf"
+        url = "https://somehost.example.com"
+        write_config(
+            host_specific_conf,
+            f"""
+            [api]
+            url = {url}
+            """,
+        )
+        config = Config("api")
+        # This is set to 'no' in the default api.conf and not overridden.
+        assert config.get("api")["token_auth_enabled"] is False
+        # This is set to 'yes' in the default api.conf but overridden in the custom
+        # api.conf.
+        assert config.get("api")["ratelimit"] is False
+        # This is set to http://example.tld in the default api.conf and overridden in
+        # api.conf.d/01_host_specific.conf.
+        assert config.get("api")["url"] == url
 
-    def test_get_option_not_found(self, config):
-        with pytest.raises(CuckooOperationalError):
-            config.get("foo")
+    def test_singleton_configs(self, default_config):
+        """Verify that Config objects that were passed the same "file_name" argument
+        are reused.
+        """
+        config1 = Config("cuckoo")
+        config2 = Config("cuckoo")
+        assert config1 is config2
 
-    def test_get_option_not_found_in_file_not_found(self, config):
-        with pytest.raises(CuckooOperationalError):
-            config = Config("bar")
-            config.get("foo")
+    def test_environment_interpolation(
+        self, default_config, custom_conf_dir, monkeypatch
+    ):
+        """Verify that environment variables are able to be referenced in config
+        files.
+        """
+        default_dir = default_config.parent
+        aux_conf = default_dir / "auxiliary.conf"
+        write_config(
+            aux_conf,
+            """
+            [virustotaldl]
+            enabled = no
+            #dlintelkey = SomeKeyWithDLAccess
+            dlpath = /tmp/
+            """,
+        )
+        custom_conf = custom_conf_dir / "auxiliary.conf"
+        write_config(
+            custom_conf,
+            """
+            [virustotaldl]
+            enabled = yes
+            dlintelkey = %(ENV:DLINTELKEY)s
+            """,
+        )
+
+        custom_secret = "MyReallySecretKeyWithAPercent(%)InIt"
+        monkeypatch.setenv("DLINTELKEY", custom_secret)
+        config = Config("auxiliary")
+        section = config.get("virustotaldl")
+        # Inherited from default config
+        assert section.dlpath == "/tmp/"
+        # Overridden from custom config
+        assert section.enabled is True
+        # Overridden from custom config and uses environment variable
+        assert section.dlintelkey == custom_secret
+
+    def test_missing_environment_interpolation(
+        self, default_config, custom_conf_dir, monkeypatch
+    ):
+        """Verify that an exception is raised if an ENV variable is to be used in a
+        config file, but that variable is not present in the environment.
+        """
+        default_dir = default_config.parent
+        aux_conf = default_dir / "auxiliary.conf"
+        write_config(
+            aux_conf,
+            """
+            [foo]
+            bar = %(ENV:IDONTEXIST)s
+            """,
+        )
+        with pytest.raises(configparser.InterpolationMissingOptionError):
+            config = Config("auxiliary")


### PR DESCRIPTION
A new custom/conf/ directory can be used to hold additional
configuration files that extend the ones in the top-level conf
directory. See the custom/README.md for more information.

`.conf.d` (e.g. `custom/conf/reporting.conf.d/`) directories may also
be used to store additional configuration.

In addition, for Config() objects, only read the files once, so that if,
say, Config("processing") is created in multiple places, they'll both
refer to the same object and the conf files would only be read once.

A new AnalysisConfig() class was created to separate the distinction
between these types of "singleton" Config objects that can read from
multiple directories versus ones that just read from an analysis.conf
(or some other single file).

Allow environment variables to be referenced in config files.
Allow config files to use values that are formatted like
%(ENV:SOME_ENVIRONMENT_VARIABLE)s. In certain deployment strategies,
this makes it easier to deal with secrets since they don't need to be
stored on disk anywhere.