### PR TITLE
Bugfix: Escape backslash used in DoppelPaymer Payload rule

### DIFF
--- a/data/yara/CAPE/DoppelPaymer.yar
+++ b/data/yara/CAPE/DoppelPaymer.yar
@@ -7,7 +7,7 @@ rule DoppelPaymer
 
     strings:
         $getproc32 = {81 FB ?? ?? ?? ?? 74 2D 8B CB E8 ?? ?? ?? ?? 85 C0 74 0C 8B C8 8B D7 E8 ?? ?? ?? ?? 5B 5F C3}
-        $cmd_string = "Setup run\n" wide
+        $cmd_string = "Setup run\\n" wide
     condition:
         uint16(0) == 0x5A4D and all of them
 }

--- a/modules/processing/parsers/CAPE/DoppelPaymer.py
+++ b/modules/processing/parsers/CAPE/DoppelPaymer.py
@@ -31,7 +31,7 @@ rule DoppelPaymer
 
     strings:
         $getproc32 = {81 FB ?? ?? ?? ?? 74 2D 8B CB E8 ?? ?? ?? ?? 85 C0 74 0C 8B C8 8B D7 E8 ?? ?? ?? ?? 5B 5F C3}
-        $cmd_string = "Setup run\n" wide
+        $cmd_string = "Setup run\\n" wide
     condition:
         uint16(0) == 0x5A4D and all of them
 }


### PR DESCRIPTION
Fixes yara.SyntaxError on compilation.