### PR TITLE
Adding 'restart now' button to list of buttons to not click

### DIFF
--- a/analyzer/windows/modules/auxiliary/human.py
+++ b/analyzer/windows/modules/auxiliary/human.py
@@ -125,6 +125,7 @@ def foreach_child(hwnd, lparam):
             "cancel",
             "do not accept the agreement",
             "i would like to help make reader even better",
+            "restart now",
             # german
             "abbrechen",
             "online nach losung suchen",


### PR DESCRIPTION
This button is often seen upon reimage in a cloud environment, since the virtual disk has technically been switched from the OS's perspective. Don't restart!