### PR TITLE
Generalizing log sub-format, fixing cuckoo.log per-task

### DIFF
--- a/cuckoo.py
+++ b/cuckoo.py
@@ -66,12 +66,14 @@ def cuckoo_init(quiet=False, debug=False, artwork=False, test=False):
         except KeyboardInterrupt:
             return
 
-    init_logging()
-
     if quiet:
-        log.setLevel(logging.WARN)
+        level = logging.WARN
     elif debug:
-        log.setLevel(logging.DEBUG)
+        level = logging.DEBUG
+    else:
+        level = logging.INFO
+    log.setLevel(level)
+    init_logging(level)
 
     check_webgui_mongo()
     init_modules()

--- a/lib/cuckoo/core/guest.py
+++ b/lib/cuckoo/core/guest.py
@@ -148,9 +148,9 @@ class GuestManager:
                 socket.create_connection((self.ipaddr, self.port), 1).close()
                 break
             except socket.timeout:
-                log.debug("%s: not ready yet", self.vmid)
+                log.debug("Task #%s: %s is not ready yet", self.task_id, self.vmid)
             except socket.error:
-                log.debug("%s: not ready yet", self.vmid)
+                log.debug("Task #%s: %s is not ready yet", self.task_id, self.vmid)
                 time.sleep(1)
 
             if time.time() > end:
@@ -371,7 +371,7 @@ class GuestManager:
             # If the analysis hits the critical timeout, just return straight
             # away and try to recover the analysis results from the guest.
             if time.time() > end:
-                log.info("%s: end of analysis reached!", self.vmid)
+                log.info("Task #%s: End of analysis reached! (id=%s, ip=%s)", self.task_id, self.vmid, self.ipaddr)
                 return
 
             try:
@@ -381,11 +381,11 @@ class GuestManager:
                 # issues thus we don't want to abort the analysis just yet and
                 # wait for things to recover
                 log.warning(
-                    "Virtual Machine: %s /status failed. This can indicate the guest losing network connectivity", self.vmid
+                    "Task #%s: Virtual Machine %s /status failed. This can indicate the guest losing network connectivity", self.task_id, self.vmid
                 )
                 continue
             except Exception as e:
-                log.error("Virtual machine: %s /status failed. %s", self.vmid, e, exc_info=True)
+                log.error("Task #%s: Virtual machine %s /status failed. %s", self.task_id, self.vmid, e, exc_info=True)
                 continue
 
             if status["status"] == "complete":

--- a/lib/cuckoo/core/guest.py
+++ b/lib/cuckoo/core/guest.py
@@ -190,7 +190,7 @@ class GuestManager:
         """Upload the analyzer to the Virtual Machine."""
         zip_data = analyzer_zipfile(self.platform)
 
-        log.debug("Uploading analyzer to guest (id=%s, ip=%s, size=%d)", self.vmid, self.ipaddr, len(zip_data))
+        log.debug("Task #%s: Uploading analyzer to guest (id=%s, ip=%s, size=%d)", self.task_id, self.vmid, self.ipaddr, len(zip_data))
 
         self.determine_analyzer_path()
         data = {
@@ -220,7 +220,7 @@ class GuestManager:
         :param options: options
         :return:
         """
-        log.info("Uploading support files to guest (id=%s, ip=%s)", self.vmid, self.ipaddr)
+        log.info("Task #%s: Uploading support files to guest (id=%s, ip=%s)", self.task_id, self.vmid, self.ipaddr)
         basedir = os.path.dirname(options["target"])
 
         for dirpath, _, files in os.walk(basedir):
@@ -235,7 +235,7 @@ class GuestManager:
 
     def upload_scripts(self):
         """Upload various scripts such as pre_script and during_scripts."""
-        log.info("Uploading script files to guest  (id=%s, ip=%s)", self.vmid, self.ipaddr)
+        log.info("Task #%s: Uploading script files to guest (id=%s, ip=%s)", self.task_id, self.vmid, self.ipaddr)
         # Temp File location of pre_script and during_script
         base_dir = os.path.join("/tmp/cuckoo-tmp", str(self.task_id))
         # File path of Analyses path. Storage of script
@@ -256,7 +256,7 @@ class GuestManager:
         """Start the analysis by uploading all required files.
         @param options: the task options
         """
-        log.info("Starting analysis #%s on guest (id=%s, ip=%s)", self.task_id, self.vmid, self.ipaddr)
+        log.info("Task #%s: Starting analysis on guest (id=%s, ip=%s)", self.task_id, self.vmid, self.ipaddr)
 
         self.options = options
         self.timeout = options["timeout"] + cfg.timeouts.critical
@@ -299,7 +299,7 @@ class GuestManager:
             db.guest_set_status(self.task_id, "failed")
             return
 
-        log.info("Guest is running CAPE Agent %s (id=%s, ip=%s)", version, self.vmid, self.ipaddr)
+        log.info("Task #%s: Guest is running CAPE Agent %s (id=%s, ip=%s)", self.task_id, version, self.vmid, self.ipaddr)
 
         # Pin the Agent to our IP address so that it is not accessible by
         # other Virtual Machines etc.
@@ -362,7 +362,7 @@ class GuestManager:
 
         while db.guest_get_status(self.task_id) == "running" and self.do_run:
             if count >= 5:
-                log.debug("%s: analysis #%s is still running", self.vmid, self.task_id)
+                log.debug("Task #%s: Analysis is still running (id=%s, ip=%s)", self.task_id, self.vmid, self.ipaddr)
                 count = 0
 
             count += 1
@@ -389,10 +389,10 @@ class GuestManager:
                 continue
 
             if status["status"] == "complete":
-                log.info("%s: analysis completed successfully", self.vmid)
+                log.info("Task #%s: Analysis completed successfully (id=%s, ip=%s)", self.task_id, self.vmid, self.ipaddr)
                 db.guest_set_status(self.task_id, "complete")
                 return
             elif status["status"] == "exception":
-                log.warning("%s: analysis #%s caught an exception\n%s", self.vmid, self.task_id, status["description"])
+                log.warning("Task #%s: Analysis caught an exception (id=%s, ip=%s)\n%s", self.task_id, self.vmid, self.ipaddr, status["description"])
                 db.guest_set_status(self.task_id, "failed")
                 return

--- a/lib/cuckoo/core/log.py
+++ b/lib/cuckoo/core/log.py
@@ -54,7 +54,7 @@ class TaskHandler(logging.Handler):
         if not task:
             return
 
-        task[1].write(f"{self.format(record)}\n")
+        task[1].write(f"{self.format(record)}\n".encode())
 
 
 class ConsoleHandler(logging.StreamHandler):
@@ -145,35 +145,19 @@ def task_log_stop(task_id):
 def init_logger(name, level=None):
     formatter = logging.Formatter("%(asctime)s [%(name)s] %(levelname)s: %(message)s")
 
-    if name == "cuckoo.log":
-        l = logging.handlers.WatchedFileHandler(cwd("log", "cuckoo.log"))
-        l.setFormatter(formatter)
-        l.setLevel(level)
-
-    if name == "cuckoo.json":
-        j = JsonFormatter()
-        l = logging.handlers.WatchedFileHandler(cwd("log", "cuckoo.json"))
-        l.setFormatter(j)
-        l.addFilter(j)
-
     if name == "console":
         l = ConsoleHandler()
         l.setFormatter(formatter)
         l.setLevel(level)
 
-    if name == "database":
+    elif name == "database":
         l = DatabaseHandler()
         l.setLevel(logging.ERROR)
 
-    if name == "task":
+    elif name == "task":
         l = TaskHandler()
         l.setFormatter(formatter)
-
-    if name.startswith("process-") and name.endswith(".json"):
-        j = JsonFormatter()
-        l = logging.handlers.WatchedFileHandler(cwd("log", name))
-        l.setFormatter(j)
-        l.addFilter(j)
+        l.setLevel(logging.DEBUG)
 
     _loggers[name] = l
     logging.getLogger().addHandler(l)

--- a/lib/cuckoo/core/resultserver.py
+++ b/lib/cuckoo/core/resultserver.py
@@ -213,7 +213,7 @@ class FileUpload(ProtocolHandler):
                 log.debug("File upload error for %s (task #%s)", dump_path, self.task_id)
                 if e.errno == errno.EEXIST:
                     raise CuckooOperationalError(
-                        f"Analyzer for task #{self.task_id} tried to overwrite an existing file: {file_path}"
+                        "Task #%s: Analyzer tried to overwrite an existing file: %s" % (self.task_id, file_path)
                     )
                 raise
         # ToDo we need Windows path
@@ -315,7 +315,7 @@ class GeventResultServerWorker(gevent.server.StreamServer):
     def add_task(self, task_id, ipaddr):
         with self.task_mgmt_lock:
             self.tasks[ipaddr] = task_id
-            log.debug("Now tracking machine %s for task #%s", ipaddr, task_id)
+            log.debug("Task #%s: The associated machine IP is %s", task_id, ipaddr)
 
     def del_task(self, task_id, ipaddr):
         """Delete ResultServer state and abort pending RequestHandlers. Since
@@ -326,10 +326,10 @@ class GeventResultServerWorker(gevent.server.StreamServer):
             if self.tasks.pop(ipaddr, None) is None:
                 log.warning("ResultServer did not have a task with ID %s and IP %s", task_id, ipaddr)
             else:
-                log.debug("Stopped tracking machine %s for task #%s", ipaddr, task_id)
+                log.debug("Task %s: Stopped tracking machine %s", task_id, ipaddr)
             ctxs = self.handlers.pop(task_id, set())
             for ctx in ctxs:
-                log.debug("Cancel %s for task %s", ctx, task_id)
+                log.debug("Task #%s: Cancel %s", task_id, ctx)
                 ctx.cancel()
 
     def create_folders(self):

--- a/lib/cuckoo/core/startup.py
+++ b/lib/cuckoo/core/startup.py
@@ -23,6 +23,7 @@ from lib.cuckoo.common.exceptions import CuckooOperationalError, CuckooStartupEr
 from lib.cuckoo.common.objects import File
 from lib.cuckoo.common.utils import create_folders
 from lib.cuckoo.core.database import TASK_FAILED_ANALYSIS, TASK_RUNNING, Database
+from lib.cuckoo.core.log import init_logger
 from lib.cuckoo.core.plugins import import_package, import_plugin, list_plugins
 from lib.cuckoo.core.rooter import rooter, socks5s, vpns
 
@@ -161,9 +162,14 @@ def check_linux_dist():
         pass
 
 
-def init_logging():
-    """Initializes logging."""
+def init_logging(level: int):
+    """Initializes logging.
+    @param level: The logging level for the console logs
+    """
     formatter = logging.Formatter("%(asctime)s [%(name)s] %(levelname)s: %(message)s")
+
+    init_logger("console", level)
+    init_logger("database")
 
     if cuckoo.log_rotation.enabled:
         days = cuckoo.log_rotation.backup_count or 7
@@ -175,15 +181,7 @@ def init_logging():
     fh.setFormatter(formatter)
     log.addHandler(fh)
 
-    ch = ConsoleHandler()
-    ch.setFormatter(formatter)
-    log.addHandler(ch)
-
-    dh = DatabaseHandler()
-    dh.setLevel(logging.ERROR)
-    log.addHandler(dh)
-
-    log.setLevel(logging.INFO)
+    init_logger("task")
 
     logging.getLogger("urllib3").setLevel(logging.WARNING)
 


### PR DESCRIPTION
The `init_logger` method seems to be half-migrated from Cuckoo. The PR implements it, and populates the cuckoo.log per-task.

Also tried to make the sub-format for each log in the Guest and Resultserver the same:
`Task #<task-id>: blah blah (id=<vm-id>, ip=<vm-ip>)`