### PR TITLE
Refactor the loading of mwcp and malwareconfig parsers

### DIFF
--- a/lib/cuckoo/common/cape_utils.py
+++ b/lib/cuckoo/common/cape_utils.py
@@ -78,11 +78,8 @@ def load_mwcp_parsers():
         import mwcp
 
         logging.getLogger("mwcp").setLevel(logging.CRITICAL)
-        mwcp.register_parser_directory(
-            os.path.join(CUCKOO_ROOT, process_cfg.mwcp.modules_path))
-        _malware_parsers = {
-            block.name.rsplit(".", 1)[-1]: block.name
-            for block in mwcp.get_parser_descriptions(config_only=False)}
+        mwcp.register_parser_directory(os.path.join(CUCKOO_ROOT, process_cfg.mwcp.modules_path))
+        _malware_parsers = {block.name.rsplit(".", 1)[-1]: block.name for block in mwcp.get_parser_descriptions(config_only=False)}
         assert "MWCP_TEST" in _malware_parsers
         return _malware_parsers, mwcp
     except ImportError as e:
@@ -104,8 +101,7 @@ def load_malwareconfig_parsers():
         if process_cfg.ratdecoders.modules_path:
             from lib.cuckoo.common.load_extra_modules import ratdecodedr_load_decoders
 
-            ratdecoders_local_modules = ratdecodedr_load_decoders(
-                [os.path.join(CUCKOO_ROOT, process_cfg.ratdecoders.modules_path)])
+            ratdecoders_local_modules = ratdecodedr_load_decoders([os.path.join(CUCKOO_ROOT, process_cfg.ratdecoders.modules_path)])
             if ratdecoders_local_modules:
                 __decoders__.update(ratdecoders_local_modules)
             assert "TestRats" in __decoders__

--- a/lib/cuckoo/common/cape_utils.py
+++ b/lib/cuckoo/common/cape_utils.py
@@ -72,7 +72,7 @@ except ImportError:
 
 def load_mwcp_parsers():
     if not process_cfg.mwcp.enabled:
-        return {}
+        return {}, False
     # Import All config parsers
     try:
         import mwcp
@@ -96,7 +96,7 @@ HAS_MWCP = bool(malware_parsers)
 
 def load_malwareconfig_parsers():
     if not process_cfg.ratdecoders.enabled:
-        return False
+        return False, False, False
     try:
         from malwareconfig import fileparser
         from malwareconfig.modules import __decoders__
@@ -109,15 +109,15 @@ def load_malwareconfig_parsers():
             if ratdecoders_local_modules:
                 __decoders__.update(ratdecoders_local_modules)
             assert "TestRats" in __decoders__
-        return True
+        return True, __decoders__, fileparser
     except ImportError:
         logging.info("Missed RATDecoders -> pip3 install malwareconfig")
     except Exception as e:
         logging.error(e, exc_info=True)
-    return False
+    return False, False, False
 
 
-HAS_MALWARECONFIGS = load_malwareconfig_parsers()
+HAS_MALWARECONFIGS, __decoders__, fileparser = load_malwareconfig_parsers()
 
 HAVE_MALDUCK = False
 if process_cfg.malduck.enabled:

--- a/lib/cuckoo/common/cape_utils.py
+++ b/lib/cuckoo/common/cape_utils.py
@@ -84,13 +84,13 @@ def load_mwcp_parsers():
             block.name.rsplit(".", 1)[-1]: block.name
             for block in mwcp.get_parser_descriptions(config_only=False)}
         assert "MWCP_TEST" in _malware_parsers
-        return _malware_parsers
+        return _malware_parsers, mwcp
     except ImportError as e:
         logging.info("Missed MWCP -> pip3 install mwcp\nDetails: %s", e)
-        return {}
+        return {}, False
 
 
-malware_parsers = load_mwcp_parsers()
+malware_parsers, mwcp = load_mwcp_parsers()
 HAS_MWCP = bool(malware_parsers)
 
 


### PR DESCRIPTION
Move the loading of `mwcp` and `malwareconfig` parsers into functions to be able to test them and to use them in testing.