### PR TITLE
refactor: remove __future__ imports

### DIFF
--- a/agent/agent.py
+++ b/agent/agent.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import, print_function
 import argparse
 import cgi
 import http.server

--- a/analyzer/linux/analyzer.py
+++ b/analyzer/linux/analyzer.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import datetime
 import logging
 import os

--- a/analyzer/linux/lib/api/process.py
+++ b/analyzer/linux/lib/api/process.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import logging
 import os
 import subprocess

--- a/analyzer/linux/lib/api/screenshot.py
+++ b/analyzer/linux/lib/api/screenshot.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import logging
 import math
 

--- a/analyzer/linux/lib/common/abstracts.py
+++ b/analyzer/linux/lib/common/abstracts.py
@@ -2,8 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
-
 from lib.api.process import Process
 from lib.common.exceptions import CuckooPackageError
 

--- a/analyzer/linux/lib/common/apicalls.py
+++ b/analyzer/linux/lib/common/apicalls.py
@@ -3,7 +3,6 @@
 # This software may be modified and distributed under the terms
 # of the MIT license. See the LICENSE file for details.
 
-from __future__ import absolute_import
 import logging
 import os
 

--- a/analyzer/linux/lib/common/constants.py
+++ b/analyzer/linux/lib/common/constants.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import os
 import tempfile
 

--- a/analyzer/linux/lib/common/exceptions.py
+++ b/analyzer/linux/lib/common/exceptions.py
@@ -2,6 +2,7 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
+
 class CuckooError(Exception):
     pass
 

--- a/analyzer/linux/lib/common/exceptions.py
+++ b/analyzer/linux/lib/common/exceptions.py
@@ -2,9 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
-
-
 class CuckooError(Exception):
     pass
 

--- a/analyzer/linux/lib/common/hashing.py
+++ b/analyzer/linux/lib/common/hashing.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import hashlib
 
 BUFSIZE = 1024 * 1024

--- a/analyzer/linux/lib/common/rand.py
+++ b/analyzer/linux/lib/common/rand.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import random
 import string
 

--- a/analyzer/linux/lib/common/results.py
+++ b/analyzer/linux/lib/common/results.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import logging
 import os
 import socket

--- a/analyzer/linux/lib/core/config.py
+++ b/analyzer/linux/lib/core/config.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import configparser
 
 

--- a/analyzer/linux/lib/core/packages.py
+++ b/analyzer/linux/lib/core/packages.py
@@ -3,7 +3,6 @@
 # This software may be modified and distributed under the terms
 # of the MIT license. See the LICENSE file for details.
 
-from __future__ import absolute_import
 import inspect
 import logging
 import subprocess

--- a/analyzer/linux/lib/core/startup.py
+++ b/analyzer/linux/lib/core/startup.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import logging
 import os
 

--- a/analyzer/linux/modules/auxiliary/screenshots.py
+++ b/analyzer/linux/modules/auxiliary/screenshots.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import logging
 import time
 from io import BytesIO

--- a/analyzer/linux/modules/auxiliary/stap.py
+++ b/analyzer/linux/modules/auxiliary/stap.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import logging
 import os
 import subprocess

--- a/analyzer/windows/analyzer.py
+++ b/analyzer/windows/analyzer.py
@@ -4,7 +4,6 @@
 # TODO
 #  https://github.com/cuckoosandbox/cuckoo/blob/ad5bf8939fb4b86d03c4d96014b174b8b56885e3/cuckoo/core/plugins.py#L29
 
-from __future__ import absolute_import
 import hashlib
 import logging
 import os

--- a/analyzer/windows/lib/api/process.py
+++ b/analyzer/windows/lib/api/process.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import base64
 import contextlib
 import logging

--- a/analyzer/windows/lib/api/screenshot.py
+++ b/analyzer/windows/lib/api/screenshot.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import logging
 import math
 

--- a/analyzer/windows/lib/api/utils.py
+++ b/analyzer/windows/lib/api/utils.py
@@ -12,7 +12,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import absolute_import
 import logging
 import socket
 import subprocess

--- a/analyzer/windows/lib/common/abstracts.py
+++ b/analyzer/windows/lib/common/abstracts.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import glob
 import logging
 import os

--- a/analyzer/windows/lib/common/common.py
+++ b/analyzer/windows/lib/common/common.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import logging
 import os
 

--- a/analyzer/windows/lib/common/constants.py
+++ b/analyzer/windows/lib/common/constants.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import os
 
 from lib.common.rand import random_string

--- a/analyzer/windows/lib/common/defines.py
+++ b/analyzer/windows/lib/common/defines.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 from ctypes import (
     POINTER,
     WINFUNCTYPE,

--- a/analyzer/windows/lib/common/rand.py
+++ b/analyzer/windows/lib/common/rand.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import random
 import string
 

--- a/analyzer/windows/lib/common/results.py
+++ b/analyzer/windows/lib/common/results.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import logging
 import os
 import socket

--- a/analyzer/windows/lib/core/config.py
+++ b/analyzer/windows/lib/core/config.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import configparser
 
 

--- a/analyzer/windows/lib/core/log.py
+++ b/analyzer/windows/lib/core/log.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import logging
 import socket
 import traceback

--- a/analyzer/windows/lib/core/privileges.py
+++ b/analyzer/windows/lib/core/privileges.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 from ctypes import POINTER, wintypes
 
 from lib.common.defines import (

--- a/analyzer/windows/lib/core/startup.py
+++ b/analyzer/windows/lib/core/startup.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import contextlib
 import ctypes
 import logging

--- a/analyzer/windows/modules/auxiliary/browser.py
+++ b/analyzer/windows/modules/auxiliary/browser.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import logging
 import os
 import time

--- a/analyzer/windows/modules/auxiliary/curtain.py
+++ b/analyzer/windows/modules/auxiliary/curtain.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import logging
 import os
 import subprocess

--- a/analyzer/windows/modules/auxiliary/digisig.py
+++ b/analyzer/windows/modules/auxiliary/digisig.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import json
 import locale
 import logging

--- a/analyzer/windows/modules/auxiliary/disguise.py
+++ b/analyzer/windows/modules/auxiliary/disguise.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import io
 import itertools
 import logging

--- a/analyzer/windows/modules/auxiliary/evtx.py
+++ b/analyzer/windows/modules/auxiliary/evtx.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import itertools
 import logging
 import os

--- a/analyzer/windows/modules/auxiliary/human.py
+++ b/analyzer/windows/modules/auxiliary/human.py
@@ -3,7 +3,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import contextlib
 import logging
 import random

--- a/analyzer/windows/modules/auxiliary/screenshots.py
+++ b/analyzer/windows/modules/auxiliary/screenshots.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import logging
 import time
 from io import BytesIO

--- a/analyzer/windows/modules/auxiliary/usage.py
+++ b/analyzer/windows/modules/auxiliary/usage.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import logging
 import time
 from ctypes import byref, create_string_buffer, sizeof

--- a/analyzer/windows/modules/packages/Shellcode-Unpacker.py
+++ b/analyzer/windows/modules/packages/Shellcode-Unpacker.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import logging
 import os
 import shutil

--- a/analyzer/windows/modules/packages/Shellcode.py
+++ b/analyzer/windows/modules/packages/Shellcode.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import os
 import shutil
 

--- a/analyzer/windows/modules/packages/Shellcode_x64.py
+++ b/analyzer/windows/modules/packages/Shellcode_x64.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import os
 import shutil
 

--- a/analyzer/windows/modules/packages/UPX.py
+++ b/analyzer/windows/modules/packages/UPX.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import os
 import shutil
 

--- a/analyzer/windows/modules/packages/UPX_dll.py
+++ b/analyzer/windows/modules/packages/UPX_dll.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import os
 import shutil
 

--- a/analyzer/windows/modules/packages/Unpacker_dll.py
+++ b/analyzer/windows/modules/packages/Unpacker_dll.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import os
 import shutil
 

--- a/analyzer/windows/modules/packages/Unpacker_js.py
+++ b/analyzer/windows/modules/packages/Unpacker_js.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import os
 
 from lib.common.abstracts import Package

--- a/analyzer/windows/modules/packages/Unpacker_zip.py
+++ b/analyzer/windows/modules/packages/Unpacker_zip.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import logging
 import os
 import shutil

--- a/analyzer/windows/modules/packages/applet.py
+++ b/analyzer/windows/modules/packages/applet.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import tempfile
 
 from lib.common.abstracts import Package

--- a/analyzer/windows/modules/packages/dll.py
+++ b/analyzer/windows/modules/packages/dll.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import contextlib
 import os
 import shutil

--- a/analyzer/windows/modules/packages/exe.py
+++ b/analyzer/windows/modules/packages/exe.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import os
 import shutil
 from subprocess import call

--- a/analyzer/windows/modules/packages/html.py
+++ b/analyzer/windows/modules/packages/html.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import logging
 import shutil
 

--- a/analyzer/windows/modules/packages/js.py
+++ b/analyzer/windows/modules/packages/js.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import os
 
 from lib.common.abstracts import Package

--- a/analyzer/windows/modules/packages/js_antivm.py
+++ b/analyzer/windows/modules/packages/js_antivm.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import os
 
 from lib.common.abstracts import Package

--- a/analyzer/windows/modules/packages/processes.py
+++ b/analyzer/windows/modules/packages/processes.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import os
 import time
 

--- a/analyzer/windows/modules/packages/processes_simple.py
+++ b/analyzer/windows/modules/packages/processes_simple.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import os
 import time
 

--- a/analyzer/windows/modules/packages/pub.py
+++ b/analyzer/windows/modules/packages/pub.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 from winreg import HKEY_CURRENT_USER, KEY_READ, KEY_SET_VALUE, REG_DWORD, CreateKeyEx, EnumKey, OpenKey, QueryInfoKey, SetValueEx
 
 from lib.common.abstracts import Package

--- a/analyzer/windows/modules/packages/pub2016.py
+++ b/analyzer/windows/modules/packages/pub2016.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 from winreg import HKEY_CURRENT_USER, KEY_READ, KEY_SET_VALUE, REG_DWORD, CreateKeyEx, EnumKey, OpenKey, QueryInfoKey, SetValueEx
 
 from lib.common.abstracts import Package

--- a/analyzer/windows/modules/packages/rar.py
+++ b/analyzer/windows/modules/packages/rar.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import logging
 import os
 import re

--- a/analyzer/windows/modules/packages/service.py
+++ b/analyzer/windows/modules/packages/service.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import ctypes
 import logging
 import sys

--- a/analyzer/windows/modules/packages/vawtrak.py
+++ b/analyzer/windows/modules/packages/vawtrak.py
@@ -1,6 +1,5 @@
 # Andriy :P
 
-from __future__ import absolute_import
 import os
 import shutil
 from subprocess import call

--- a/analyzer/windows/modules/packages/vbejse.py
+++ b/analyzer/windows/modules/packages/vbejse.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 from shutil import copyfile
 
 from lib.common.abstracts import Package

--- a/analyzer/windows/modules/packages/vbs.py
+++ b/analyzer/windows/modules/packages/vbs.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import os
 
 from lib.common.abstracts import Package

--- a/analyzer/windows/modules/packages/zip.py
+++ b/analyzer/windows/modules/packages/zip.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import logging
 import os
 import shutil

--- a/cuckoo.py
+++ b/cuckoo.py
@@ -3,7 +3,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import argparse
 import logging
 import os

--- a/docs/book/src/conf.py
+++ b/docs/book/src/conf.py
@@ -10,7 +10,6 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-from __future__ import absolute_import
 import os
 import sys
 

--- a/lib/cuckoo/common/abstracts.py
+++ b/lib/cuckoo/common/abstracts.py
@@ -3,7 +3,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import, print_function
 import datetime
 import logging
 import os

--- a/lib/cuckoo/common/cape_utils.py
+++ b/lib/cuckoo/common/cape_utils.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import hashlib
 import logging
 import os

--- a/lib/cuckoo/common/colors.py
+++ b/lib/cuckoo/common/colors.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import os
 import sys
 

--- a/lib/cuckoo/common/compare.py
+++ b/lib/cuckoo/common/compare.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import contextlib
 import json
 import zlib

--- a/lib/cuckoo/common/config.py
+++ b/lib/cuckoo/common/config.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import configparser
 import glob
 import os

--- a/lib/cuckoo/common/constants.py
+++ b/lib/cuckoo/common/constants.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import os
 
 _current_dir = os.path.abspath(os.path.dirname(__file__))

--- a/lib/cuckoo/common/demux.py
+++ b/lib/cuckoo/common/demux.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import, print_function
 import logging
 import os
 import sys

--- a/lib/cuckoo/common/dist_db.py
+++ b/lib/cuckoo/common/dist_db.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import sys
 from datetime import datetime
 

--- a/lib/cuckoo/common/dns.py
+++ b/lib/cuckoo/common/dns.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import select
 import socket
 import threading

--- a/lib/cuckoo/common/email_utils.py
+++ b/lib/cuckoo/common/email_utils.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import email
 import mimetypes
 from email.header import decode_header, make_header

--- a/lib/cuckoo/common/files.py
+++ b/lib/cuckoo/common/files.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import errno
 import hashlib
 import logging

--- a/lib/cuckoo/common/icon.py
+++ b/lib/cuckoo/common/icon.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 from ctypes import POINTER, Structure, byref
 from ctypes import c_ubyte as BYTE
 from ctypes import c_uint as DWORD

--- a/lib/cuckoo/common/integrations/XLMMacroDeobfuscator.py
+++ b/lib/cuckoo/common/integrations/XLMMacroDeobfuscator.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import logging
 import os
 

--- a/lib/cuckoo/common/integrations/capa.py
+++ b/lib/cuckoo/common/integrations/capa.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import collections
 import logging
 import os

--- a/lib/cuckoo/common/integrations/vba2graph.py
+++ b/lib/cuckoo/common/integrations/vba2graph.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import logging
 import os
 

--- a/lib/cuckoo/common/integrations/vbadeobf.py
+++ b/lib/cuckoo/common/integrations/vbadeobf.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import binascii
 import contextlib
 import string

--- a/lib/cuckoo/common/irc.py
+++ b/lib/cuckoo/common/irc.py
@@ -5,7 +5,6 @@
 
 """IRC Protocol"""
 
-from __future__ import absolute_import
 import logging
 from io import BytesIO
 

--- a/lib/cuckoo/common/logo.py
+++ b/lib/cuckoo/common/logo.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import, print_function
 import random
 import sys
 

--- a/lib/cuckoo/common/misc.py
+++ b/lib/cuckoo/common/misc.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import os
 
 from lib.cuckoo.common.constants import CUCKOO_ROOT

--- a/lib/cuckoo/common/netlog.py
+++ b/lib/cuckoo/common/netlog.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import datetime
 import logging
 import struct

--- a/lib/cuckoo/common/objects.py
+++ b/lib/cuckoo/common/objects.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import binascii
 import contextlib
 import copy

--- a/lib/cuckoo/common/pdftools/pdf-parser.py
+++ b/lib/cuckoo/common/pdftools/pdf-parser.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python
-from __future__ import absolute_import, print_function
-
 __description__ = "pdf-parser, use it to parse a PDF document"
 __author__ = "Didier Stevens"
 __version__ = "0.7.5"

--- a/lib/cuckoo/common/pdftools/pdfid.py
+++ b/lib/cuckoo/common/pdftools/pdfid.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python
-from __future__ import absolute_import, print_function
-
 __description__ = "Tool to test a PDF file"
 __author__ = "Didier Stevens"
 __version__ = "0.2.7"

--- a/lib/cuckoo/common/quarantine.py
+++ b/lib/cuckoo/common/quarantine.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import, print_function
 import contextlib
 import hashlib
 import logging

--- a/lib/cuckoo/common/saztopcap.py
+++ b/lib/cuckoo/common/saztopcap.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import glob
 import logging
 import os

--- a/lib/cuckoo/common/url_validate.py
+++ b/lib/cuckoo/common/url_validate.py
@@ -3,7 +3,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import re
 
 # this is with some fixes https://github.com/kvesteri/validators/blob/master/validators/url.py

--- a/lib/cuckoo/common/utils.py
+++ b/lib/cuckoo/common/utils.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import contextlib
 import errno
 import fcntl

--- a/lib/cuckoo/common/utils_pretty_print_funcs.py
+++ b/lib/cuckoo/common/utils_pretty_print_funcs.py
@@ -2,8 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
-
 import lib.cuckoo.common.utils_dicts as utils_dicts
 
 

--- a/lib/cuckoo/common/web_utils.py
+++ b/lib/cuckoo/common/web_utils.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, print_function
 import hashlib
 import json
 import logging

--- a/lib/cuckoo/core/database.py
+++ b/lib/cuckoo/core/database.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import json
 import logging
 import os

--- a/lib/cuckoo/core/guest.py
+++ b/lib/cuckoo/core/guest.py
@@ -3,7 +3,6 @@
 # See the file 'docs/LICENSE' for copying permission.
 # https://github.com/cuckoosandbox/cuckoo/blob/master/cuckoo/core/guest.py
 
-from __future__ import absolute_import
 import datetime
 import json
 import logging

--- a/lib/cuckoo/core/plugins.py
+++ b/lib/cuckoo/core/plugins.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import inspect
 import json
 import logging

--- a/lib/cuckoo/core/resultserver.py
+++ b/lib/cuckoo/core/resultserver.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import, print_function
 import errno
 import json
 import logging

--- a/lib/cuckoo/core/rooter.py
+++ b/lib/cuckoo/core/rooter.py
@@ -3,7 +3,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import json
 import logging
 import os.path

--- a/lib/cuckoo/core/scheduler.py
+++ b/lib/cuckoo/core/scheduler.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import logging
 import os
 import queue

--- a/lib/cuckoo/core/startup.py
+++ b/lib/cuckoo/core/startup.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import, print_function
 import copy
 import logging
 import logging.handlers

--- a/modules/auxiliary/sniffer.py
+++ b/modules/auxiliary/sniffer.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import getpass
 import logging
 import os

--- a/modules/machinery/aws.py
+++ b/modules/machinery/aws.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import logging
 import time
 

--- a/modules/machinery/esx.py
+++ b/modules/machinery/esx.py
@@ -3,8 +3,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
-
 import libvirt
 
 from lib.cuckoo.common.abstracts import LibVirtMachinery

--- a/modules/machinery/kvm.py
+++ b/modules/machinery/kvm.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import xml.etree.ElementTree as ET
 
 from lib.cuckoo.common.abstracts import LibVirtMachinery

--- a/modules/machinery/multi.py
+++ b/modules/machinery/multi.py
@@ -8,7 +8,6 @@
 Pseudo-machinery for using multiple machinery.
 """
 
-from __future__ import absolute_import
 import inspect
 import types
 

--- a/modules/machinery/proxmox.py
+++ b/modules/machinery/proxmox.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import logging
 import sys
 import time

--- a/modules/machinery/qemu.py
+++ b/modules/machinery/qemu.py
@@ -4,7 +4,6 @@
 
 # https://qemu.readthedocs.io/en/latest/
 
-from __future__ import absolute_import
 import logging
 import os
 import os.path

--- a/modules/machinery/virtualbox.py
+++ b/modules/machinery/virtualbox.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import logging
 import os
 import os.path

--- a/modules/machinery/vmware.py
+++ b/modules/machinery/vmware.py
@@ -3,7 +3,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import glob
 import logging
 import os.path

--- a/modules/machinery/vmwareserver.py
+++ b/modules/machinery/vmwareserver.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import logging
 import os.path
 import subprocess

--- a/modules/machinery/vsphere.py
+++ b/modules/machinery/vsphere.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import logging
 import random
 import re

--- a/modules/machinery/xenserver.py
+++ b/modules/machinery/xenserver.py
@@ -6,7 +6,6 @@
 XenServer machinery.
 """
 
-from __future__ import absolute_import
 import logging
 import threading
 

--- a/modules/processing/CAPE.py
+++ b/modules/processing/CAPE.py
@@ -12,7 +12,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import absolute_import
 import hashlib
 import imp
 import json

--- a/modules/processing/analysisinfo.py
+++ b/modules/processing/analysisinfo.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import codecs
 import logging
 import os

--- a/modules/processing/antiransomware.py
+++ b/modules/processing/antiransomware.py
@@ -12,7 +12,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import absolute_import
 import json
 import logging
 import os

--- a/modules/processing/behavior.py
+++ b/modules/processing/behavior.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import datetime
 import logging
 import os

--- a/modules/processing/curtain.py
+++ b/modules/processing/curtain.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import ast
 import base64
 import itertools

--- a/modules/processing/debug.py
+++ b/modules/processing/debug.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import codecs
 import os
 

--- a/modules/processing/decompression.py
+++ b/modules/processing/decompression.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import glob
 import os
 import zipfile

--- a/modules/processing/deduplication.py
+++ b/modules/processing/deduplication.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import logging
 import os
 

--- a/modules/processing/dropped.py
+++ b/modules/processing/dropped.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import json
 import os
 

--- a/modules/processing/maliciousmacrobot.py
+++ b/modules/processing/maliciousmacrobot.py
@@ -12,7 +12,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import absolute_import
 import logging
 import os
 

--- a/modules/processing/memory.py
+++ b/modules/processing/memory.py
@@ -7,7 +7,6 @@
 
 # Vol3 docs - https://volatility3.readthedocs.io/en/latest/index.html
 
-from __future__ import absolute_import
 import logging
 import os
 from typing import Any, Dict, List, Optional, Tuple, Union

--- a/modules/processing/network.py
+++ b/modules/processing/network.py
@@ -6,7 +6,6 @@
 # http://stackoverflow.com/questions/10665925/how-to-sort-huge-files-with-python
 # http://code.activestate.com/recipes/576755/
 
-from __future__ import absolute_import
 import binascii
 import heapq
 import logging

--- a/modules/processing/parsers/CAPE/BackOffLoader.py
+++ b/modules/processing/parsers/CAPE/BackOffLoader.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, print_function
 from binascii import hexlify
 from hashlib import md5
 from struct import unpack_from

--- a/modules/processing/parsers/CAPE/BackOffPOS.py
+++ b/modules/processing/parsers/CAPE/BackOffPOS.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, print_function
 from binascii import hexlify
 from hashlib import md5
 from struct import unpack_from

--- a/modules/processing/parsers/CAPE/CobaltStrikeBeacon.py
+++ b/modules/processing/parsers/CAPE/CobaltStrikeBeacon.py
@@ -9,7 +9,6 @@ TODO:
     2. Dynamic size parsing
 """
 
-from __future__ import absolute_import, print_function
 import argparse
 import io
 import json

--- a/modules/processing/parsers/CAPE/Greame.py
+++ b/modules/processing/parsers/CAPE/Greame.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import string
 
 import pefile

--- a/modules/processing/parsers/CAPE/JavaDropper.py_disabled
+++ b/modules/processing/parsers/CAPE/JavaDropper.py_disabled
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-from __future__ import absolute_import, print_function
 import hashlib
 import string
 import zlib

--- a/modules/processing/parsers/CAPE/Nymaim.py_disabled
+++ b/modules/processing/parsers/CAPE/Nymaim.py_disabled
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, print_function
 import re
 import string
 import struct

--- a/modules/processing/parsers/CAPE/Pandora.py
+++ b/modules/processing/parsers/CAPE/Pandora.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import pefile
 
 

--- a/modules/processing/parsers/CAPE/PoisonIvy.py
+++ b/modules/processing/parsers/CAPE/PoisonIvy.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import string
 from struct import unpack
 

--- a/modules/processing/parsers/CAPE/PredatorPain.py_disabled
+++ b/modules/processing/parsers/CAPE/PredatorPain.py_disabled
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, print_function
 from base64 import b64decode
 from binascii import unhexlify
 

--- a/modules/processing/parsers/CAPE/REvil.py
+++ b/modules/processing/parsers/CAPE/REvil.py
@@ -14,7 +14,6 @@
 
 #!/usr/bin/python
 
-from __future__ import absolute_import
 import json
 import struct
 

--- a/modules/processing/parsers/CAPE/Strrat.py
+++ b/modules/processing/parsers/CAPE/Strrat.py
@@ -20,7 +20,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from __future__ import absolute_import, print_function
 import base64
 import zipfile
 from hashlib import pbkdf2_hmac

--- a/modules/processing/parsers/CAPE/TSCookie.py
+++ b/modules/processing/parsers/CAPE/TSCookie.py
@@ -5,7 +5,6 @@
 #
 # Credit to JPCERT - this is derived from https://github.com/JPCERTCC/aa-tools/blob/master/tscookie_decode.py
 
-from __future__ import absolute_import
 import collections
 import re
 import sys

--- a/modules/processing/parsers/CAPE/TrickBot.py
+++ b/modules/processing/parsers/CAPE/TrickBot.py
@@ -21,7 +21,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from __future__ import absolute_import
 import hashlib
 import struct
 import xml.etree.ElementTree as ET

--- a/modules/processing/parsers/CAPE/UrsnifV3.py
+++ b/modules/processing/parsers/CAPE/UrsnifV3.py
@@ -12,7 +12,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import absolute_import
 import binascii
 import struct
 

--- a/modules/processing/parsers/CAPE/_ShadowTech.py_disabled
+++ b/modules/processing/parsers/CAPE/_ShadowTech.py_disabled
@@ -3,7 +3,6 @@
 ShadowTech Config Extractor
 """
 
-from __future__ import absolute_import, print_function
 import re
 import string
 

--- a/modules/processing/parsers/CAPE/_VirusRat.py_disabled
+++ b/modules/processing/parsers/CAPE/_VirusRat.py_disabled
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import re
 
 import database

--- a/modules/processing/parsers/CAPE/_jRat.py_disabled
+++ b/modules/processing/parsers/CAPE/_jRat.py_disabled
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, print_function
 import re
 from base64 import b64decode
 from io import StringIO

--- a/modules/processing/parsers/CAPE/test_cape.py
+++ b/modules/processing/parsers/CAPE/test_cape.py
@@ -1,5 +1,2 @@
-from __future__ import absolute_import
-
-
 def extract_config():
     pass

--- a/modules/processing/parsers/CAPE/unrecom.py
+++ b/modules/processing/parsers/CAPE/unrecom.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import string
 import xml.etree.ElementTree as ET
 from io import StringIO

--- a/modules/processing/parsers/CAPE/xRAT.py_disabled
+++ b/modules/processing/parsers/CAPE/xRAT.py_disabled
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import hashlib
 import re
 from base64 import b64decode

--- a/modules/processing/parsers/mwcp/test_mwcp.py
+++ b/modules/processing/parsers/mwcp/test_mwcp.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from mwcp.parser import Parser
 
 

--- a/modules/processing/parsers/plugxconfig/plugx.py
+++ b/modules/processing/parsers/plugxconfig/plugx.py
@@ -22,7 +22,6 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 
-from __future__ import absolute_import
 import socket
 from collections import OrderedDict, defaultdict
 from socket import inet_ntoa

--- a/modules/processing/procdump.py
+++ b/modules/processing/procdump.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import json
 import os
 from datetime import datetime

--- a/modules/processing/procmemory.py
+++ b/modules/processing/procmemory.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import logging
 import os
 

--- a/modules/processing/strings.py
+++ b/modules/processing/strings.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import os.path
 
 from lib.cuckoo.common.abstracts import Processing

--- a/modules/processing/suricata.py
+++ b/modules/processing/suricata.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import datetime
 import json
 import logging

--- a/modules/processing/sysmon.py
+++ b/modules/processing/sysmon.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import logging
 import os
 import re

--- a/modules/processing/targetinfo.py
+++ b/modules/processing/targetinfo.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import os.path
 
 from lib.cuckoo.common.abstracts import Processing

--- a/modules/processing/usage.py
+++ b/modules/processing/usage.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import os
 
 from lib.cuckoo.common.abstracts import Processing

--- a/modules/reporting/bingraph.py
+++ b/modules/reporting/bingraph.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import logging
 import os
 

--- a/modules/reporting/callback.py
+++ b/modules/reporting/callback.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, print_function
 import json
 import logging
 

--- a/modules/reporting/compression.py
+++ b/modules/reporting/compression.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import os
 import zipfile
 

--- a/modules/reporting/compressresults.py
+++ b/modules/reporting/compressresults.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import json
 import logging
 import zlib

--- a/modules/reporting/jsondump.py
+++ b/modules/reporting/jsondump.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import os
 
 from lib.cuckoo.common.abstracts import Report

--- a/modules/reporting/litereport.py
+++ b/modules/reporting/litereport.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import os
 
 from lib.cuckoo.common.abstracts import Report

--- a/modules/reporting/maec41.py
+++ b/modules/reporting/maec41.py
@@ -5,7 +5,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file "docs/LICENSE" for copying permission.
 
-from __future__ import absolute_import
 import hashlib
 import os
 import re

--- a/modules/reporting/maec5.py
+++ b/modules/reporting/maec5.py
@@ -5,7 +5,6 @@
 # MAEC 5.0 Cuckoo Report Module
 # https://maecproject.github.io/releases/5.0/MAEC_Vocabularies_Specification.pdf
 
-from __future__ import absolute_import
 import io
 import json
 import logging

--- a/modules/reporting/mitre.py
+++ b/modules/reporting/mitre.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import logging
 
 from lib.cuckoo.common.abstracts import Report

--- a/modules/reporting/mongodb.py
+++ b/modules/reporting/mongodb.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import gc
 import logging
 

--- a/modules/reporting/reporthtml.py
+++ b/modules/reporting/reporthtml.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import base64
 import codecs
 import os

--- a/modules/reporting/reporthtmlsummary.py
+++ b/modules/reporting/reporthtmlsummary.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import base64
 import codecs
 import os

--- a/modules/reporting/reportpdf.py
+++ b/modules/reporting/reportpdf.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import logging
 import os
 from subprocess import call

--- a/modules/reporting/resubmitexe.py
+++ b/modules/reporting/resubmitexe.py
@@ -12,7 +12,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import absolute_import
 import datetime
 import logging
 import ntpath

--- a/modules/reporting/retention.py
+++ b/modules/reporting/retention.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import json
 import logging
 import os

--- a/modules/reporting/submitCAPE.py
+++ b/modules/reporting/submitCAPE.py
@@ -13,7 +13,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import absolute_import
 import logging
 import os
 

--- a/modules/reporting/syslog.py
+++ b/modules/reporting/syslog.py
@@ -14,7 +14,6 @@ logname = syslog.log  # if yes, what logname? [Default: syslog.txt]
 -KillerInstinct
 """
 
-from __future__ import absolute_import
 import os
 import socket
 

--- a/modules/reporting/tmpfsclean.py
+++ b/modules/reporting/tmpfsclean.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import logging
 import os
 import shutil

--- a/tests/email_test.py
+++ b/tests/email_test.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import, print_function
 import os
 import sys
 from datetime import datetime

--- a/tests/integrity.py
+++ b/tests/integrity.py
@@ -9,7 +9,6 @@ Checks the integrity of one or more virtual machine(s). In order to ensure
 that there are no remaining tasks in the queue this utility will clean the
 entire database before starting various analyses.
 """
-from __future__ import absolute_import, print_function
 import argparse
 import json
 import logging

--- a/tests/processor_tests.py
+++ b/tests/processor_tests.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import os
 import tempfile
 

--- a/tests/reporter_tests.py
+++ b/tests/reporter_tests.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import os
 import tempfile
 

--- a/tests/sniffer_tests.py
+++ b/tests/sniffer_tests.py
@@ -2,6 +2,4 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
-
 from nose.tools import assert_equals

--- a/tests/test_abstracts.py
+++ b/tests/test_abstracts.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import os
 import tempfile
 

--- a/tests/test_aplib.py
+++ b/tests/test_aplib.py
@@ -2,8 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
-
 from lib.cuckoo.common import aplib
 
 

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -2,8 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
-
 from modules.processing.behavior import ParseProcessLog
 
 

--- a/tests/test_colors.py
+++ b/tests/test_colors.py
@@ -2,8 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
-
 from lib.cuckoo.common.colors import black, blue, bold, color, cyan, green, magenta, red, white, yellow  # noqa: F401
 
 

--- a/tests/test_compressor.py
+++ b/tests/test_compressor.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import, print_function
 import os
 import pathlib
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import, print_function
 import configparser
 import textwrap
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import base64
 import os
 import shutil

--- a/tests/test_demux.py
+++ b/tests/test_demux.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import pathlib
 import tempfile
 

--- a/tests/test_dist_db.py
+++ b/tests/test_dist_db.py
@@ -2,8 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
-
 from sqlalchemy import Table
 
 from lib.cuckoo.common.dist_db import Machine, Node, StringList, Task, create_session

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -3,7 +3,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import, print_function
 import io
 import os
 import shutil

--- a/tests/test_icon.py
+++ b/tests/test_icon.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import pathlib
 
 import pytest

--- a/tests/test_logo.py
+++ b/tests/test_logo.py
@@ -2,8 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
-
 from lib.cuckoo.common import logo
 
 

--- a/tests/test_netlog.py
+++ b/tests/test_netlog.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import datetime
 import os
 import pathlib

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import, print_function
 import logging
 import os
 import pathlib

--- a/tests/test_quarantine.py
+++ b/tests/test_quarantine.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import pathlib
 import tempfile
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, print_function
 import os
 import pathlib
 import queue

--- a/tests/test_suricata_naming.py
+++ b/tests/test_suricata_naming.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, print_function
 import os
 import sys
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import, print_function
 import os
 
 import pytest

--- a/tests/test_utils_pretty_print_funcs.py
+++ b/tests/test_utils_pretty_print_funcs.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import, print_function
 import os
 import random
 

--- a/tests/test_web_utils.py
+++ b/tests/test_web_utils.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import, print_function
 import os
 import tempfile
 

--- a/utils/admin.py
+++ b/utils/admin.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, print_function
 import os
 import shutil
 import sys

--- a/utils/cleaners.py
+++ b/utils/cleaners.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import, print_function
 import argparse
 import atexit
 import logging

--- a/utils/cuckoomx.py
+++ b/utils/cuckoomx.py
@@ -1,5 +1,4 @@
 #!/bin/python
-from __future__ import absolute_import, print_function
 import email
 import hashlib
 import imaplib

--- a/utils/db_migration/env.py
+++ b/utils/db_migration/env.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import, with_statement
 import os.path
 import sys
 from logging.config import fileConfig

--- a/utils/db_migration/versions/add_distributed.py
+++ b/utils/db_migration/versions/add_distributed.py
@@ -15,8 +15,6 @@ Create Date: 2019-09-24 10:18:40.007575
 """
 
 # revision identifiers, used by Alembic.
-from __future__ import absolute_import
-
 revision = "e4954d358c80"
 down_revision = "36926b59dfbb"
 

--- a/utils/db_migration/versions/add_sample_parent_id.py
+++ b/utils/db_migration/versions/add_sample_parent_id.py
@@ -13,8 +13,6 @@ Create Date: 2019-05-03 08:14:52.075368
 """
 
 # revision identifiers, used by Alembic.
-from __future__ import absolute_import, print_function
-
 revision = "36926b59dfbb"
 down_revision = "3c8bf4133b44"
 

--- a/utils/db_migration/versions/add_shrike_and_parent_id_columns.py
+++ b/utils/db_migration/versions/add_shrike_and_parent_id_columns.py
@@ -10,8 +10,6 @@ Create Date: 2015-03-29 08:43:11.468664
 
 """
 # revision identifiers, used by Alembic.
-from __future__ import absolute_import, print_function
-
 revision = "f111620bb8"
 down_revision = "4b09c454108c"
 

--- a/utils/db_migration/versions/add_task_tlp.py
+++ b/utils/db_migration/versions/add_task_tlp.py
@@ -9,8 +9,6 @@ Revises: 30d0230de7cd
 Create Date: 2020-04-10 12:17:18.530901
 
 """
-from __future__ import absolute_import, print_function
-
 # revision identifiers, used by Alembic.
 revision = "7331c4d994fd"
 down_revision = "30d0230de7cd"

--- a/utils/db_migration/versions/from_0_6_to_1_1.py
+++ b/utils/db_migration/versions/from_0_6_to_1_1.py
@@ -11,8 +11,6 @@ Create Date: 2014-03-23 23:30:36.756792
 """
 
 # Revision identifiers, used by Alembic.
-from __future__ import absolute_import, print_function
-
 revision = "263a45963c72"
 mongo_revision = "1"
 down_revision = None

--- a/utils/db_migration/versions/from_1_1_to_1_2-added_states.py
+++ b/utils/db_migration/versions/from_1_1_to_1_2-added_states.py
@@ -11,8 +11,6 @@ Create Date: 2015-02-28 19:08:29.284111
 # Spaghetti as a way of life.
 
 # Revision identifiers, used by Alembic.
-from __future__ import absolute_import, print_function
-
 revision = "495d5a6edef3"
 down_revision = "18eee46c6f81"
 

--- a/utils/db_migration/versions/from_1_1_to_1_2-extend_file_type.py
+++ b/utils/db_migration/versions/from_1_1_to_1_2-extend_file_type.py
@@ -12,8 +12,6 @@ Create Date: 2014-08-21 12:41:30.863956
 """
 
 # Revision identifiers, used by Alembic.
-from __future__ import absolute_import
-
 revision = "18eee46c6f81"
 down_revision = "263a45963c72"
 

--- a/utils/db_migration/versions/from_1_2_to_1_2-accuvant-add_statistics.py
+++ b/utils/db_migration/versions/from_1_2_to_1_2-accuvant-add_statistics.py
@@ -11,8 +11,6 @@ Create Date: 2015-03-05 07:39:21.036983
 """
 
 # revision identifiers, used by Alembic.
-from __future__ import absolute_import, print_function
-
 revision = "4b09c454108c"
 down_revision = "495d5a6edef3"
 

--- a/utils/db_migration/versions/proper_indexes.py
+++ b/utils/db_migration/versions/proper_indexes.py
@@ -11,7 +11,6 @@ Create Date: 2016-05-13 11:04:41.685468
 """
 
 # revision identifiers, used by Alembic.
-from __future__ import absolute_import, print_function
 import sys
 
 revision = "3c8bf4133b44"

--- a/utils/db_migration_dist/env.py
+++ b/utils/db_migration_dist/env.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import, with_statement
 import os
 import sys
 from logging.config import fileConfig

--- a/utils/dist.py
+++ b/utils/dist.py
@@ -5,7 +5,6 @@
 # See the file 'docs/LICENSE' for copying permission.
 # ToDo
 # https://github.com/cuckoosandbox/cuckoo/pull/1694/files
-from __future__ import absolute_import, print_function
 import argparse
 import distutils.util
 import hashlib

--- a/utils/email_test.py
+++ b/utils/email_test.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, print_function
 import logging
 import os
 import smtplib

--- a/utils/listdump.py
+++ b/utils/listdump.py
@@ -3,7 +3,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import, print_function
 import os
 import struct
 import sys

--- a/utils/machine.py
+++ b/utils/machine.py
@@ -3,7 +3,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import argparse
 import logging
 import os.path

--- a/utils/process.py
+++ b/utils/process.py
@@ -2,7 +2,6 @@
 # Copyright (C) 2010-2015 Cuckoo Foundation.
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
-from __future__ import absolute_import
 import argparse
 import gc
 import json

--- a/utils/rooter.py
+++ b/utils/rooter.py
@@ -3,7 +3,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import argparse
 import errno
 import grp

--- a/utils/sample_path.py
+++ b/utils/sample_path.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, print_function
 import os
 import sys
 

--- a/utils/smtp_sinkhole.py
+++ b/utils/smtp_sinkhole.py
@@ -3,7 +3,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import argparse
 import asyncore
 import logging

--- a/utils/submit.py
+++ b/utils/submit.py
@@ -3,7 +3,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import, print_function
 import argparse
 import fnmatch
 import logging

--- a/utils/tcpdumpwrapper.py
+++ b/utils/tcpdumpwrapper.py
@@ -4,7 +4,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import os
 import sys
 import time

--- a/utils/test_suricata_signature.py
+++ b/utils/test_suricata_signature.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import, print_function
 import os
 import sys
 

--- a/utils/tridupdate.py
+++ b/utils/tridupdate.py
@@ -13,7 +13,6 @@
 # --------------------------------------------------------------------------
 
 
-from __future__ import print_function
 import argparse
 import hashlib
 import os

--- a/utils/vpncheck.py
+++ b/utils/vpncheck.py
@@ -3,7 +3,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import, print_function
 import argparse
 import fcntl
 import os

--- a/utils/yara_test.py
+++ b/utils/yara_test.py
@@ -3,7 +3,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import, print_function
 import logging
 import os
 import sys

--- a/web/analysis/forms.py
+++ b/web/analysis/forms.py
@@ -2,8 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
-
 from django import forms
 from submission.models import Comment, Tag
 

--- a/web/analysis/templatetags/analysis_tags.py
+++ b/web/analysis/templatetags/analysis_tags.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import os
 from io import StringIO
 

--- a/web/analysis/templatetags/generic_tags.py
+++ b/web/analysis/templatetags/generic_tags.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from collections import deque
 
 from django.template.defaultfilters import register

--- a/web/analysis/templatetags/key_tags.py
+++ b/web/analysis/templatetags/key_tags.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from django import template
 
 register = template.Library()

--- a/web/analysis/templatetags/pdf_tags.py
+++ b/web/analysis/templatetags/pdf_tags.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from django import template
 
 register = template.Library()

--- a/web/analysis/urls.py
+++ b/web/analysis/urls.py
@@ -2,8 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file "docs/LICENSE" for copying permission.
 
-from __future__ import absolute_import
-
 from analysis import views
 from django.urls import re_path
 

--- a/web/analysis/views.py
+++ b/web/analysis/views.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import, print_function
 import base64
 import datetime
 import json

--- a/web/apiv2/urls.py
+++ b/web/apiv2/urls.py
@@ -2,8 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file "docs/LICENSE" for copying permission.
 
-from __future__ import absolute_import
-
 from apiv2 import views
 
 # from django.conf.urls import include

--- a/web/apiv2/views.py
+++ b/web/apiv2/views.py
@@ -1,5 +1,4 @@
 # encoding: utf-8
-from __future__ import absolute_import
 import json
 import logging
 import os

--- a/web/compare/urls.py
+++ b/web/compare/urls.py
@@ -2,8 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file "docs/LICENSE" for copying permission.
 
-from __future__ import absolute_import
-
 from compare import views
 from django.urls import re_path
 

--- a/web/compare/views.py
+++ b/web/compare/views.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import sys
 
 from django.conf import settings

--- a/web/dashboard/urls.py
+++ b/web/dashboard/urls.py
@@ -2,8 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file "docs/LICENSE" for copying permission.
 
-from __future__ import absolute_import
-
 from dashboard import views
 from django.urls import re_path
 

--- a/web/dashboard/views.py
+++ b/web/dashboard/views.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import sys
 
 from django.conf import settings

--- a/web/manage.py
+++ b/web/manage.py
@@ -3,7 +3,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import os
 import sys
 

--- a/web/submission/urls.py
+++ b/web/submission/urls.py
@@ -2,8 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
-
 from django.urls import re_path
 from submission import views
 

--- a/web/submission/views.py
+++ b/web/submission/views.py
@@ -3,7 +3,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import, print_function
 import logging
 import os
 import random

--- a/web/web/asgi.py
+++ b/web/web/asgi.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 # Copyright (C) 2010-2015 Cuckoo Foundation.
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.

--- a/web/web/headers.py
+++ b/web/web/headers.py
@@ -2,7 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
 import sys
 
 from django.conf import settings

--- a/web/web/local_settings.py
+++ b/web/web/local_settings.py
@@ -2,8 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
-
 LOCAL_SETTINGS = True
 from .settings import *
 

--- a/web/web/settings.py
+++ b/web/web/settings.py
@@ -1,7 +1,6 @@
 # Copyright (C) 2010-2015 Cuckoo Foundation.
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
-from __future__ import absolute_import
 import os
 import sys
 from pathlib import Path

--- a/web/web/urls.py
+++ b/web/web/urls.py
@@ -2,8 +2,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-from __future__ import absolute_import
-
 from analysis import views as analysis_views
 from dashboard import views as dashboard_views
 from django.conf import settings

--- a/web/web/wsgi.py
+++ b/web/web/wsgi.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 # Copyright (C) 2010-2015 Cuckoo Foundation.
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.


### PR DESCRIPTION
The `__future__` module is only relevant in python 2 and does not achieve anything in python 3 projects