### PR TITLE
Fix bug in parsing ranges of ID's in process.py.

### DIFF
--- a/utils/process.py
+++ b/utils/process.py
@@ -310,8 +310,11 @@ def parse_id(id_string: str):
     blocks = [block.split("-") for block in id_string.split(",")]
     for index, block in enumerate(blocks):
         block = list(map(int, block))
-        if len(block) == 2 and block[1] < block[0]:
-            raise TypeError("Invalid id input")
+        if len(block) == 2:
+            if block[1] < block[0]:
+                raise TypeError("Invalid id input")
+            else:
+                blocks[index] = block
         elif len(block) == 1:
             blocks[index] = (block[0], block[0])
         else:


### PR DESCRIPTION
If a valid range of ID's was given on the command line, parse_id
would raise an exception. This fixes that.