### PR TITLE
Add empty VTDL_PRIV_KEY to local_settings.py

### DIFF
--- a/web/web/local_settings.py
+++ b/web/web/local_settings.py
@@ -58,3 +58,6 @@ SOCIALACCOUNT_PROVIDERS = {
         ],
     },
 }
+
+## Uncomment and enter your VirusTotal API key, in case you want to upload to VT from the web interface
+#VTDL_PRIV_KEY = ""


### PR DESCRIPTION
It took me a few seconds to figure out why virustotal uploading didn't work, after setting "[vtupload]" to "enabled = yes" in conf/web.conf.
This makes it easier to find after a fresh installation.