### PR TITLE
Removing unused folders, reusing RESULT_UPLOADABLE

### DIFF
--- a/lib/cuckoo/core/resultserver.py
+++ b/lib/cuckoo/core/resultserver.py
@@ -46,11 +46,9 @@ BANNED_PATH_CHARS = b"\x00:"
 RESULT_UPLOADABLE = (
     b"CAPE",
     b"aux",
-    b"buffer",
     b"curtain",
     b"debugger",
     b"tlsdump",
-    b"extracted",
     b"files",
     b"memory",
     b"procdump",
@@ -333,23 +331,7 @@ class GeventResultServerWorker(gevent.server.StreamServer):
                 ctx.cancel()
 
     def create_folders(self):
-        folders = (
-            "CAPE",
-            "aux",
-            "curtain",
-            "files",
-            "logs",
-            "memory",
-            "shots",
-            "sysmon",
-            "stap",
-            "procdump",
-            "debugger",
-            "tlsdump",
-            "evtx",
-        )
-
-        for folder in folders:
+        for folder in RESULT_UPLOADABLE + ["logs"]:
             try:
                 create_folder(self.storagepath, folder=folder)
             except Exception as e:


### PR DESCRIPTION
All folders listed under `RESULT_UPLOADABLE`:
https://github.com/kevoreilly/CAPEv2/blob/master/lib/cuckoo/core/resultserver.py#L46:L61

other than `report` should be created in this method here:
https://github.com/kevoreilly/CAPEv2/blob/master/lib/cuckoo/core/resultserver.py#L336:L350
?

Also it looks like `buffer` and `extracted` are unused in CAPE.