### PR TITLE
Added logic to fix potential race condition when provisioning new EC2…

### DIFF
--- a/modules/machinery/aws.py
+++ b/modules/machinery/aws.py
@@ -80,9 +80,7 @@ class AWS(Machinery):
             if num_of_machines_to_start <= 0:
                 break
             if self._status(machine.label) in [AWS.POWEROFF, AWS.STOPPING]:
-                self.ec2_machines[
-                    machine.label
-                ].start()  # not using self.start() to avoid _wait_ method
+                self.ec2_machines[machine.label].start()  # not using self.start() to avoid _wait_ method
                 num_of_machines_to_start -= 1
 
     def _delete_machine_form_db(self, label):
@@ -114,15 +112,9 @@ class AWS(Machinery):
         autoscale_options = self.options.get("autoscale")
         # If configured, use specific network interface for this
         # machine, else use the default value.
-        interface = (
-            autoscale_options["interface"]
-            if autoscale_options.get("interface")
-            else machinery_options.get("interface")
-        )
+        interface = autoscale_options["interface"] if autoscale_options.get("interface") else machinery_options.get("interface")
         resultserver_ip = (
-            autoscale_options["resultserver_ip"]
-            if autoscale_options.get("resultserver_ip")
-            else Config("cuckoo:resultserver:ip")
+            autoscale_options["resultserver_ip"] if autoscale_options.get("resultserver_ip") else Config("cuckoo:resultserver:ip")
         )
         if autoscale_options.get("resultserver_port"):
             resultserver_port = autoscale_options["resultserver_port"]
@@ -201,21 +193,11 @@ class AWS(Machinery):
         running_machines_gap = machinery_options.get("running_machines_gap", 0)
         dynamic_machines_limit = autoscale_options["dynamic_machines_limit"]
 
-        self._start_next_machines(
-            num_of_machines_to_start=min(
-                current_available_machines, running_machines_gap
-            )
-        )
+        self._start_next_machines(num_of_machines_to_start=min(current_available_machines, running_machines_gap))
         #  if no sufficient machines left  -> launch a new machines
-        while (
-            autoscale_options["autoscale"]
-            and current_available_machines < running_machines_gap
-        ):
+        while autoscale_options["autoscale"] and current_available_machines < running_machines_gap:
             if self.dynamic_machines_count >= dynamic_machines_limit:
-                log.debug(
-                    "Reached dynamic machines limit - %d machines"
-                    % dynamic_machines_limit
-                )
+                log.debug("Reached dynamic machines limit - %d machines" % dynamic_machines_limit)
                 break
             if not self._allocate_new_machine():
                 break
@@ -353,9 +335,7 @@ class AWS(Machinery):
                 break
             except Exception as e:
                 attempts += 1
-                log.warning(
-                    "Failed while modifying new instance attribute. Trying again."
-                )
+                log.warning("Failed while modifying new instance attribute. Trying again.")
         log.debug("Created %s\n%s", new_instance.id, repr(response))
         return new_instance
 
@@ -383,14 +363,10 @@ class AWS(Machinery):
         instance = self.ec2_machines[label]
         state = self._status(label)
         if state != AWS.POWEROFF:
-            raise CuckooMachineError(
-                "Instance '%s' state '%s' is not poweroff" % (label, state)
-            )
+            raise CuckooMachineError("Instance '%s' state '%s' is not poweroff" % (label, state))
         volumes = list(instance.volumes.all())
         if len(volumes) != 1:
-            raise CuckooMachineError(
-                "Instance '%s' has wrong number of volumes %d" % (label, len(volumes))
-            )
+            raise CuckooMachineError("Instance '%s' has wrong number of volumes %d" % (label, len(volumes)))
         old_volume = volumes[0]
 
         log.debug("Detaching %s", old_volume.id)
@@ -404,10 +380,7 @@ class AWS(Machinery):
 
         log.debug("Old volume %s in state %s", old_volume.id, old_volume.state)
         if old_volume.state != "available":
-            raise CuckooMachineError(
-                "Old volume turned into state %s instead of 'available'"
-                % old_volume.state
-            )
+            raise CuckooMachineError("Old volume turned into state %s instead of 'available'" % old_volume.state)
         log.debug("Deleting old volume")
         volume_type = old_volume.volume_type
         old_volume.delete()
@@ -428,9 +401,7 @@ class AWS(Machinery):
         if new_volume.state != "available":
             state = new_volume.state
             new_volume.delete()
-            raise CuckooMachineError(
-                "New volume turned into state %s instead of 'available'" % state
-            )
+            raise CuckooMachineError("New volume turned into state %s instead of 'available'" % state)
 
         log.debug("Attaching new volume")
         resp = instance.attach_volume(VolumeId=new_volume.id, Device="/dev/sda1")
@@ -443,6 +414,4 @@ class AWS(Machinery):
         log.debug("new volume %s in state %s", new_volume.id, new_volume.state)
         if new_volume.state != "in-use":
             new_volume.delete()
-            raise CuckooMachineError(
-                "New volume turned into state %s instead of 'in-use'" % old_volume.state
-            )
+            raise CuckooMachineError("New volume turned into state %s instead of 'in-use'" % old_volume.state)

--- a/modules/machinery/aws.py
+++ b/modules/machinery/aws.py
@@ -3,10 +3,11 @@ import logging
 import time
 
 import boto3
+from sqlalchemy.exc import SQLAlchemyError
+
 from lib.cuckoo.common.abstracts import Machinery
 from lib.cuckoo.common.config import Config
 from lib.cuckoo.common.exceptions import CuckooCriticalError, CuckooMachineError
-from sqlalchemy.exc import SQLAlchemyError
 
 logging.getLogger("boto3").setLevel(logging.CRITICAL)
 logging.getLogger("botocore").setLevel(logging.CRITICAL)

--- a/web/submission/views.py
+++ b/web/submission/views.py
@@ -562,13 +562,13 @@ def index(request, resubmit_hash=False):
             machinery = cfg.cuckoo.get("machinery")
             if machinery == "multi":
                 for mmachinery in Config(machinery).multi.get("machinery").split(","):
-                    vms = [x.strip() for x in getattr(Config(mmachinery), mmachinery).get("machines").split(",")]
+                    vms = [x.strip() for x in getattr(Config(mmachinery), mmachinery).get("machines").split(",") if x.strip()]
                     if any(["tags" in list(getattr(Config(mmachinery), vmtag).keys()) for vmtag in vms]):
                         enabledconf["tags"] = True
                         break
             else:
                 # Get VM names for machinery config elements
-                vms = [x.strip() for x in getattr(Config(machinery), machinery).get("machines").split(",")]
+                vms = [x.strip() for x in getattr(Config(machinery), machinery).get("machines").split(",") if x.strip()]
                 # Check each VM config element for tags
                 if any(["tags" in list(getattr(Config(machinery), vmtag).keys()) for vmtag in vms]):
                     enabledconf["tags"] = True


### PR DESCRIPTION
- Addresses some issues parsing blanked out values in the `aws.conf` file.
- Addresses intermittent errors with aws machinery where newly provisioned EC2 instances would occasionally raise ResourceNotFound errors when attempting to pull information about the instance.