### PR TITLE
Fix logic for finding if a detection was already seen.

### DIFF
--- a/lib/cuckoo/common/utils.py
+++ b/lib/cuckoo/common/utils.py
@@ -646,14 +646,13 @@ def store_temp_file(filedata, filename, path=None):
 
 def add_family_detection(results: dict, family: str, detected_by: str, detected_on: str):
     results.setdefault("detections", [])
-    found = False
     detection = {detected_by: detected_on}
     for block in results["detections"]:
         if family == block.get("family", ""):
-            found = True
-            if not detection in block["details"]:
+            if not any(map(lambda d: d == detection, block["details"])):
                 block["details"].append(detection)
-    if not found:
+            break
+    else:
         results["detections"].append({"family": family, "details": [detection]})
 
 


### PR DESCRIPTION
The line `if not detection in block["details"]:` would never evaluate to
True, because block["details"] contains references to dicts created in
previous invocations of this function--that statement does not actually
compare the contents of the dicts themselves, but only that they're the
same object.

Also, bail out of the loop when we found the family and use python's
for/else construct instead of tracking `found` ourselves.

QUESTION: I was curious about the decision to use lists for these objects (results['detections'] and the 'details' instead of just using dicts that key off the family and detected_by, respectively. I'm guessing there was a reason--it just seems like it would've been simpler than having to iterate over these lists to find items.