### PR TITLE
fix parser name bug

### DIFF
--- a/lib/cuckoo/common/cape_utils.py
+++ b/lib/cuckoo/common/cape_utils.py
@@ -118,7 +118,7 @@ if process_cfg.CAPE_extractors.enabled:
     cape_malware_parsers = cape_load_decoders(CUCKOO_ROOT)
     if cape_malware_parsers:
         HAVE_CAPE_EXTRACTORS = True
-    assert "test_cape" in cape_malware_parsers
+    assert "test cape" in cape_malware_parsers
 
 try:
     from modules.processing.parsers.plugxconfig import plugx

--- a/lib/cuckoo/common/load_extra_modules.py
+++ b/lib/cuckoo/common/load_extra_modules.py
@@ -42,7 +42,7 @@ def cape_load_decoders(CUCKOO_ROOT):
 
     for name in CAPE_DECODERS:
         try:
-            cape_modules[name] = importlib.import_module(f"modules.processing.parsers.CAPE.{name}")
+            cape_modules[name.replace('_', ' ')] = importlib.import_module(f"modules.processing.parsers.CAPE.{name}")
         except (ImportError, IndexError) as e:
             if "datadirs" in str(e):
                 print("You are using wrong pype32 library. pip3 uninstall pype32 && pip3 install -U pype32-py3")

--- a/lib/cuckoo/common/load_extra_modules.py
+++ b/lib/cuckoo/common/load_extra_modules.py
@@ -42,7 +42,7 @@ def cape_load_decoders(CUCKOO_ROOT):
 
     for name in CAPE_DECODERS:
         try:
-            cape_modules[name.replace('_', ' ')] = importlib.import_module(f"modules.processing.parsers.CAPE.{name}")
+            cape_modules[name.replace("_", " ")] = importlib.import_module(f"modules.processing.parsers.CAPE.{name}")
         except (ImportError, IndexError) as e:
             if "datadirs" in str(e):
                 print("You are using wrong pype32 library. pip3 uninstall pype32 && pip3 install -U pype32-py3")


### PR DESCRIPTION
When I add a parser like "A_B.py", it cannot be found. Now I fix it.