### PR TITLE
Fix condition for adding tasks for extracted files.

### DIFF
--- a/lib/cuckoo/core/database.py
+++ b/lib/cuckoo/core/database.py
@@ -1545,7 +1545,7 @@ class Database(object, metaclass=Singleton):
                     task_ids.append(config["id"])
                 else:
                     config = static_extraction(file)
-                if config or static_extraction:
+                if config or only_extraction:
                     task_ids += self.add_static(
                         file_path=file, priority=priority, tlp=tlp, user_id=user_id, username=username, options=options
                     )


### PR DESCRIPTION
Note that I'm not totally positive that this should be `only_extraction`, but I am pretty sure it's not supposed to be `static_extraction` because, since that's a function, it will always be truthy.