### PR TITLE
Make sure that the keys from tmp_config are not put in the top-level config dict

### DIFF
--- a/modules/processing/CAPE.py
+++ b/modules/processing/CAPE.py
@@ -270,7 +270,7 @@ class CAPE(Processing):
             cape_name = hit["name"].replace("_", " ")
             tmp_config = static_config_parsers(hit["name"], file_data)
             if tmp_config and tmp_config.get(cape_name):
-                config.update(tmp_config[cape_name])
+                config.setdefault(cape_name, {}).update(tmp_config[cape_name])
 
         if type_string:
             log.info("CAPE: type_string: %s", type_string)


### PR DESCRIPTION
We had some Emotet samples that ended up having the 'address', 'ECC ECK1', and 'ECC ECS1' key at the top level of the resulting CAPE.configs object as well as under CAPE.configs.Emotet. I tracked it down to this line where we were calling `config.update(tmp_config[cape_name])` which would take all of the keys under 'Emotet' from `tmp_config` and put them as top-level keys in `config`.

```
        "CAPE" : {
                "configs" : [
                        {
                                "address" : [
                                        [
                                                <list of addr/port>
                                        ]
                                ],
                                "ECC ECK1" : [
                                        "-----BEGIN PUBLIC KEY-----\n<key>\n-----END PUBLIC KEY-----"
                                ],
                                "ECC ECS1" : [
                                        "-----BEGIN PUBLIC KEY-----\n<key>\n-----END PUBLIC KEY-----"
                                ],
                                "Emotet" : {
                                        "address" : [
                                                [
                                                        <list of addr/port>
                                                ]
                                        ],
                                        "ECC ECK1" : [
                                                "-----BEGIN PUBLIC KEY-----\n<key>\n-----END PUBLIC KEY-----"
                                        ],
                                        "ECC ECS1" : [
                                                "-----BEGIN PUBLIC KEY-----\n<key>\n-----END PUBLIC KEY-----"
                                        ]
                                }
                        }
                ]
        }