### PR TITLE
Whitelist 8.8.8.8 and 1.1.1.1 as hosts.

### DIFF
--- a/conf/processing.conf
+++ b/conf/processing.conf
@@ -103,7 +103,7 @@ sort_pcap = no
 dnswhitelist = yes
 # additional entries
 dnswhitelist_file = extra/whitelist_domains.txt
-ipwhitelist = no
+ipwhitelist = yes
 ipwhitelist_file = extra/whitelist_ips.txt
 
 # Should the server use a compressed version of behavioural logs? This helps

--- a/extra/whitelist_ips.txt
+++ b/extra/whitelist_ips.txt
@@ -1,0 +1,4 @@
+# CloudFlare's DNS server
+1.1.1.1
+# Google's DNS server
+8.8.8.8

--- a/modules/processing/network.py
+++ b/modules/processing/network.py
@@ -90,20 +90,21 @@ ip_passlist_file = proc_cfg.network.ipwhitelist_file
 # Be less verbose about httpreplay logging messages.
 logging.getLogger("httpreplay").setLevel(logging.CRITICAL)
 
+comment_re = re.compile(r"\s*#.*")
 if enabled_passlist and passlist_file:
     with open(os.path.join(CUCKOO_ROOT, passlist_file), "r") as f:
-        domains = list(set(f.read().splitlines()))
-    for domain in domains:
-        if domain.startswith("#") or len(domain.strip()) == 0:
-            # comment or empty line
-            continue
-        domain_passlist_re.append(domain)
-
+        for domain in f.readlines():
+            domain = comment_re.sub("", domain).strip()
+            if domain:
+                domain_passlist_re.append(domain)
 
 ip_passlist = set()
 if enabled_ip_passlist and ip_passlist_file:
     with open(os.path.join(CUCKOO_ROOT, ip_passlist_file), "r") as f:
-        ip_passlist = set(f.read().split("\n"))
+        for ip in f.readlines():
+            ip = comment_re.sub("", ip).strip()
+            if ip:
+                ip_passlist.add(ip)
 
 
 class Pcap:


### PR DESCRIPTION
Also allow comments in the domain and IP whitelist files to be on the
same line as the entry (e.g. `1.1.1.1  # such and such`) and don't read
the whole file in to memory at once.