### PR TITLE
Add ability to run multiple dll functions by name, either by specification, or by discovery

### DIFF
--- a/analyzer/windows/modules/packages/dll.py
+++ b/analyzer/windows/modules/packages/dll.py
@@ -3,11 +3,14 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 import contextlib
+import logging
 import os
 import shutil
 
 from lib.common.abstracts import Package
 from lib.common.common import check_file_extension
+
+log = logging.getLogger(__name__)
 
 
 class Dll(Package):
@@ -19,9 +22,13 @@ class Dll(Package):
 
     def start(self, path):
         rundll32 = self.get_path("rundll32.exe")
-        function = self.options.get("function", "#1")
+        function = self.options.get("function", "")
         arguments = self.options.get("arguments", "")
         dllloader = self.options.get("dllloader")
+        dll_multi = self.options.get("dll_multi", False)
+        max_dll_exports = int(self.options.get("max_dll_exports", 5))
+        if max_dll_exports <= 0:
+            max_dll_exports = 5
 
         # If the file doesn't have the proper .dll extension force it
         # and rename it. This is needed for rundll32 to execute correctly.
@@ -33,15 +40,66 @@ class Dll(Package):
             shutil.copy(rundll32, newname)
             rundll32 = newname
 
-        with contextlib.suppress(ValueError, AssertionError):
-            start, end = (int(_.lstrip("#")) for _ in function.replace("..", "-").split("-", 1))
-            assert start < end
-            args = '/c for /l %i in ({start},1,{end}) do @{rundll32} "{path}",#%i {arguments}'.format(**locals())
-            # if there are multiple functions launch them by their ordinal number in a for loop via cmd.exe calling rundll32.exe
-            return self.execute("C:\\Windows\\System32\\cmd.exe", args.strip(), path)
+        # If we just want a DLL function by a single function, a single ordinal or an ordinal range
+        if not dll_multi or dll_multi.lower() in ["false", "no", "off"]:
+            if not function:
+                function = "#1"
+            with contextlib.suppress(ValueError, AssertionError):
+                start, end = (int(_.lstrip("#")) for _ in function.replace("..", "-").split("-", 1))
+                assert start < end
+                args = '/c for /l %i in ({start},1,{end}) do @{rundll32} "{path}",#%i {arguments}'.format(**locals())
+                # if there are multiple functions launch them by their ordinal number in a for loop via cmd.exe calling rundll32.exe
+                return self.execute("C:\\Windows\\System32\\cmd.exe", args.strip(), path)
 
-        args = f'"{path}"' if dllloader == "regsvcs.exe" else f'"{path}",{function}'
-        if arguments:
-            args += f" {arguments}"
+            args = f'"{path}"' if dllloader == "regsvcs.exe" else f'"{path}",{function}'
+            if arguments:
+                args += f" {arguments}"
 
-        return self.execute(rundll32, args, path)
+            return self.execute(rundll32, args, path)
+
+        # If we want to launch multiple functions by name or dynamically launch DLL functions by their export name
+        else:
+            # Allow ability to receive multiple entry points by submission, through the use of a pipe
+            function = set([item for item in function.split("|") if item])
+            if not function:
+                try:
+                    from pefile import PE, PEFormatError
+                    # We have a DLL file, but no user specified function(s) to run. let's try to pick a few...
+                    dll_parsed = None
+                    try:
+                        dll_parsed = PE(data=open(path, "rb").read())
+                    except PEFormatError as e:
+                        log.warning(f"Could not parse PE file due to {e}")
+
+                    if dll_parsed and hasattr(dll_parsed, "DIRECTORY_ENTRY_EXPORT"):
+                        # Do we have any exports?
+                        for export_symbol in dll_parsed.DIRECTORY_ENTRY_EXPORT.symbols:
+                            if export_symbol.name is not None:
+                                if type(export_symbol.name) == str:
+                                    function.add(export_symbol.name)
+                                elif type(export_symbol.name) == bytes:
+                                    function.add(export_symbol.name.decode())
+                            else:
+                                function.add(f"#{export_symbol.ordinal}")
+                except ImportError:
+                    log.error("'pefile' module is not installed. On your guest, run 'pip install pefile'.")
+
+            # Wow, seriously? Nothing yet?
+            if not function:
+                function.add("DllMain")
+                function.add("DllRegisterServer")
+
+            # Run them all!
+            ret_list = []
+            for function_name in list(function)[:max_dll_exports]:
+                args = f'"{path}"' if dllloader == "regsvcs.exe" else f'"{path}",{function_name}'
+                if arguments:
+                    args += f" {arguments}"
+
+                ret_list.append(self.execute(rundll32, args, path))
+
+            available_functions = ",".join(list(function)[max_dll_exports:])
+            if available_functions:
+                log.info(f"There were {len(function) - max_dll_exports} other exports that were not executed: {available_functions}.")
+
+            return ret_list

--- a/analyzer/windows/modules/packages/dll.py
+++ b/analyzer/windows/modules/packages/dll.py
@@ -85,7 +85,7 @@ class Dll(Package):
                 else:
                     use_export_name = False
 
-                available_exports = self.config.exports.split(",")
+                available_exports = list(filter(None, self.config.exports.split(",")))
 
                 # If there are no available exports, default
                 if not available_exports:

--- a/analyzer/windows/modules/packages/dll.py
+++ b/analyzer/windows/modules/packages/dll.py
@@ -3,11 +3,14 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 import contextlib
+import logging
 import os
 import shutil
 
 from lib.common.abstracts import Package
 from lib.common.common import check_file_extension
+
+log = logging.getLogger(__name__)
 
 MAX_DLL_EXPORTS_DEFAULT = 8
 
@@ -36,49 +39,78 @@ class Dll(Package):
 
         # If user has requested we use something (function, functions, ordinal, ordinal range)
         function = self.options.get("function")
+
+        # Does the user want us to run multiple exports that are available?
+        enable_multi = self.options.get("enable_multi", "")
+        if enable_multi.lower() in ["on", "yes", "true"]:
+            enable_multi = True
+        else:
+            enable_multi = False
+
         run_ordinal_range = False
         run_multiple_functions = False
-        if function:
 
-            # If user has requested we use functions, separated by commas
-            if "," in function:
+        if function:
+            # If user has requested we use functions (by name or by ordinal number), separated by commas
+            if enable_multi and "," in function:
                 function = function.split(",")
                 run_multiple_functions = True
 
             # If user has requested we use an ordinal range, separated by a hyphen or by ..
-            elif "-" in function or ".." in function:
+            elif enable_multi and ("-" in function or ".." in function):
                 run_ordinal_range = True
 
-        # If user has not requested that we use something, we should default to running all available exports, up to a limit
+            # If the user has not enabled multi, but requested multiple functions, log it and default to #1
+            elif not enable_multi and ("," in function or "-" in function or ".." in function):
+                log.warning("You need to enable the `enable_multi` option if you want to run multiple functions.")
+                # Setting function to the first ordinal number since the user does not want use to run multiple functions.
+                function = "#1"
+
+        # If user has not requested that we use a function(s), we should default to running main export entry or
+        # all available exports, up to a limit, if enabled
         else:
-            available_exports = self.config.exports.split(",")
-
-            # Used for export discovery / splitting
-            use_export_name = self.options.get("use_export_name")
-            if use_export_name.lower() in ["on", "yes", "true"]:
-                use_export_name = True
-            else:
-                use_export_name = False
-
-            if not available_exports:
-                if use_export_name:
-                    function = ["DllMain", "DllRegisterServer"]
-                    run_multiple_functions = True
-                else:
+            # If the user does not want us to run multiple exports that are available, set function to default
+            if not enable_multi:
+                if not use_export_name:
                     function = "#1"
-            else:
-                max_dll_exports = int(self.options.get("max_dll_exports", MAX_DLL_EXPORTS_DEFAULT))
-                if max_dll_exports <= 0:
-                    max_dll_exports = MAX_DLL_EXPORTS_DEFAULT
-                dll_exports_num = min(len(available_exports), max_dll_exports)
-
-                if use_export_name:
-                    function = available_exports[:dll_exports_num]
-                    run_multiple_functions = True
                 else:
-                    function = f"#1-{dll_exports_num}"
-                    run_ordinal_range = True
+                    function = "DllMain"
 
+            # The user does want us to run multiple functions if we can find them
+            else:
+                # Does the user want us to run multiple exports by name?
+                use_export_name = self.options.get("use_export_name", "")
+                if use_export_name.lower() in ["on", "yes", "true"]:
+                    use_export_name = True
+                else:
+                    use_export_name = False
+
+                available_exports = self.config.exports.split(",")
+
+                # If there are no available exports, default
+                if not available_exports:
+                    if use_export_name:
+                        function = ["DllMain", "DllRegisterServer"]
+                        run_multiple_functions = True
+                    else:
+                        function = "#1"
+
+                # If there are available exports, set limit and determine if we are to use name or number
+                else:
+                    max_dll_exports = int(self.options.get("max_dll_exports", MAX_DLL_EXPORTS_DEFAULT))
+                    if max_dll_exports <= 0:
+                        max_dll_exports = MAX_DLL_EXPORTS_DEFAULT
+                    dll_exports_num = min(len(available_exports), max_dll_exports)
+
+                    if use_export_name:
+                        function = available_exports[:dll_exports_num]
+                        run_multiple_functions = True
+                    else:
+                        function = f"#1-{dll_exports_num}"
+                        run_ordinal_range = True
+
+        # To get to this stage, the user has enabled `enable_multi`, and has either specified an ordinal
+        # range or requested that we use available exports by ordinal number, up to a limit
         if run_ordinal_range:
             with contextlib.suppress(ValueError, AssertionError):
                 start, end = (int(_.lstrip("#")) for _ in function.replace("..", "-").split("-", 1))
@@ -87,6 +119,8 @@ class Dll(Package):
                 # if there are multiple functions launch them by their ordinal number in a for loop via cmd.exe calling rundll32.exe
                 return self.execute("C:\\Windows\\System32\\cmd.exe", args.strip(), path)
 
+        # To get to this stage, the user has enabled `enable_multi`, and has either specified a list of function names
+        # or requested that we use available exports by name, up to a limit
         elif run_multiple_functions:
             ret_list = []
             for function_name in function:
@@ -97,6 +131,10 @@ class Dll(Package):
                 ret_list.append(self.execute(rundll32, args, path))
             return ret_list
 
+        # To get to this stage, the user has either:
+        # - enabled `enable_multi`, did not provide a function, and does not want to use export names (default to #1)
+        # - specified a single function, either by name or by ordinal number
+        # - specified multiple functions, but did not enable `enable_multi`
         else:
             args = f'"{path}"' if dllloader == "regsvcs.exe" else f'"{path}",{function}'
             if arguments:

--- a/docs/book/src/usage/packages.rst
+++ b/docs/book/src/usage/packages.rst
@@ -49,6 +49,11 @@ The following is a list of the existing packages in alphabetical order:
             * ``dllloader``: specify a process name to use to fake the DLL launcher name instead of rundll32.exe (this is used to fool possible anti-sandboxing tricks of certain malware)
             * ``procmemdump`` *[yes/no]*: if enabled, take memory dumps of all actively monitored processes.
             * ``dll``: specify the name of an optional DLL to be used as a replacement for capemon.dll.
+            * ``dll_multi`` *[yes/no, true/false, on/off]*: if enabled, will allow multiple functions to be specified by name.
+            These functions must be separated by the `|` character, and must be supplied in the `function` task option. If this option is enabled, no function is specified,
+            and the Pip package `pefile` is installed in the guest, then the package will dynamically gather functions to run, up to the limit found in the `max_dll_exports` task option.
+            * ``max_dll_exports``: A positive integer, representing how many functions you wish to execute.
+
 
     * ``doc``: used to run and analyze **Microsoft Word documents**.
 

--- a/docs/book/src/usage/packages.rst
+++ b/docs/book/src/usage/packages.rst
@@ -44,14 +44,14 @@ The following is a list of the existing packages in alphabetical order:
 
         **Options**:
             * ``free`` *[yes/no]*: if enabled, no behavioral logs will be produced and the malware will be executed freely.
-            * ``function``: specify the function to be executed. If none is specified, CAPE will try to run ``DllMain``.
+            * ``function``: specify the function to be executed. If none is specified, CAPE will try to run all available functions,
+            up to the limit found in the `max_dll_exports` task option.
             * ``arguments``: specify arguments to pass to the DLL through commandline.
             * ``dllloader``: specify a process name to use to fake the DLL launcher name instead of rundll32.exe (this is used to fool possible anti-sandboxing tricks of certain malware)
             * ``procmemdump`` *[yes/no]*: if enabled, take memory dumps of all actively monitored processes.
             * ``dll``: specify the name of an optional DLL to be used as a replacement for capemon.dll.
-            * ``dll_multi`` *[yes/no, true/false, on/off]*: if enabled, will allow multiple functions to be specified by name.
-            These functions must be separated by the `|` character, and must be supplied in the `function` task option. If this option is enabled, no function is specified,
-            and the Pip package `pefile` is installed in the guest, then the package will dynamically gather functions to run, up to the limit found in the `max_dll_exports` task option.
+            * ``use_export_name`` *[yes/no, true/false, on/off]*: if enabled and no function is specified,
+            then the package will run all available functions, up to the limit found in the `max_dll_exports` task option.
             * ``max_dll_exports``: A positive integer, representing how many functions you wish to execute.
 
 

--- a/docs/book/src/usage/packages.rst
+++ b/docs/book/src/usage/packages.rst
@@ -50,9 +50,9 @@ The following is a list of the existing packages in alphabetical order:
             * ``dllloader``: specify a process name to use to fake the DLL launcher name instead of rundll32.exe (this is used to fool possible anti-sandboxing tricks of certain malware)
             * ``procmemdump`` *[yes/no]*: if enabled, take memory dumps of all actively monitored processes.
             * ``dll``: specify the name of an optional DLL to be used as a replacement for capemon.dll.
-            * ``use_export_name`` *[yes/no, true/false, on/off]*: if enabled and no function is specified,
-            then the package will run all available functions, up to the limit found in the `max_dll_exports` task option.
-            * ``max_dll_exports``: A positive integer, representing how many functions you wish to execute.
+            * ``enable_mutli`` *[yes/no, true/false, on/off]*: if enabled, multiple functions can be run.
+            * ``use_export_name`` *[yes/no, true/false, on/off]*: if enabled, functions will be run by name rather than by ordinal number.
+            * ``max_dll_exports``: A positive integer, representing how many functions you wish to execute. `enable_mutli` must be enabled.
 
 
     * ``doc``: used to run and analyze **Microsoft Word documents**.


### PR DESCRIPTION
Modifying the `dll.py` package to allow the ability to run multiple DLL functions if specified by name in the `function` option, or if `pefile` is installed on the guest then we can dynamically find libraries to run.