### PR TITLE
Fix KeyError in virustotal integration.

### DIFF
--- a/lib/cuckoo/common/integrations/virustotal.py
+++ b/lib/cuckoo/common/integrations/virustotal.py
@@ -264,7 +264,7 @@ def vt_lookup(category: str, target: str, results: dict = {}, on_demand: bool = 
 
         virustotal["detection"] = get_vt_consensus(detectnames)
         if virustotal.get("detection", False) and results:
-            add_family_detection(results, vt_response["detection"], "VirusTotal", vt_response["sha256"])
+            add_family_detection(results, virustotal["detection"], "VirusTotal", virustotal["sha256"])
         return virustotal
     except requests.exceptions.RequestException as e:
         return {


### PR DESCRIPTION
We were checking virustotal to see if it has the 'detection' key, but
then attempt to use vt_response, which might not have that key. Also,
the 'sha256' key does not exist in vt_response, but it does in
virustotal.