### PR TITLE
"CAPE Yara" format display

### DIFF
--- a/data/html/sections/file.html
+++ b/data/html/sections/file.html
@@ -93,18 +93,15 @@
                 <th>CAPE Yara</th>
                 <td>
                     <ul style="margin-top: 0;margin-bottom: 0;">
-                        {% for sig in results.target.file.cape_yara %}
+                    {% for sig in results.target.file.cape_yara %}
                         <li>
-                            {% if sig.meta.cape_type %}
-                                {{sig.meta.cape_type}}
-                            {% elif sig.meta.description %}
-                                {{sig.meta.description}}
-                            {% endif %}
-                            {% if sig.meta.author %}
-                                - Author: {{sig.meta.author}}
-                            {% endif %}
-                            </li>
-                        {% endfor %}
+                        {{sig.name}}
+                        {% if sig.meta.cape_type %} - {{sig.meta.cape_type}}
+                        {% elif sig.meta.description %} - {{sig.meta.description}}
+                        {% endif %}
+                        {% if sig.meta.author %} - Author: {{sig.meta.author}}{% endif %}
+                        </li>
+                    {% endfor %}
                     </ul>
                 </td>
             </tr>

--- a/web/templates/analysis/generic/_file_info.html
+++ b/web/templates/analysis/generic/_file_info.html
@@ -197,13 +197,11 @@
                 <ul style="margin-bottom: 0;">
                 {% for sign in file.cape_yara %}
                     <li>
-                    {% if sign.meta.cape_type %}
-                        {{sign.meta.cape_type}}
+                    {{sign.name}}
+                    {% if sign.meta.cape_type %} - {{sign.meta.cape_type}}
+                    {% elif sign.meta.description %} - {{sign.meta.description}}
                     {% endif %}
-                    {{sign.meta.name}} {% if sign.meta.description %} - {{sign.meta.description}} {% endif %}
-                    {% if sign.meta.author %}
-                        - Author: {{sign.meta.author}}
-                    {% endif %}
+                    {% if sign.meta.author %} - Author: {{sign.meta.author}}{% endif %}
                     </li>
                 {% endfor %}
                 </ul>

--- a/web/templates/analysis/generic/_subfile_info.html
+++ b/web/templates/analysis/generic/_subfile_info.html
@@ -183,13 +183,11 @@
                 <ul style="margin-bottom: 0;">
                 {% for sign in sub_file.cape_yara %}
                     <li>
-                    {% if sign.meta.cape_type %}
-                        {{sign.meta.cape_type}}
+                    {{sign.name}}
+                    {% if sign.meta.cape_type %} - {{sign.meta.cape_type}}
+                    {% elif sign.meta.description %} - {{sign.meta.description}}
                     {% endif %}
-                    {{sign.meta.name}} {% if sign.meta.description %} - {{sign.meta.description}} {% endif %}
-                    {% if sign.meta.author %}
-                        - Author: {{sign.meta.author}}
-                    {% endif %}
+                    {% if sign.meta.author %} - Author: {{sign.meta.author}}{% endif %}
                     </li>
                 {% endfor %}
                 </ul>

--- a/web/templates/analysis/procmemory/index.html
+++ b/web/templates/analysis/procmemory/index.html
@@ -41,15 +41,20 @@
                         <tr>
                             <th>CAPE Yara</th>
                             <td>
-                                {% for match in proc.cape_yara %}
-                                <li>Match: {{match.name}} - {{match.meta.description}} - Author: {{match.meta.author}}
-                                    <!--
-                                    {% for key, value in match.memblocks.items %}
-                                        <div span style="padding-left: 16px;">'{{key}}' in address space {{value}}</div>
-                                    {% endfor %}
-                                    -->
-                                </li>
+                            {% for match in proc.cape_yara %}
+                                <li>
+                                Match: {{sign.name}}
+                                {% if sign.meta.cape_type %} - {{sign.meta.cape_type}}
+                                {% elif sign.meta.description %} - {{sign.meta.description}}
+                                {% endif %}
+                                {% if sign.meta.author %} - Author: {{sign.meta.author}}{% endif %}
+                                <!--
+                                {% for key, value in match.memblocks.items %}
+                                    <div span style="padding-left: 16px;">'{{key}}' in address space {{value}}</div>
                                 {% endfor %}
+                                -->
+                                </li>
+                            {% endfor %}
                             </td>
                         </tr>
                         {% endif %}


### PR DESCRIPTION
All "CAPE Yara" use same display style.  
Not "meta.name" rather than "name".  