### PR TITLE
Fixing bug where boolean values were received as strings

### DIFF
--- a/lib/cuckoo/common/web_utils.py
+++ b/lib/cuckoo/common/web_utils.py
@@ -1015,6 +1015,22 @@ def force_int(value):
         return value
 
 
+def force_bool(value):
+    if type(value) == bool:
+        return value
+
+    if not value:
+        return False
+
+    if value in ["False", "false", "FALSE"]:
+        return False
+    elif value in ["True", "true", "TRUE"]:
+        return True
+    else:
+        log.warning(f"Value of '{value}' cannot be converted from string to bool")
+        return False
+
+
 def parse_request_arguments(request):
     static = request.POST.get("static", "")
     referrer = validate_referrer(request.POST.get("referrer"))
@@ -1027,18 +1043,18 @@ def parse_request_arguments(request):
     tags_tasks = request.POST.get("tags_tasks")
     tags = request.POST.get("tags")
     custom = request.POST.get("custom", "")
-    memory = bool(request.POST.get("memory", False))
+    memory = force_bool(request.POST.get("memory", False))
     clock = request.POST.get("clock", datetime.now().strftime("%m-%d-%Y %H:%M:%S"))
     if not clock:
         clock = datetime.now().strftime("%m-%d-%Y %H:%M:%S")
     if "1970" in clock:
         clock = datetime.now().strftime("%m-%d-%Y %H:%M:%S")
-    enforce_timeout = bool(request.POST.get("enforce_timeout", False))
+    enforce_timeout = force_bool(request.POST.get("enforce_timeout", False))
     shrike_url = request.POST.get("shrike_url")
     shrike_msg = request.POST.get("shrike_msg")
     shrike_sid = request.POST.get("shrike_sid")
     shrike_refer = request.POST.get("shrike_refer")
-    unique = bool(request.POST.get("unique", False))
+    unique = force_bool(request.POST.get("unique", False))
     tlp = request.POST.get("tlp")
     lin_options = request.POST.get("lin_options", "")
     route = request.POST.get("route")

--- a/lib/cuckoo/common/web_utils.py
+++ b/lib/cuckoo/common/web_utils.py
@@ -1022,12 +1022,12 @@ def force_bool(value):
     if not value:
         return False
 
-    if value in ["False", "false", "FALSE"]:
+    if value in ("False", "false", "FALSE"):
         return False
-    elif value in ["True", "true", "TRUE"]:
+    elif value in ("True", "true", "TRUE"):
         return True
     else:
-        log.warning(f"Value of '{value}' cannot be converted from string to bool")
+        log.warning("Value of %s cannot be converted from string to bool", value)
         return False
 
 


### PR DESCRIPTION
As per the QueryDict [documentation](https://docs.djangoproject.com/en/4.0/ref/request-response/#django.http.QueryDict), values received from the POST body are interpreted as strings.

For example, if I submit a file to the REST API with a parameter that contains boolean value, such as `enforce_timeout`, set to `False`, this will be received as `"False"` by the REST API here 

https://github.com/kevoreilly/CAPEv2/blob/768334e13515f6700a49c3422d6279991175041c/web/apiv2/views.py#L256

Then this value is converted to a boolean here 

https://github.com/kevoreilly/CAPEv2/blob/768334e13515f6700a49c3422d6279991175041c/lib/cuckoo/common/web_utils.py#L1036

This will always evaluate non-empty strings to True, even if you set the value to be False in the submitter client.

See my proposed fix to address this bug :)