### PR TITLE
enable initial APIv2 tests in GitHub CI

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = web.settings
+python_paths = web

--- a/requirements.tests.in
+++ b/requirements.tests.in
@@ -3,6 +3,8 @@ requests==2.27.1
 flake8==3.8.4
 pytest-cov==2.11.1
 pytest-mock==2.0.0
+pytest-django==4.5.2
+pytest-pythonpath==0.7.4
 func-timeout==4.3.5
 tenacity==7.0.0
 httpretty==0.9.7

--- a/tests/web/test_apiv2.py
+++ b/tests/web/test_apiv2.py
@@ -2,7 +2,6 @@ import os
 import unittest.mock
 from unittest.mock import patch
 
-import pytest
 from django.test import SimpleTestCase
 
 from lib.cuckoo.core.database import (
@@ -22,17 +21,19 @@ from lib.cuckoo.core.database import (
 
 
 class ReprocessTask(SimpleTestCase):
-    @pytest.mark.skip(reason="TODO")
+
+    taskprocess_config = "lib.cuckoo.common.web_utils.apiconf.taskreprocess"
+    """API configuration to patch in each test case."""
+
+    @patch.dict(taskprocess_config, {"enabled": False})
     def test_api_disabled(self):
-        patch_target = "lib.cuckoo.common.web_utils.apiconf.taskreprocess"
-        with patch.dict(patch_target, {"enabled": False}):
-            response = self.client.get("/apiv2/tasks/reprocess/1/")
+        response = self.client.get("/apiv2/tasks/reprocess/1/")
         assert response.status_code == 200
         assert response.headers["content-type"] == "application/json"
         json_body = {"error": True, "error_value": "Task Reprocess API is Disabled"}
         assert response.json() == json_body
 
-    @pytest.mark.skip(reason="TODO")
+    @patch.dict(taskprocess_config, {"enabled": True})
     def test_task_does_not_exist(self):
         patch_target = "lib.cuckoo.core.database.Database.view_task"
         with patch(patch_target, return_value=None):
@@ -42,7 +43,7 @@ class ReprocessTask(SimpleTestCase):
         json_body = {"error": True, "error_value": "Task ID does not exist in the database"}
         assert response.json() == json_body
 
-    @pytest.mark.skip(reason="TODO")
+    @patch.dict(taskprocess_config, {"enabled": True})
     def test_can_reprocess(self):
         task = Task()
         valid_status = (TASK_REPORTED, TASK_RECOVERED, TASK_FAILED_PROCESSING, TASK_FAILED_REPORTING)
@@ -57,7 +58,7 @@ class ReprocessTask(SimpleTestCase):
                     assert response.headers["content-type"] == "application/json"
                     assert response.json() == expected_response
 
-    @pytest.mark.skip(reason="TODO")
+    @patch.dict(taskprocess_config, {"enabled": True})
     def test_cant_reprocess(self):
         task = Task()
         invalid_status = (


### PR DESCRIPTION
Adds pytest-django and pytest-pythonpath test dependencies, and configures both with a simple pytest.ini. This should be enough to get the start of APIv2 test coverage via GitHub CI.