### PR TITLE
reschedule using sample storage; fixes #804

### DIFF
--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -20,7 +20,7 @@ class TestDatabaseEngine(object):
     def setup_method(self):
         with NamedTemporaryFile(mode="w+", delete=False) as f:
             f.write("hehe")
-        self.temp = f.name
+        self.temp_filename = f.name
         pcap_header_base64 = b"1MOyoQIABAAAAAAAAAAAAAAABAABAAAA"
         pcap_bytes = base64.b64decode(pcap_header_base64)
         self.temp_pcap = store_temp_file(pcap_bytes, "%s.pcap" % f.name)
@@ -32,7 +32,7 @@ class TestDatabaseEngine(object):
 
     def teardown_method(self):
         del self.d
-        os.unlink(self.temp)
+        os.unlink(self.temp_filename)
         shutil.rmtree(self.binary_storage)
 
     def add_url(self, url, priority=1, status="pending"):
@@ -44,7 +44,7 @@ class TestDatabaseEngine(object):
 
         # Add task.
         count = self.session.query(Task).count()
-        self.d.add_path(self.temp)
+        self.d.add_path(self.temp_filename)
         assert self.session.query(Task).count() == count + 1
 
         # Add url.
@@ -65,18 +65,18 @@ class TestDatabaseEngine(object):
         assert err and len(err[0].message) == 1024
 
     def test_task_set_options(self):
-        assert self.d.add_path(self.temp, options={"foo": "bar"}) is None
-        t1 = self.d.add_path(self.temp, options="foo=bar")
+        assert self.d.add_path(self.temp_filename, options={"foo": "bar"}) is None
+        t1 = self.d.add_path(self.temp_filename, options="foo=bar")
         assert self.d.view_task(t1).options == "foo=bar"
 
     def test_task_tags_str(self):
-        task = self.d.add_path(self.temp, tags="foo,,bar")
+        task = self.d.add_path(self.temp_filename, tags="foo,,bar")
         tag_list = list(self.d.view_task(task).tags)
         assert [str(x.name) for x in tag_list].sort() == ["foo", "bar"].sort()
 
     def test_reschedule_file(self):
         count = self.session.query(Task).count()
-        task_id = self.d.add_path(self.temp)
+        task_id = self.d.add_path(self.temp_filename)
         assert self.session.query(Task).count() == count + 1
         task = self.d.view_task(task_id)
         assert task is not None
@@ -84,7 +84,7 @@ class TestDatabaseEngine(object):
 
         # write a real sample to storage
         sample_path = os.path.join(self.binary_storage, task.sample.sha256)
-        shutil.copy(self.temp, sample_path)
+        shutil.copy(self.temp_filename, sample_path)
 
         new_task_id = self.d.reschedule(task_id)
         assert new_task_id is not None
@@ -93,7 +93,7 @@ class TestDatabaseEngine(object):
 
     def test_reschedule_static(self):
         count = self.session.query(Task).count()
-        task_id = self.d.add_static(self.temp)
+        task_id = self.d.add_static(self.temp_filename)
         assert self.session.query(Task).count() == count + 1
         task = self.d.view_task(task_id)
         assert task is not None
@@ -101,7 +101,7 @@ class TestDatabaseEngine(object):
 
         # write a real sample to storage
         static_path = os.path.join(self.binary_storage, task.sample.sha256)
-        shutil.copy(self.temp, static_path)
+        shutil.copy(self.temp_filename, static_path)
 
         new_task_id = self.d.reschedule(task_id)
         assert new_task_id is not None


### PR DESCRIPTION
use sample storage when rescheduling tasks, not temporary files