### PR TITLE
Adding ability to toggle what aux modules can run in VM

### DIFF
--- a/analyzer/windows/analyzer.py
+++ b/analyzer/windows/analyzer.py
@@ -466,6 +466,7 @@ class Analyzer:
                     # We continue so that the module is not added to AUX_ENABLED
                     continue
                 else:
+                    log.debug('Trying to start auxiliary module "%s"...', module.__name__)
                     aux.start()
                     log.debug('Started auxiliary module "%s"', module.__name__)
             except (NotImplementedError, AttributeError):
@@ -473,6 +474,7 @@ class Analyzer:
             except Exception as e:
                 log.warning("Cannot execute auxiliary module %s: %s", module.__name__, e)
             else:
+                log.debug("Started auxiliary module %s", module.__name__)
                 AUX_ENABLED.append(aux)
 
         """

--- a/analyzer/windows/analyzer.py
+++ b/analyzer/windows/analyzer.py
@@ -456,18 +456,23 @@ class Analyzer:
             # if module.__name__ == "Screenshots" and disable_screens:
             #    continue
             try:
-                log.debug('Initializing auxiliary module "%s"...', module.__name__)
                 aux = module(self.options, self.config)
-                # log.debug('Initialized auxiliary module "%s"', module.__name__)
+                log.debug('Initialized auxiliary module "%s"', module.__name__)
                 aux_avail.append(aux)
-                # log.debug('Trying to start auxiliary module "%s"...', module.__name__)
-                aux.start()
+
+                # If the auxiliary module is not enabled, we shouldn't start it
+                if hasattr(aux, "enabled") and not getattr(aux, "enabled", False):
+                    log.debug('Auxiliary module "%s" is disabled.', module.__name__)
+                    # We continue so that the module is not added to AUX_ENABLED
+                    continue
+                else:
+                    aux.start()
+                    log.debug('Started auxiliary module "%s"', module.__name__)
             except (NotImplementedError, AttributeError):
                 log.warning("Auxiliary module %s was not implemented", module.__name__)
             except Exception as e:
                 log.warning("Cannot execute auxiliary module %s: %s", module.__name__, e)
             else:
-                log.debug("Started auxiliary module %s", module.__name__)
                 AUX_ENABLED.append(aux)
 
         """

--- a/analyzer/windows/modules/auxiliary/browser.py
+++ b/analyzer/windows/modules/auxiliary/browser.py
@@ -9,6 +9,7 @@ from threading import Thread
 
 from lib.api.process import Process
 from lib.common.abstracts import Auxiliary
+from lib.core.config import Config
 
 log = logging.getLogger(__name__)
 
@@ -19,7 +20,9 @@ class Browser(Auxiliary, Thread):
     def __init__(self, options, config):
         Auxiliary.__init__(self, options, config)
         Thread.__init__(self)
-        self.do_run = True
+        self.config = Config(cfg="analysis.conf")
+        self.enabled = self.config.browser
+        self.do_run = self.enabled
         self.seconds_elapsed = 0
 
     def stop(self):

--- a/analyzer/windows/modules/auxiliary/curtain.py
+++ b/analyzer/windows/modules/auxiliary/curtain.py
@@ -70,7 +70,5 @@ class Curtain(Thread, Auxiliary):
         return False
 
     def stop(self):
-        if self.enabled:
-            self.collectLogs()
-            return True
-        return False
+        self.collectLogs()
+        return True

--- a/analyzer/windows/modules/auxiliary/digisig.py
+++ b/analyzer/windows/modules/auxiliary/digisig.py
@@ -11,6 +11,7 @@ from io import BytesIO
 from lib.api.utils import Utils
 from lib.common.abstracts import Auxiliary
 from lib.common.results import NetlogFile
+from lib.core.config import Config
 
 log = logging.getLogger(__name__)
 util = Utils()
@@ -34,10 +35,12 @@ class DigiSig(Auxiliary):
 
     def __init__(self, options, config):
         Auxiliary.__init__(self, options, config)
+        self.config = Config(cfg="analysis.conf")
+        self.enabled = self.config.digisig
+        self.do_run = self.enabled
         self.cert_build = []
         self.time_build = []
         self.json_data = {"sha1": None, "signers": [], "timestamp": None, "valid": False, "error": None, "error_desc": None}
-        self.enabled = True
 
     def build_output(self, outputType, line):
         if line:
@@ -101,9 +104,6 @@ class DigiSig(Auxiliary):
             self.json_data["signers"].append(buf)
 
     def start(self):
-        if not self.enabled:
-            return True
-
         try:
             if self.config.category != "file":
                 log.debug("Skipping authenticode validation, analysis is not a file")

--- a/analyzer/windows/modules/auxiliary/disguise.py
+++ b/analyzer/windows/modules/auxiliary/disguise.py
@@ -28,12 +28,19 @@ from winreg import (
 
 from lib.common.abstracts import Auxiliary
 from lib.common.rand import random_integer, random_string
+from lib.core.config import Config
 
 log = logging.getLogger(__name__)
 
 
 class Disguise(Auxiliary):
     """Disguise the analysis environment."""
+
+    def __init__(self, options, config):
+        Auxiliary.__init__(self, options, config)
+        self.config = Config(cfg="analysis.conf")
+        self.enabled = self.config.disguise
+        self.do_run = self.enabled
 
     @staticmethod
     def run_as_system(command):

--- a/analyzer/windows/modules/auxiliary/evtx.py
+++ b/analyzer/windows/modules/auxiliary/evtx.py
@@ -223,7 +223,5 @@ class Evtx(Thread, Auxiliary):
         return False
 
     def stop(self):
-        if self.enabled:
-            self.collect_windows_logs()
-            return True
-        return False
+        self.collect_windows_logs()
+        return True

--- a/analyzer/windows/modules/auxiliary/human.py
+++ b/analyzer/windows/modules/auxiliary/human.py
@@ -12,6 +12,7 @@ from threading import Thread
 
 from lib.common.abstracts import Auxiliary
 from lib.common.defines import BM_CLICK, CF_TEXT, GMEM_MOVEABLE, KERNEL32, USER32, WM_CLOSE, WM_GETTEXT, WM_GETTEXTLENGTH
+from lib.core.config import Config
 
 log = logging.getLogger(__name__)
 
@@ -261,7 +262,9 @@ class Human(Auxiliary, Thread):
     def __init__(self, options, config):
         Auxiliary.__init__(self, options, config)
         Thread.__init__(self)
-        self.do_run = True
+        self.config = Config(cfg="analysis.conf")
+        self.enabled = self.config.human
+        self.do_run = self.enabled
 
     def stop(self):
         self.do_run = False

--- a/analyzer/windows/modules/auxiliary/screenshots.py
+++ b/analyzer/windows/modules/auxiliary/screenshots.py
@@ -10,6 +10,7 @@ from threading import Thread
 from lib.api.screenshot import Screenshot
 from lib.common.abstracts import Auxiliary
 from lib.common.results import NetlogFile
+from lib.core.config import Config
 
 log = logging.getLogger(__name__)
 
@@ -23,12 +24,12 @@ SKIP_AREA = None
 class Screenshots(Auxiliary, Thread):
     """Take screenshots."""
 
-    priority = 1
-
     def __init__(self, options, config):
         Auxiliary.__init__(self, options, config)
         Thread.__init__(self)
-        self.do_run = True
+        self.config = Config(cfg="analysis.conf")
+        self.enabled = self.config.screenshots
+        self.do_run = self.enabled
 
     def stop(self):
         """Stop screenshotting."""

--- a/analyzer/windows/modules/auxiliary/tlsdump.py
+++ b/analyzer/windows/modules/auxiliary/tlsdump.py
@@ -9,6 +9,7 @@ from lib.api.process import Process
 from lib.common.abstracts import Auxiliary
 from lib.common.defines import KERNEL32, PROCESSENTRY32, TH32CS_SNAPPROCESS
 from lib.common.exceptions import CuckooError
+from lib.core.config import Config
 
 log = logging.getLogger(__name__)
 
@@ -16,11 +17,11 @@ log = logging.getLogger(__name__)
 class TLSDumpMasterSecrets(Auxiliary):
     """Dump TLS master secrets from lsass process"""
 
-    def __init__(self, options=None, config=None):
-        if options is None:
-            options = {}
-        self.config = config
-        self.options = options
+    def __init__(self, options, config):
+        Auxiliary.__init__(self, options, config)
+        self.config = Config(cfg="analysis.conf")
+        self.enabled = self.config.tlsdump
+        self.do_run = self.enabled
         self.options["tlsdump"] = "1"
 
     def start(self):

--- a/analyzer/windows/modules/auxiliary/usage.py
+++ b/analyzer/windows/modules/auxiliary/usage.py
@@ -10,6 +10,7 @@ from threading import Thread
 from lib.common.abstracts import Auxiliary
 from lib.common.defines import DWORD, KERNEL32, MEMORYSTATUSEX, PDH, PDH_FMT_COUNTERVALUE, PDH_FMT_DOUBLE, PVOID
 from lib.common.results import NetlogFile
+from lib.core.config import Config
 
 log = logging.getLogger(__name__)
 
@@ -20,7 +21,9 @@ class Usage(Auxiliary, Thread):
     def __init__(self, options, config):
         Auxiliary.__init__(self, options, config)
         Thread.__init__(self)
-        self.do_run = True
+        self.config = Config(cfg="analysis.conf")
+        self.enabled = self.config.usage
+        self.do_run = self.enabled
         self.pidlist = []
 
     def stop(self):

--- a/conf/auxiliary.conf
+++ b/conf/auxiliary.conf
@@ -15,12 +15,19 @@
 # reg add "HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\PowerShell\Transcription" /v OutputDirectory /t REG_SZ /d C:\PSTranscipts /f /reg:64
 # reg add "HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\PowerShell\Transcription" /v EnableInvocationHeader /t REG_DWORD /d 00000001 /f /reg:64
 
-#Modules to be enabled or not inside of the VM
+# Modules to be enabled or not inside of the VM
 [auxiliary_modules]
+browser = yes
 curtain = no
-sysmon = no
-procmon = no
+digisig = yes
+disguise = yes
 evtx = no
+human = yes
+procmon = no
+screenshots = yes
+sysmon = no
+tlsdump = yes
+usage = yes
 
 [sniffer]
 # Enable or disable the use of an external sniffer (tcpdump) [yes/no].


### PR DESCRIPTION
This PR does the following:
-> Adds each auxiliary module to the `auxiliary_module` section in `auxiliary.conf`.
-> Allows these config values to control if a module is "enabled"
-> In `analyzer.py`, check if module is enabled and then start it


I'm not sure how the `run()` method in auxiliary modules is called, but the `enabled` flag should be used there too.