### PR TITLE
add reprocessing API to APIv2, and APIv2 test capabilities

### DIFF
--- a/conf/api.conf
+++ b/conf/api.conf
@@ -142,6 +142,13 @@ auth_only = no
 rps = 1/s
 rpm = 5/m
 
+# Configure the ability to reprocess a task.
+[taskreprocess]
+enabled = no
+auth_only = no
+rps = 1/s
+rpm = 5/m
+
 # Configure the ability to delete a specified Task ID.
 [taskdelete]
 enabled = no

--- a/modules/processing/parsers/CAPE/Emotet.py
+++ b/modules/processing/parsers/CAPE/Emotet.py
@@ -20,7 +20,7 @@ from itertools import cycle
 
 import pefile
 import yara
-from Cryptodome.PublicKey import RSA, ECC
+from Cryptodome.PublicKey import ECC, RSA
 from Cryptodome.Util import asn1
 
 log = logging.getLogger()

--- a/tests/web/test_apiv2.py
+++ b/tests/web/test_apiv2.py
@@ -1,0 +1,73 @@
+import os
+from unittest.mock import patch
+import unittest.mock
+from django.test import SimpleTestCase
+from lib.cuckoo.core.database import (
+    Task,
+    TASK_REPORTED,
+    TASK_COMPLETED,
+    TASK_RECOVERED,
+    TASK_FAILED_ANALYSIS,
+    TASK_FAILED_PROCESSING,
+    TASK_FAILED_REPORTING,
+    TASK_DISTRIBUTED_COMPLETED,
+    TASK_BANNED,
+    TASK_PENDING,
+    TASK_RUNNING,
+    TASK_DISTRIBUTED,
+)
+
+class ReprocessTask(SimpleTestCase):
+    def test_api_disabled(self):
+        patch_target = "lib.cuckoo.common.web_utils.apiconf.taskreprocess"
+        with patch.dict(patch_target, {"enabled": False}):
+            response = self.client.get("/apiv2/tasks/reprocess/1/")
+        assert response.status_code == 200
+        assert response.headers["content-type"] == "application/json"
+        json_body = {"error": True, "error_value": "Task Reprocess API is Disabled"}
+        assert response.json() == json_body
+
+    def test_task_does_not_exist(self):
+        patch_target = "lib.cuckoo.core.database.Database.view_task"
+        with patch(patch_target, return_value=None):
+            response = self.client.get("/apiv2/tasks/reprocess/1/")
+        assert response.status_code == 200
+        assert response.headers["content-type"] == "application/json"
+        json_body = {"error": True, "error_value": "Task ID does not exist in the database"}
+        assert response.json() == json_body
+
+    def test_can_reprocess(self):
+        task = Task()
+        valid_status = (TASK_REPORTED, TASK_RECOVERED, TASK_FAILED_PROCESSING, TASK_FAILED_REPORTING)
+        patch_target = "lib.cuckoo.core.database.Database.view_task"
+        with patch(patch_target, return_value=task):
+            for status in valid_status:
+                expected_response = {"error": False, "data": f"Task ID 1 with status {status} marked for reprocessing"}
+                with self.subTest(status):
+                    task.status = status
+                    response = self.client.get("/apiv2/tasks/reprocess/1/")
+                    assert response.status_code == 200
+                    assert response.headers["content-type"] == "application/json"
+                    assert response.json() == expected_response
+
+    def test_cant_reprocess(self):
+        task = Task()
+        invalid_status = (
+            TASK_COMPLETED,
+            TASK_FAILED_ANALYSIS,
+            TASK_DISTRIBUTED_COMPLETED,
+            TASK_BANNED,
+            TASK_PENDING,
+            TASK_RUNNING,
+            TASK_DISTRIBUTED,
+        )
+        patch_target = "lib.cuckoo.core.database.Database.view_task"
+        with patch(patch_target, return_value=task):
+            for status in invalid_status:
+                expected_response = {"error": True, "error_value": f"Task ID 1 cannot be reprocessed in status {status}"}
+                with self.subTest(status):
+                    task.status = status
+                    response = self.client.get("/apiv2/tasks/reprocess/1/")
+                    assert response.status_code == 200
+                    assert response.headers["content-type"] == "application/json"
+                    assert response.json() == expected_response

--- a/tests/web/test_apiv2.py
+++ b/tests/web/test_apiv2.py
@@ -1,21 +1,24 @@
 import os
-from unittest.mock import patch
 import unittest.mock
+from unittest.mock import patch
+
 from django.test import SimpleTestCase
+
 from lib.cuckoo.core.database import (
-    Task,
-    TASK_REPORTED,
+    TASK_BANNED,
     TASK_COMPLETED,
-    TASK_RECOVERED,
+    TASK_DISTRIBUTED,
+    TASK_DISTRIBUTED_COMPLETED,
     TASK_FAILED_ANALYSIS,
     TASK_FAILED_PROCESSING,
     TASK_FAILED_REPORTING,
-    TASK_DISTRIBUTED_COMPLETED,
-    TASK_BANNED,
     TASK_PENDING,
+    TASK_RECOVERED,
+    TASK_REPORTED,
     TASK_RUNNING,
-    TASK_DISTRIBUTED,
+    Task,
 )
+
 
 class ReprocessTask(SimpleTestCase):
     def test_api_disabled(self):

--- a/web/apiv2/urls.py
+++ b/web/apiv2/urls.py
@@ -30,6 +30,7 @@ urlpatterns = [
     url(r"^tasks/list/(?P<limit>\d+)/(?P<offset>\d+)/(?P<window>\d+)/$", views.tasks_list),
     url(r"^tasks/view/(?P<task_id>\d+)/$", views.tasks_view),
     url(r"^tasks/reschedule/(?P<task_id>\d+)/$", views.tasks_reschedule),
+    url(r"^tasks/reprocess/(?P<task_id>\d+)/$", views.tasks_reprocess),
     url(r"^tasks/delete/(?P<task_id>(\d+|[0-9,]+))/$", views.tasks_delete),
     url(r"^tasks/delete/(?P<task_id>\d+)/(?P<status>\w+)/$", views.tasks_delete),
     url(r"^tasks/delete_many/$", views.tasks_delete_many),

--- a/web/apiv2/views.py
+++ b/web/apiv2/views.py
@@ -58,10 +58,10 @@ from lib.cuckoo.common.web_utils import (
 )
 from lib.cuckoo.core.database import (
     TASK_COMPLETED,
-    TASK_RECOVERED,
-    TASK_REPORTED,
     TASK_FAILED_PROCESSING,
     TASK_FAILED_REPORTING,
+    TASK_RECOVERED,
+    TASK_REPORTED,
     TASK_RUNNING,
     Database,
     Task,

--- a/web/apiv2/views.py
+++ b/web/apiv2/views.py
@@ -56,7 +56,16 @@ from lib.cuckoo.common.web_utils import (
     statistics,
     validate_task,
 )
-from lib.cuckoo.core.database import TASK_RUNNING, Database, Task
+from lib.cuckoo.core.database import (
+    TASK_COMPLETED,
+    TASK_RECOVERED,
+    TASK_REPORTED,
+    TASK_FAILED_PROCESSING,
+    TASK_FAILED_REPORTING,
+    TASK_RUNNING,
+    Database,
+    Task,
+)
 from lib.cuckoo.core.rooter import _load_socks5_operational, vpns
 
 try:
@@ -980,8 +989,49 @@ def tasks_reschedule(request, task_id):
         resp["error"] = False
         resp["data"] = "Task ID {0} has been rescheduled".format(task_id)
     else:
-        resp = {"error": True, "error_value": ("An error occured while trying to reschedule Task ID {0}".format(task_id))}
+        resp = {"error": True, "error_value": ("An error occurred while trying to reschedule Task ID {0}".format(task_id))}
 
+    return Response(resp)
+
+
+@csrf_exempt
+@api_view(["GET"])
+def tasks_reprocess(request, task_id):
+
+    resp = {}
+    if not apiconf.taskreprocess.get("enabled"):
+        resp["error"] = True
+        resp["error_value"] = "Task Reprocess API is Disabled"
+        return Response(resp)
+
+    task = db.view_task(task_id)
+    if not task:
+        resp["error"] = True
+        resp["error_value"] = "Task ID does not exist in the database"
+        return Response(resp)
+
+    # task status suitable for reprocessing
+    valid_status = {
+        # allow reprocessing of tasks already processed (maybe detections changed)
+        TASK_REPORTED,
+        # allow reprocessing of tasks that were rescheduled
+        TASK_RECOVERED,
+        # allow reprocessing of tasks that previously failed the processing stage
+        TASK_FAILED_PROCESSING,
+        # allow reprocessing of tasks that previously failed the reporting stage
+        TASK_FAILED_REPORTING,
+    }
+
+    if task.status not in valid_status:
+        error_fmt = "Task ID {0} cannot be reprocessed in status {1}"
+        resp["error"] = True
+        resp["error_value"] = error_fmt.format(task_id, task.status)
+        return Response(resp)
+
+    db.set_status(task_id, TASK_COMPLETED)
+    resp["error"] = False
+    resp_fmt = "Task ID {0} with status {1} marked for reprocessing"
+    resp["data"] = resp_fmt.format(task_id, task.status)
     return Response(resp)
 
 

--- a/web/templates/apiv2/index.html
+++ b/web/templates/apiv2/index.html
@@ -298,6 +298,28 @@ Acepts as params status to check for status and/or option to search by option LI
         </td>
       </tr>
       <tr>
+          <td>Reprocess Task</td>
+          {% if config.taskreprocess.enabled %}
+              <td><span class="badge badge-success">Yes</span></td>
+          {% else %}
+              <td><span class="badge badge-danger">No</span></td>
+          {% endif %}
+          <td>
+              <ul>
+                  <li>RPS: {{ config.taskreprocess.rps }}</li>
+                  <li>RPM: {{ config.taskreprocess.rpm }}</li>
+              </ul>
+          </td>
+          <td>Mark an analysis task as ready to be processed. Return object will be JSON.</td>
+          <td><a class="accordion-toggle" data-toggle="collapse" href="#taskreprocess" aria-expanded="false" aria-controls="#taskreprocess">Example</a>
+          </td>
+      </tr>
+      <tr class="collapse" id="taskreprocess">
+          <td colspan="5">
+              <pre>curl {{ config.api.url }}/apiv2/tasks/reprocess/[task id]/</pre>
+          </td>
+      </tr>
+      <tr>
         <td>Delete Task</td>
         {% if config.taskdelete.enabled %}
         <td><span class="badge badge-success">Yes</span></td>

--- a/web/web/settings.py
+++ b/web/web/settings.py
@@ -17,15 +17,18 @@ sys.path.append(CUCKOO_PATH)
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 
+RUNNING_TESTS = 'test' in sys.argv
+
 from lib.cuckoo.common.config import Config
 
 # In case we have VPNs enabled we need to initialize through the following
 # two methods as they verify the interaction with VPNs as well as gather
 # which VPNs are available (for representation upon File/URL submission).
-from lib.cuckoo.core.startup import init_rooter, init_routing
+if not RUNNING_TESTS:
+    from lib.cuckoo.core.startup import init_rooter, init_routing
 
-init_rooter()
-init_routing()
+    init_rooter()
+    init_routing()
 
 
 cfg = Config("reporting")
@@ -443,21 +446,22 @@ TEST_RUNNER = "django.test.runner.DiscoverRunner"
 # the site admins on every HTTP 500 error when DEBUG=False.
 # See http://docs.djangoproject.com/en/dev/topics/logging for
 # more details on how to customize your logging configuration.
-LOGGING = {
-    "version": 1,
-    "disable_existing_loggers": False,
-    "filters": {"require_debug_false": {"()": "django.utils.log.RequireDebugFalse"}},
-    "handlers": {
-        "mail_admins": {"level": "ERROR", "filters": ["require_debug_false"], "class": "django.utils.log.AdminEmailHandler"}
-    },
-    "loggers": {
-        "django.request": {
-            "handlers": ["mail_admins"],
-            "level": "ERROR",
-            "propagate": True,
+if not RUNNING_TESTS:
+    LOGGING = {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "filters": {"require_debug_false": {"()": "django.utils.log.RequireDebugFalse"}},
+        "handlers": {
+            "mail_admins": {"level": "ERROR", "filters": ["require_debug_false"], "class": "django.utils.log.AdminEmailHandler"}
         },
-    },
-}
+        "loggers": {
+            "django.request": {
+                "handlers": ["mail_admins"],
+                "level": "ERROR",
+                "propagate": True,
+            },
+        },
+    }
 
 SILENCED_SYSTEM_CHECKS = [
     "admin.E408",

--- a/web/web/settings.py
+++ b/web/web/settings.py
@@ -17,7 +17,7 @@ sys.path.append(CUCKOO_PATH)
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 
-RUNNING_TESTS = 'test' in sys.argv
+RUNNING_TESTS = "test" in sys.argv
 
 from lib.cuckoo.common.config import Config
 


### PR DESCRIPTION
This adds the API `tasks/reprocess/<task_id>/`, along with the start of test coverage for anything in APIv2.