### PR TITLE
Fix pymongo fork-safe warnings

### DIFF
--- a/dev_utils/mongodb.py
+++ b/dev_utils/mongodb.py
@@ -45,6 +45,7 @@ def connect_to_mongo() -> MongoClient:
             username=repconf.mongodb.get("username"),
             password=repconf.mongodb.get("password"),
             authSource=repconf.mongodb.get("authsource", "cuckoo"),
+            connect=False,
         )
     except (ConnectionFailure, ServerSelectionTimeoutError):
         log.error("Cannot connect to MongoDB")


### PR DESCRIPTION
Relevant logs:
```
May 16 23:49:08 ubuntu python3[4324]: 2022-05-16 23:49:08,006 [lib.cuckoo.core.plugins] DEBUG: Executing reporting module "MongoDB"
May 16 23:49:08 ubuntu python3[4324]: /usr/local/lib/python3.8/dist-packages/pymongo/topology.py:162: UserWarning: MongoClient opened before fork. Create MongoClient only after forking. See PyMongo's documentation for details: https://pymongo.readthedocs.io/en/stable/faq.html#is-pymongo-fork-safe
May 16 23:49:08 ubuntu python3[4324]:   warnings.warn(
```

Reference: https://pymongo.readthedocs.io/en/stable/faq.html#is-pymongo-fork-safe

From https://pymongo.readthedocs.io/en/stable/api/pymongo/mongo_client.html:
> connect (optional): if True (the default), immediately begin connecting to MongoDB in the background. Otherwise connect on the first operation.