### PR TITLE
Adding periodic logger to enhance debugging of pending tasks, locked machines, etc

### DIFF
--- a/conf/cuckoo.conf
+++ b/conf/cuckoo.conf
@@ -72,6 +72,10 @@ daydelta = 0
 # Path to the unix socket for running root commands.
 rooter = /tmp/cuckoo-rooter
 
+# Enable if you want to see a DEBUG log periodically containing backlog of pending tasks, locked vs unlocked machines.
+# NOTE: Enabling this feature adds 4 database calls every 10 seconds.
+periodic_log = off
+
 [resultserver]
 # The Result Server is used to receive in real time the behavioral logs
 # produced by the analyzer.

--- a/lib/cuckoo/core/scheduler.py
+++ b/lib/cuckoo/core/scheduler.py
@@ -759,7 +759,8 @@ class Scheduler:
             self.maxcount = self.cfg.cuckoo.max_analysis_count
 
         # Start the logger which grabs database information
-        self._thr_periodic_log()
+        if self.cfg.cuckoo.periodic_log:
+            self._thr_periodic_log()
 
         # This loop runs forever.
         while self.running:

--- a/lib/cuckoo/core/scheduler.py
+++ b/lib/cuckoo/core/scheduler.py
@@ -22,7 +22,7 @@ from lib.cuckoo.common.exceptions import (
 from lib.cuckoo.common.integrations.parse_pe import PortableExecutable
 from lib.cuckoo.common.objects import File
 from lib.cuckoo.common.utils import convert_to_printable, create_folder, free_space_monitor, get_memdump_path, load_categories
-from lib.cuckoo.core.database import TASK_COMPLETED, Database
+from lib.cuckoo.core.database import TASK_COMPLETED, TASK_PENDING, Database
 from lib.cuckoo.core.guest import GuestManager
 from lib.cuckoo.core.plugins import RunAuxiliary, list_plugins
 from lib.cuckoo.core.resultserver import ResultServer
@@ -758,6 +758,9 @@ class Scheduler:
         if self.maxcount is None:
             self.maxcount = self.cfg.cuckoo.max_analysis_count
 
+        # Start the logger which grabs database information
+        self._thr_periodic_log()
+
         # This loop runs forever.
         while self.running:
             time.sleep(1)
@@ -825,3 +828,9 @@ class Scheduler:
                 raise errors.get(block=False)
             except queue.Empty:
                 pass
+
+    def _thr_periodic_log(self):
+        log.debug("# Tasks: %d; # Available Machines: %d; # Locked Machines: %d; # Total Machines: %d;",
+                  self.db.count_tasks(status=TASK_PENDING), self.db.count_machines_available(),
+                  len(self.db.list_machines(locked=True)), len(self.db.list_machines()))
+        threading.Timer(10, self._thr_periodic_log).start()


### PR DESCRIPTION
This may not be for everyone since it adds 4 additional DB calls every ten seconds, but it is crucial to our operations to be able to determine the backlog in CAPE and the status of locked vs unlocked machines. 