### PR TITLE
Add missing ics_attck_json arg in mitre Attck funcs

### DIFF
--- a/lib/cuckoo/common/abstracts.py
+++ b/lib/cuckoo/common/abstracts.py
@@ -61,13 +61,14 @@ if repconf.mitre.enabled:
         if pyattck_version >= (4, 1, 1) and pyattck_version <= (5, 2, 0):
             mitre = Attck(
                 nested_subtechniques=True,
-                save_config=True,
                 use_config=True,
+                save_config=True,
                 config_file_path=os.path.join(CUCKOO_ROOT, "data", "mitre", "config.yml"),
                 data_path=os.path.join(CUCKOO_ROOT, "data", "mitre"),
                 enterprise_attck_json=os.path.join(CUCKOO_ROOT, "data", "mitre", "enterprise_attck_json.json"),
                 pre_attck_json=os.path.join(CUCKOO_ROOT, "data", "mitre", "pre_attck_json.json"),
                 mobile_attck_json=os.path.join(CUCKOO_ROOT, "data", "mitre", "mobile_attck_json.json"),
+                ics_attck_json=os.path.join(CUCKOO_ROOT, "data", "mitre", "ics_attck_json.json"),
                 nist_controls_json=os.path.join(CUCKOO_ROOT, "data", "mitre", "nist_controls_json.json"),
                 generated_attck_json=os.path.join(CUCKOO_ROOT, "data", "mitre", "generated_attck_json.json"),
                 generated_nist_json=os.path.join(CUCKOO_ROOT, "data", "mitre", "generated_nist_json.json"),

--- a/utils/community.py
+++ b/utils/community.py
@@ -68,13 +68,14 @@ def mitre():
 
     mitre = Attck(
         nested_subtechniques=True,
-        save_config=False,
         use_config=False,
+        save_config=False,
         config_file_path=os.path.join(CUCKOO_ROOT, "data", "mitre", "config.yml"),
         data_path=os.path.join(CUCKOO_ROOT, "data", "mitre"),
         enterprise_attck_json="https://raw.githubusercontent.com/mitre/cti/master/enterprise-attack/enterprise-attack.json",
         pre_attck_json="https://raw.githubusercontent.com/mitre/cti/master/pre-attack/pre-attack.json",
         mobile_attck_json="https://raw.githubusercontent.com/mitre/cti/master/mobile-attack/mobile-attack.json",
+        ics_attck_json="https://raw.githubusercontent.com/mitre/cti/master/ics-attack/ics-attack.json",
         nist_controls_json="https://raw.githubusercontent.com/center-for-threat-informed-defense/attack-control-framework-mappings/master/frameworks/ATT%26CK-v9.0/nist800-53-r4/stix/nist800-53-r4-controls.json",
         generated_attck_json="https://swimlane-pyattck.s3.us-west-2.amazonaws.com/generated_attck_data.json",
         generated_nist_json="https://swimlane-pyattck.s3.us-west-2.amazonaws.com/attck_to_nist_controls.json",


### PR DESCRIPTION
Missing `ics_attck_json` argument causes an error in air-gapped environments
Linked to https://github.com/kevoreilly/community/pull/252