### PR TITLE
Allow extracted files that match yara rules with a cape_type to trigger config extraction.

### DIFF
--- a/modules/processing/CAPE.py
+++ b/modules/processing/CAPE.py
@@ -249,17 +249,11 @@ class CAPE(Processing):
         # Process CAPE Yara hits
 
         executed_config_parsers = set()
-        for tmp_data, hit in (
-            [
-                (file_data, yara)
-                for yara in file_info["cape_yara"]
-            ]
-            + [
-                (extracted_file["data"].encode(), yara)
-                for extracted_file in file_info.get("extracted_files", [])
-                for yara in extracted_file["cape_yara"]
-            ]
-        ):
+        for tmp_data, hit in [(file_data, yara) for yara in file_info["cape_yara"]] + [
+            (extracted_file["data"].encode(), yara)
+            for extracted_file in file_info.get("extracted_files", [])
+            for yara in extracted_file["cape_yara"]
+        ]:
 
             # Check for a payload or config hit
             try:

--- a/modules/processing/CAPE.py
+++ b/modules/processing/CAPE.py
@@ -249,7 +249,17 @@ class CAPE(Processing):
         # Process CAPE Yara hits
 
         executed_config_parsers = set()
-        for hit in file_info["cape_yara"]:
+        for tmp_data, hit in (
+            [
+                (file_data, yara)
+                for yara in file_info["cape_yara"]
+            ]
+            + [
+                (extracted_file["data"].encode(), yara)
+                for extracted_file in file_info.get("extracted_files", [])
+                for yara in extracted_file["cape_yara"]
+            ]
+        ):
 
             # Check for a payload or config hit
             try:
@@ -265,7 +275,7 @@ class CAPE(Processing):
                     file_info["cape_type"] += "DLL" if type_strings[2] == ("(DLL)") else "executable"
 
             if cape_name and cape_name not in executed_config_parsers:
-                tmp_config = static_config_parsers(cape_name, file_data)
+                tmp_config = static_config_parsers(cape_name, tmp_data)
                 config.update(tmp_config)
                 executed_config_parsers.add(cape_name)
 


### PR DESCRIPTION
*Note*: I am not familiar with how the extracted_files attribute of file_info is used. All I know is that I downloaded a SocGholish sample from a CAPE sandbox and resubmitted it. When it got to this point in the code, the cape_yara attribute was empty, but the file that matched the yara rule was in extracted_files and that had a yara rule match. Without this code change, no config extraction would be done.

tl;dr - Please make sure that this change makes sense. I only have a limited amount of test data.

Is the 'data' attribute of the extracted_file always a str (as it was in my SocGholish example) or could it be a 'bytes' object?