### PR TITLE
Simplifying connection reset log

### DIFF
--- a/lib/cuckoo/core/resultserver.py
+++ b/lib/cuckoo/core/resultserver.py
@@ -115,7 +115,7 @@ class HandlerContext:
 
             if e.errno != errno.ECONNRESET:
                 raise
-            log.debug("Task #%s had connection reset for %s, error: %s", self.task_id, self, e)
+            log.debug("Task #%s had %s for %s", self.task_id, e.strerror.lower(), self)
             return b""
         except Exception as e:
             print(e)


### PR DESCRIPTION
Prior to this PR, this particular log showed up as so:
```
[lib.cuckoo.core.resultserver] DEBUG: Task #1216 had connection reset for <Context for b'LOG'>, error: [Errno 104] Connection reset by peer
[lib.cuckoo.core.resultserver] DEBUG: Task #1216 had connection reset for <Context for None>, error: [Errno 104] Connection reset by peer
[lib.cuckoo.core.resultserver] DEBUG: Task #1216 had connection reset for <Context for b'BSON'>, error: [Errno 104] Connection reset by peer
```

This is redundant information though, since this log will only show up if the connection is reset. So I suggest refactoring the log so that it is more concise:

```
[lib.cuckoo.core.resultserver] DEBUG: Task #4 had connection reset by peer for <Context for b'BSON'>
[lib.cuckoo.core.resultserver] DEBUG: Task #4 had connection reset by peer for <Context for b'BSON'>
```