### PR TITLE
Revert "fix: configparser parsing of % symbol"

### DIFF
--- a/analyzer/windows/lib/core/config.py
+++ b/analyzer/windows/lib/core/config.py
@@ -8,7 +8,7 @@ import configparser
 class Config:
     def __init__(self, cfg):
         """@param cfg: configuration file."""
-        config = configparser.ConfigParser(allow_no_value=True, interpolation=True)
+        config = configparser.ConfigParser(allow_no_value=True)
         config.read(cfg)
 
         for section in config.sections():


### PR DESCRIPTION
Reverts kevoreilly/CAPEv2#984 - causing failure in analyzer to load config