### PR TITLE
Remove explicit inheritance from object

### DIFF
--- a/admin/admin.py
+++ b/admin/admin.py
@@ -125,7 +125,7 @@ def file_recon(file: str, yara_category: str = "CAPE"):
         TARGET = os.path.join(CAPE_PATH, "analyzer", "windows", "modules", "packages", filename)
     elif b"def choose_package(file_type, file_name, exports, target)" in f:
         TARGET = os.path.join(CAPE_PATH, "analyzer", "windows", "lib", "core", filename)
-    elif b"class Signature(object):" in f and b"class Processing(object):" in f:
+    elif b"class Signature:" in f and b"class Processing:" in f:
         TARGET = os.path.join(CAPE_PATH, "lib", "cuckoo", "common", filename)
     elif b"class Analyzer:" in f and b"class PipeHandler(Thread):" in f and b"class PipeServer(Thread):" in f:
         TARGET = os.path.join(CAPE_PATH, "analyzer", "windows", filename)

--- a/agent/agent.py
+++ b/agent/agent.py
@@ -91,7 +91,7 @@ class MiniHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
         self.httpd.handle(self)
 
 
-class MiniHTTPServer(object):
+class MiniHTTPServer:
     def __init__(self):
         self.handler = MiniHTTPRequestHandler
 
@@ -146,7 +146,7 @@ class MiniHTTPServer(object):
         self.s._BaseServer__shutdown_request = True
 
 
-class jsonify(object):
+class jsonify:
     """Wrapper that represents Flask.jsonify functionality."""
 
     def __init__(self, **kwargs):
@@ -163,7 +163,7 @@ class jsonify(object):
         pass
 
 
-class send_file(object):
+class send_file:
     """Wrapper that represents Flask.send_file functionality."""
 
     def __init__(self, path):
@@ -191,7 +191,7 @@ class send_file(object):
         obj.send_header("Content-Length", self.length)
 
 
-class request(object):
+class request:
     form = {}
     files = {}
     client_ip = None

--- a/analyzer/linux/lib/common/abstracts.py
+++ b/analyzer/linux/lib/common/abstracts.py
@@ -8,7 +8,7 @@ from lib.api.process import Process
 from lib.common.exceptions import CuckooPackageError
 
 
-class Package(object):
+class Package:
     """Base abstract analysis package."""
 
     PATHS = []
@@ -69,7 +69,7 @@ class Package(object):
         return []
 
 
-class Auxiliary(object):
+class Auxiliary:
     priority = 0
 
     def __init__(self, options={}, analyzer=None):

--- a/analyzer/linux/lib/common/results.py
+++ b/analyzer/linux/lib/common/results.py
@@ -38,7 +38,7 @@ def upload_to_host(file_path, dump_path, pids=[], metadata="", category=""):
             nc.close()
 
 
-class NetlogConnection(object):
+class NetlogConnection:
     def __init__(self, proto=""):
         config = Config(cfg="analysis.conf")
         self.hostip, self.hostport = config.ip, config.port

--- a/analyzer/linux/lib/core/packages.py
+++ b/analyzer/linux/lib/core/packages.py
@@ -76,7 +76,7 @@ def _guess_package_name(file_type, file_name):
         return None
 
 
-class Package(object):
+class Package:
     """Base analysis package"""
 
     def __init__(self, target, **kwargs):

--- a/analyzer/windows/analyzer.py
+++ b/analyzer/windows/analyzer.py
@@ -691,7 +691,7 @@ class Analyzer:
         return True
 
 
-class Files(object):
+class Files:
     PROTECTED_NAMES = [
         "vmwareuser.exe",
         "vmwareservice.exe",
@@ -810,7 +810,7 @@ class Files(object):
             self.delete_file(list(self.files.keys())[0])
 
 
-class ProcessList(object):
+class ProcessList:
     def __init__(self):
         self.pids = []
         self.pids_notrack = []
@@ -855,7 +855,7 @@ class ProcessList(object):
             self.pids_notrack.remove(pid)
 
 
-class CommandPipeHandler(object):
+class CommandPipeHandler:
     """Pipe Handler.
     This class handles the notifications received through the Pipe Server and
     decides what to do with them.

--- a/analyzer/windows/lib/common/abstracts.py
+++ b/analyzer/windows/lib/common/abstracts.py
@@ -17,7 +17,7 @@ INJECT_QUEUEUSERAPC = 1
 log = logging.getLogger(__name__)
 
 
-class Package(object):
+class Package:
     """Base abstract analysis package."""
 
     PATHS = []
@@ -179,7 +179,7 @@ class Package(object):
         return newpath
 
 
-class Auxiliary(object):
+class Auxiliary:
     def __init__(self, options=None, config=None):
         """@param options: options dict."""
         if options is None:

--- a/analyzer/windows/lib/common/results.py
+++ b/analyzer/windows/lib/common/results.py
@@ -45,7 +45,7 @@ def upload_to_host(file_path, dump_path, pids="", ppids="", metadata="", categor
             nc.close()
 
 
-class NetlogConnection(object):
+class NetlogConnection:
     def __init__(self, proto=""):
         self.hostip, self.hostport = config.ip, config.port
         self.sock = None

--- a/analyzer/windows/lib/core/log.py
+++ b/analyzer/windows/lib/core/log.py
@@ -102,7 +102,7 @@ class LogServerThread(Thread):
             return True
 
 
-class LogServer(object):
+class LogServer:
     def __init__(self, result_ip, result_port, logserver_path):
         # Create the Named Pipe.
         sd = SECURITY_DESCRIPTOR()

--- a/docs/book/src/customization/packages.rst
+++ b/docs/book/src/customization/packages.rst
@@ -39,7 +39,7 @@ Package object:
         from lib.api.process import Process
         from lib.common.exceptions import CuckooPackageError
 
-        class Package(object):
+        class Package:
             def start(self):
                 raise NotImplementedError
 

--- a/lib/cuckoo/common/abstracts.py
+++ b/lib/cuckoo/common/abstracts.py
@@ -89,7 +89,7 @@ myresolver.domain = dns.name.Name("google-public-dns-a.google.com")
 myresolver.nameserver = ["8.8.8.8"]
 
 
-class Auxiliary(object):
+class Auxiliary:
     """Base abstract class for auxiliary modules."""
 
     def __init__(self):
@@ -114,7 +114,7 @@ class Auxiliary(object):
         raise NotImplementedError
 
 
-class Machinery(object):
+class Machinery:
     """Base abstract class for machinery modules."""
 
     # Default label used in machinery configuration file to supply virtual
@@ -646,7 +646,7 @@ class LibVirtMachinery(Machinery):
         return snapshot
 
 
-class Processing(object):
+class Processing:
     """Base abstract class for processing module."""
 
     order = 1
@@ -713,7 +713,7 @@ class Processing(object):
         raise NotImplementedError
 
 
-class Signature(object):
+class Signature:
     """Base class for Cuckoo signatures."""
 
     name = ""
@@ -1564,7 +1564,7 @@ class Signature(object):
         )
 
 
-class Report(object):
+class Report:
     """Base abstract class for reporting module."""
 
     order = 1
@@ -1621,7 +1621,7 @@ class Report(object):
         raise NotImplementedError
 
 
-class Feed(object):
+class Feed:
     """Base abstract class for feeds."""
 
     name = ""
@@ -1692,7 +1692,7 @@ class Feed(object):
         return
 
 
-class ProtocolHandler(object):
+class ProtocolHandler:
     """Abstract class for protocol handlers coming out of the analysis."""
 
     def __init__(self, task_id, ctx, version=None):

--- a/lib/cuckoo/common/aplib.py
+++ b/lib/cuckoo/common/aplib.py
@@ -14,7 +14,7 @@ __version__ = "0.6"
 __author__ = "Sandor Nemes"
 
 
-class APLib(object):
+class APLib:
 
     __slots__ = "source", "destination", "tag", "bitcount", "strict"
 

--- a/lib/cuckoo/common/files.py
+++ b/lib/cuckoo/common/files.py
@@ -43,7 +43,7 @@ def open_exclusive(path, mode="xb", bufsize=-1):
         raise
 
 
-class Storage(object):
+class Storage:
     @staticmethod
     def get_filename_from_path(path):
         """Cross-platform filename extraction from path.

--- a/lib/cuckoo/common/icon.py
+++ b/lib/cuckoo/common/icon.py
@@ -58,7 +58,7 @@ class ICONDIRENTRY(Structure):
     ]
 
 
-class PEGroupIconDir(object):
+class PEGroupIconDir:
     def __init__(self, data):
         self.data = data
         self.icondir = None

--- a/lib/cuckoo/common/integrations/parse_dotnet.py
+++ b/lib/cuckoo/common/integrations/parse_dotnet.py
@@ -14,7 +14,7 @@ log = logging.getLogger(__name__)
 # Note universal_newlines should be False as some binaries fails to convert bytes to text
 
 
-class DotNETExecutable(object):
+class DotNETExecutable:
     """.NET analysis"""
 
     def __init__(self, file_path):

--- a/lib/cuckoo/common/integrations/parse_elf.py
+++ b/lib/cuckoo/common/integrations/parse_elf.py
@@ -36,7 +36,7 @@ except ImportError:
     ELFFile = False
 
 
-class ELF(object):
+class ELF:
     def __init__(self, file_path):
         self.file_path = file_path
         self.elf = None

--- a/lib/cuckoo/common/integrations/parse_encoded_script.py
+++ b/lib/cuckoo/common/integrations/parse_encoded_script.py
@@ -11,7 +11,7 @@ log = logging.getLogger(__name__)
 
 
 # TODO: this probably can be replaced by vbe_decoder
-class EncodedScriptFile(object):
+class EncodedScriptFile:
     """Deobfuscates and interprets Windows Script Files."""
 
     encoding = (

--- a/lib/cuckoo/common/integrations/parse_hwp.py
+++ b/lib/cuckoo/common/integrations/parse_hwp.py
@@ -18,7 +18,7 @@ except ImportError:
 log = logging.getLogger(__name__)
 
 
-class HwpDocument(object):
+class HwpDocument:
     """Static analysis of HWP documents."""
 
     def __init__(self, filepath: str):

--- a/lib/cuckoo/common/integrations/parse_java.py
+++ b/lib/cuckoo/common/integrations/parse_java.py
@@ -13,7 +13,7 @@ from lib.cuckoo.common.utils import convert_to_printable, store_temp_file
 log = logging.getLogger(__name__)
 
 
-class Java(object):
+class Java:
     """Java Static Analysis"""
 
     def __init__(self, file_path: str, decomp_jar: str):

--- a/lib/cuckoo/common/integrations/parse_lnk.py
+++ b/lib/cuckoo/common/integrations/parse_lnk.py
@@ -12,7 +12,7 @@ from lib.cuckoo.common.structures import LnkEntry, LnkHeader
 log = logging.getLogger(__name__)
 
 
-class LnkShortcut(object):
+class LnkShortcut:
     signature = [0x4C, 0x00, 0x00, 0x00]
     guid = [
         0x01,

--- a/lib/cuckoo/common/integrations/parse_office.py
+++ b/lib/cuckoo/common/integrations/parse_office.py
@@ -55,7 +55,7 @@ if not processing_conf.xlsdeobf.on_demand:
 log = logging.getLogger(__name__)
 
 
-class Office(object):
+class Office:
     """Office Document Static Analysis
     Supported formats:
     - Word 97-2003 (.doc, .dot), Word 2007+ (.docm, .dotm)

--- a/lib/cuckoo/common/integrations/parse_pdf.py
+++ b/lib/cuckoo/common/integrations/parse_pdf.py
@@ -13,7 +13,7 @@ from lib.cuckoo.common.pdftools.pdfid import PDFiD, PDFiD2JSON
 log = logging.getLogger(__name__)
 
 
-class PDF(object):
+class PDF:
     """PDF Analysis."""
 
     def __init__(self, file_path: str):

--- a/lib/cuckoo/common/integrations/parse_pe.py
+++ b/lib/cuckoo/common/integrations/parse_pe.py
@@ -146,7 +146,7 @@ def IsPEImage(buf: bytes, size: int = False) -> bool:
     return True
 
 
-class PortableExecutable(object):
+class PortableExecutable:
     """PE analysis."""
 
     def __init__(self, file_path: str):

--- a/lib/cuckoo/common/integrations/parse_url.py
+++ b/lib/cuckoo/common/integrations/parse_url.py
@@ -32,7 +32,7 @@ import requests
 log = logging.getLogger(__name__)
 
 
-class URL(object):
+class URL:
     """URL 'Static' Analysis"""
 
     def __init__(self, url: str):

--- a/lib/cuckoo/common/integrations/parse_wsf.py
+++ b/lib/cuckoo/common/integrations/parse_wsf.py
@@ -19,7 +19,7 @@ except ImportError:
     HAVE_BS4 = False
 
 
-class WindowsScriptFile(object):
+class WindowsScriptFile:
     script_re = "<\\s*script\\s*.*>.*?<\\s*/\\s*script\\s*>"
 
     def __init__(self, filepath):

--- a/lib/cuckoo/common/irc.py
+++ b/lib/cuckoo/common/irc.py
@@ -19,7 +19,7 @@ except ImportError:
 log = logging.getLogger("Processing.Pcap.irc.protocol")
 
 
-class ircMessage(object):
+class ircMessage:
     """IRC Protocol Request."""
 
     # Client commands

--- a/lib/cuckoo/common/netlog.py
+++ b/lib/cuckoo/common/netlog.py
@@ -88,7 +88,7 @@ def check_names_for_typeinfo(arginfo):
     return argnames, converters
 
 
-class BsonParser(object):
+class BsonParser:
     """Interprets .bson logs from the monitor.
     The monitor provides us with "info" messages that explain how the function
     arguments will come through later on. This class remembers these info

--- a/lib/cuckoo/common/objects.py
+++ b/lib/cuckoo/common/objects.py
@@ -154,7 +154,7 @@ class URL:
         self.url = url
 
 
-class File(object):
+class File:
     """Basic file object class with all useful utilities."""
 
     # The yara rules should not change during one Cuckoo run and as such we're
@@ -575,7 +575,7 @@ class Static(File):
     pass
 
 
-class ProcDump(object):
+class ProcDump:
     def __init__(self, dump_file, pretty=False):
         self._dumpfile = open(dump_file, "rb")
         self.dumpfile = mmap.mmap(self._dumpfile.fileno(), 0, access=mmap.ACCESS_READ)

--- a/lib/cuckoo/common/pdftools/pdf-parser.py
+++ b/lib/cuckoo/common/pdftools/pdf-parser.py
@@ -1095,7 +1095,7 @@ def RunLengthDecode(data):
 # and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 
-class LZWDecoder(object):
+class LZWDecoder:
     def __init__(self, fp):
         self.fp = fp
         self.buff = 0

--- a/lib/cuckoo/common/utils.py
+++ b/lib/cuckoo/common/utils.py
@@ -871,7 +871,7 @@ def classlock(f):
     return inner
 
 
-class SuperLock(object):
+class SuperLock:
     def __init__(self):
         self.tlock = threading.Lock()
         self.mlock = multiprocessing.Lock()

--- a/lib/cuckoo/core/guest.py
+++ b/lib/cuckoo/core/guest.py
@@ -72,7 +72,7 @@ def analyzer_zipfile(platform):
     return data
 
 
-class GuestManager(object):
+class GuestManager:
     """This class represents the new Guest Manager. It operates on the new
     Cuckoo Agent which features a more abstract but more feature-rich API."""
 

--- a/lib/cuckoo/core/plugins.py
+++ b/lib/cuckoo/core/plugins.py
@@ -109,7 +109,7 @@ def list_plugins(group=None):
         return _modules
 
 
-class RunAuxiliary(object):
+class RunAuxiliary:
     """Auxiliary modules manager."""
 
     def __init__(self, task, machine):
@@ -190,7 +190,7 @@ class RunAuxiliary(object):
                 log.debug("Stopped auxiliary module: %s", module.__class__.__name__)
 
 
-class RunProcessing(object):
+class RunProcessing:
     """Analysis Results Processing Engine.
 
     This class handles the loading and execution of the processing modules.
@@ -320,7 +320,7 @@ class RunProcessing(object):
         return self.results
 
 
-class RunSignatures(object):
+class RunSignatures:
     """Run Signatures."""
 
     def __init__(self, task, results):
@@ -718,7 +718,7 @@ class RunReporting:
             log.info("No reporting modules loaded")
 
 
-class GetFeeds(object):
+class GetFeeds:
     """Feed Download and Parsing Engine
 
     This class handles the downloading and modification of feed modules.

--- a/lib/cuckoo/core/resultserver.py
+++ b/lib/cuckoo/core/resultserver.py
@@ -78,7 +78,7 @@ class Disconnect(Exception):
     pass
 
 
-class HandlerContext(object):
+class HandlerContext:
     """Holds context for protocol handlers.
     Can safely be cancelled from another thread, though in practice this will
     not occur often -- usually the connection between VM and the ResultServer
@@ -154,7 +154,7 @@ class HandlerContext(object):
         fd.flush()
 
 
-class WriteLimiter(object):
+class WriteLimiter:
     def __init__(self, fd, remain):
         self.fd = fd
         self.remain = remain

--- a/modules/processing/behavior.py
+++ b/modules/processing/behavior.py
@@ -658,7 +658,7 @@ class Summary:
         }
 
 
-class Enhanced(object):
+class Enhanced:
     """Generates a more extensive high-level representation than Summary."""
 
     key = "enhanced"
@@ -948,7 +948,7 @@ class Enhanced(object):
         return self.events
 
 
-class Anomaly(object):
+class Anomaly:
 
     """Anomaly detected during analysis.
     For example: a malware tried to remove Cuckoo's hooks.

--- a/modules/processing/memory.py
+++ b/modules/processing/memory.py
@@ -43,7 +43,7 @@ yara_rules_path = os.path.join(CUCKOO_ROOT, "data", "yara", "index_memory.yarc")
 # set logger volatility3
 
 
-class MuteProgress(object):
+class MuteProgress:
     def __init__(self):
         self._max_message_len = 0
 
@@ -77,7 +77,7 @@ class ReturnJsonRenderer(JsonRenderer):
         return final_output[1], error
 
 
-class VolatilityAPI(object):
+class VolatilityAPI:
     def __init__(self, memdump):
         """
         @param memdump: path to memdump. Ex. file:///home/vol3/memory.dmp
@@ -179,7 +179,7 @@ class VolatilityAPI(object):
 """
 
 
-class VolatilityManager(object):
+class VolatilityManager:
     """Handle several volatility results."""
 
     def __init__(self, memfile):

--- a/modules/processing/network.py
+++ b/modules/processing/network.py
@@ -822,7 +822,7 @@ class Pcap:
         return self.results
 
 
-class Pcap2(object):
+class Pcap2:
     """Interpret the PCAP file through the httpreplay library which parses
     the various protocols, decrypts and decodes them, and then provides us
     with the high level representation of it."""
@@ -1138,7 +1138,7 @@ def batch_sort(input_iterator, output_path, buffer_size=32000, output_class=None
 
 
 # magic
-class SortCap(object):
+class SortCap:
     """SortCap is a wrapper around the packet lib (dpkt) that allows us to sort pcaps
     together with the batch_sort function above."""
 

--- a/modules/processing/parsers/CAPE/Nymaim.py_disabled
+++ b/modules/processing/parsers/CAPE/Nymaim.py_disabled
@@ -76,7 +76,7 @@ class NymCfgStream(Stream):
         return h, data
 
 
-class M(object):
+class M:
     def __init__(self, dbg=None, base=0, mem=""):
         self.mem = mem
         self.base = base

--- a/modules/processing/platform/linux.py
+++ b/modules/processing/platform/linux.py
@@ -168,7 +168,7 @@ class LinuxStrace(BehaviorHandler):
         return self.processes
 
 
-class StraceParser(object):
+class StraceParser:
     """Handle strace logs from the Linux analyzer."""
 
     def __init__(self, path):
@@ -217,7 +217,7 @@ class StraceParser(object):
             }
 
 
-class StapParser(object):
+class StapParser:
     """Handle .stap logs from the Linux analyzer."""
 
     def __init__(self, fd):

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -12,7 +12,7 @@ from lib.cuckoo.common.utils import store_temp_file
 from lib.cuckoo.core.database import Database, Task
 
 
-class TestDatabaseEngine(object):
+class TestDatabaseEngine:
     """Test database stuff."""
 
     URI = None

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -15,7 +15,7 @@ from lib.cuckoo.common.exceptions import CuckooOperationalError
 from lib.cuckoo.core.scheduler import AnalysisManager
 
 
-class mock_task(object):
+class mock_task:
     def __init__(self):
         self.id = 1234
         self.category = "file"
@@ -201,7 +201,7 @@ class TestAnalysisManager:
         assert "Unable to create symlink/copy" in caplog.text
 
     def test_acquire_machine(self, setup_machinery, setup_machine_lock):
-        class mock_machinery(object):
+        class mock_machinery:
             def availables(self):
                 return True
 
@@ -239,7 +239,7 @@ class TestAnalysisManager:
         assert analysis_man.machine.name == "mock_mach"
 
     def test_acquire_machine_machinery_not_avail(self, setup_machinery, setup_machine_lock, mocker):
-        class mock_machinery(object):
+        class mock_machinery:
             def availables(self):
                 return False
 
@@ -276,7 +276,7 @@ class TestAnalysisManager:
             print((str(e)))
 
     def test_acquire_machine_machine_not_avail(self, setup_machinery, setup_machine_lock, mocker):
-        class mock_machinery(object):
+        class mock_machinery:
             def availables(self):
                 return True
 
@@ -310,7 +310,7 @@ class TestAnalysisManager:
 
     @pytest.mark.skip(reason="TODO")
     def test_build_options(self):
-        class mock_machine(object):
+        class mock_machine:
             resultserver_ip = "1.2.3.4"
             resultserver_port = "1337"
 
@@ -350,7 +350,7 @@ class TestAnalysisManager:
 
     @pytest.mark.skip(reason="TODO")
     def test_build_options_pe(self, grab_sample):
-        class mock_machine(object):
+        class mock_machine:
             resultserver_ip = "1.2.3.4"
             resultserver_port = "1337"
 

--- a/utils/rooter.py
+++ b/utils/rooter.py
@@ -29,7 +29,7 @@ log.addHandler(ch)
 log.setLevel(logging.INFO)
 
 
-class s(object):
+class s:
     iptables = None
     iptables_save = None
     iptables_restore = None
@@ -516,7 +516,7 @@ if __name__ == "__main__":
 
     # Simple object to allow a signal handler to stop the rooter loop
 
-    class Run(object):
+    class Run:
         def __init__(self):
             self.run = True
 

--- a/web/analysis/views.py
+++ b/web/analysis/views.py
@@ -159,7 +159,7 @@ anon_not_viewable_func_list = (
 )
 
 # Conditional decorator for web authentication
-class conditional_login_required(object):
+class conditional_login_required:
     def __init__(self, dec, condition):
         self.decorator = dec
         self.condition = condition

--- a/web/apiv2/views.py
+++ b/web/apiv2/views.py
@@ -109,7 +109,7 @@ if repconf.elasticsearchdb.enabled and not repconf.elasticsearchdb.searchonly:
 db = Database()
 
 # Conditional decorator for web authentication
-class conditional_login_required(object):
+class conditional_login_required:
     def __init__(self, dec, condition):
         self.decorator = dec
         self.condition = condition

--- a/web/captcha_admin/mixins.py
+++ b/web/captcha_admin/mixins.py
@@ -1,7 +1,7 @@
 from django.contrib.admin.sites import site as default_site
 
 
-class AdminSiteRegistryFix(object):
+class AdminSiteRegistryFix:
     """
     This fix links the '_registry' property to the original AdminSites
     '_registry' property. This is necessary, because of the character of

--- a/web/compare/views.py
+++ b/web/compare/views.py
@@ -39,7 +39,7 @@ if enabledconf["elasticsearchdb"]:
 
 
 # Conditional decorator for web authentication
-class conditional_login_required(object):
+class conditional_login_required:
     def __init__(self, dec, condition):
         self.decorator = dec
         self.condition = condition

--- a/web/dashboard/views.py
+++ b/web/dashboard/views.py
@@ -28,7 +28,7 @@ from lib.cuckoo.core.database import (
 
 
 # Conditional decorator for web authentication
-class conditional_login_required(object):
+class conditional_login_required:
     def __init__(self, dec, condition):
         self.decorator = dec
         self.condition = condition

--- a/web/submission/views.py
+++ b/web/submission/views.py
@@ -87,7 +87,7 @@ def get_form_data(platform):
 
 
 # Conditional decorator for web authentication
-class conditional_login_required(object):
+class conditional_login_required:
     def __init__(self, dec, condition):
         self.decorator = dec
         self.condition = condition

--- a/web/web/middleware.py
+++ b/web/web/middleware.py
@@ -9,7 +9,7 @@ try:  # django 1.10+
     from django.utils.deprecation import MiddlewareMixin
 except ImportError:
 
-    class MiddlewareMixin(object):
+    class MiddlewareMixin:
         def __init__(self, get_response=None):
             pass
 


### PR DESCRIPTION
Defining a class via
```python
class foo(object):
...
```
is the same as
```python
class foo:
...
```
in python 3.

There would be a difference if the code was written in Python 2, but the code would definitely break elsewhere anyways if Python 2 was used to run CAPE.