### PR TITLE
Fix JsonDump bytes decode error

### DIFF
--- a/modules/reporting/jsondump.py
+++ b/modules/reporting/jsondump.py
@@ -23,7 +23,11 @@ class JsonDump(Report):
 
     def default(self, obj):
         if isinstance(obj, bytes):
-            return obj.decode()
+            try:
+                result = obj.decode()
+            except UnicodeDecodeError:
+                result = f"UnicodeDecodeError, bytes hex str: {obj.hex()}"
+            return result
         raise TypeError
 
     def run(self, results):


### PR DESCRIPTION
When I submit a file to CAPE, it can not generate a report.json.  
I submit it to CAPE, and it should have same problem: https://capesandbox.com/analysis/270313/  
I fix it by converting some bytes to hex str, at least the report.json can be generated. There may be a better way.