### PR TITLE
ci: remove flake8 pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,10 +10,10 @@ repos:
       - id: mixed-line-ending
       - id: debug-statements
 
-  - repo: https://github.com/csachs/pyproject-flake8
-    rev: v0.0.1a4
-    hooks:
-      - id: pyproject-flake8
+  # - repo: https://github.com/csachs/pyproject-flake8
+  #   rev: v0.0.1a4
+  #   hooks:
+  #     - id: pyproject-flake8
 
   - repo: https://github.com/psf/black
     rev: 22.3.0


### PR DESCRIPTION
flake8 currently fails (to implement the hook after code cleanup)