### PR TITLE
Adding ttp attribute to Signature class

### DIFF
--- a/docs/book/src/customization/signatures.rst
+++ b/docs/book/src/customization/signatures.rst
@@ -122,6 +122,7 @@ some initial attributes. These are the ones you can currently set:
     * ``alert``: if set to True can be used to specify that the signature should be reported (perhaps by a dedicated reporting module).
     * ``minimum``: the minimum required version of CAPE to successfully run this signature.
     * ``maximum``: the maximum required version of CAPE to successfully run this signature.
+    * ``ttp``: a list of MITRE ATT&CK IDs applicable to this signature.
 
 In our example, we would create the following skeleton:
 

--- a/lib/cuckoo/common/abstracts.py
+++ b/lib/cuckoo/common/abstracts.py
@@ -727,6 +727,7 @@ class Signature:
     enabled = True
     minimum = None
     maximum = None
+    ttp = []
 
     # Higher order will be processed later (only for non-evented signatures)
     # this can be used for having meta-signatures that check on other lower-


### PR DESCRIPTION
The `ttp` attribute is already informally available and used by 283 (possibly 285 with https://github.com/kevoreilly/community/pull/267) of the 676 signatures in the community repository. I suggest we formalize this for documentation's sake and add the attribute to the Signature class.