### PR TITLE
make poetry play nice with utils/submit.py

### DIFF
--- a/utils/submit.py
+++ b/utils/submit.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env -S poetry run python3
 # Copyright (C) 2010-2015 Cuckoo Foundation.
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.


### PR DESCRIPTION
So was just sitting down for writing a perl module for fetching and shoving a lot of drek into CAPE and I noticed that utils/submit.py was borked post move to poetry.

Updated the interpreter for the script to `#!/usr/bin/env -S poetry run python3`, which will automatically invoke poetry to run the script.