### PR TITLE
Processing Improvements

### DIFF
--- a/conf/processing.conf
+++ b/conf/processing.conf
@@ -57,6 +57,12 @@ enabled = no
 
 [behavior]
 enabled = yes
+# Toggle specific modules within the BehaviorAnalysis class
+anomaly = yes
+processtree = yes
+summary = yes
+enhanced = yes
+encryptedbuffers = yes
 
 [debug]
 enabled = yes

--- a/conf/reporting.conf
+++ b/conf/reporting.conf
@@ -230,3 +230,6 @@ command=/foo/bar.pl
 # run statistics, this may take more times.
 [runstatistics]
 enabled = no
+
+[malheur]
+enabled = no

--- a/conf/web.conf
+++ b/conf/web.conf
@@ -240,3 +240,6 @@ enabled = yes
 
 [during_script]
 enabled = yes
+
+[web_reporting]
+enabled = yes

--- a/lib/cuckoo/common/abstracts.py
+++ b/lib/cuckoo/common/abstracts.py
@@ -756,6 +756,7 @@ class Signature:
         self._current_call_raw_dict = None
         self.hostname2ips = {}
         self.machinery_conf = machinery_conf
+        self.matched = False
 
     def statistics_custom(self, pretime, extracted: bool = False):
         """

--- a/lib/cuckoo/common/integrations/parse_pe.py
+++ b/lib/cuckoo/common/integrations/parse_pe.py
@@ -153,11 +153,9 @@ class PortableExecutable:
     @property
     def file_data(self):
         if not self._file_data:
-            try:
+            if os.path.exists(self.file_path):
                 with open(self.file_path, "rb") as f:
                     self._file_data = f.read()
-            except FileNotFoundError as e:
-                log.error(e, exc_info=True)
         return self._file_data
 
     # Obtained from

--- a/lib/cuckoo/common/integrations/parse_pe.py
+++ b/lib/cuckoo/common/integrations/parse_pe.py
@@ -153,8 +153,11 @@ class PortableExecutable:
     @property
     def file_data(self):
         if not self._file_data:
-            with open(self.file_path, "rb") as f:
-                self._file_data = f.read()
+            try:
+                with open(self.file_path, "rb") as f:
+                    self._file_data = f.read()
+            except FileNotFoundError as e:
+                log.error(e, exc_info=True)
         return self._file_data
 
     # Obtained from
@@ -251,6 +254,9 @@ class PortableExecutable:
         @return: file type or None.
         """
         if not HAVE_MAGIC:
+            return None
+
+        if not data:
             return None
 
         try:
@@ -798,7 +804,7 @@ class PortableExecutable:
 
     def get_dll_exports(self) -> str:
         file_type = self._get_filetype(self.file_data)
-        if HAVE_PEFILE and ("PE32" in file_type or "MS-DOS executable" in file_type):
+        if HAVE_PEFILE and file_type and ("PE32" in file_type or "MS-DOS executable" in file_type):
             try:
                 pe = pefile.PE(self.file_path)
                 if hasattr(pe, "DIRECTORY_ENTRY_EXPORT"):

--- a/lib/cuckoo/common/objects.py
+++ b/lib/cuckoo/common/objects.py
@@ -246,7 +246,10 @@ class File:
     @property
     def file_data(self):
         if not self._file_data:
-            self._file_data = open(self.file_path, "rb").read()
+            try:
+                self._file_data = open(self.file_path, "rb").read()
+            except FileNotFoundError as e:
+                log.error(e, exc_info=True)
         return self._file_data
 
     def get_size(self):

--- a/lib/cuckoo/common/objects.py
+++ b/lib/cuckoo/common/objects.py
@@ -246,10 +246,8 @@ class File:
     @property
     def file_data(self):
         if not self._file_data:
-            try:
+            if os.path.exists(self.file_path):
                 self._file_data = open(self.file_path, "rb").read()
-            except FileNotFoundError as e:
-                log.error(e, exc_info=True)
         return self._file_data
 
     def get_size(self):

--- a/lib/cuckoo/core/log.py
+++ b/lib/cuckoo/core/log.py
@@ -41,7 +41,7 @@ class DatabaseHandler(logging.Handler):
     def emit(self, record):
         # TODO Should this also attempt to guess the task ID from _tasks?
         if hasattr(record, "task_id"):
-            Database().add_error(self.format(record), int(record.task_id), getattr(record, "error_action", None))
+            Database().add_error(self.format(record), int(record.task_id))
 
 
 class TaskHandler(logging.Handler):

--- a/lib/cuckoo/core/plugins.py
+++ b/lib/cuckoo/core/plugins.py
@@ -36,7 +36,6 @@ _modules = defaultdict(dict)
 
 processing_cfg = Config("processing")
 reporting_cfg = Config("reporting")
-web_cfg = Config("web")
 
 config_mapper = {
     "processing": processing_cfg,
@@ -649,9 +648,8 @@ class RunReporting:
         # remove unwanted/duplicate information from reporting
         for process in results["behavior"]["processes"]:
             process["calls"].begin_reporting()
-            if web_cfg.web_reporting.get("enabled", True):
-                # required to convert object to list
-                process["calls"] = list(process["calls"])
+            # required to convert object to list
+            process["calls"] = list(process["calls"])
 
         self.results = results
         self.analysis_path = os.path.join(CUCKOO_ROOT, "storage", "analyses", str(task["id"]))

--- a/lib/cuckoo/core/plugins.py
+++ b/lib/cuckoo/core/plugins.py
@@ -36,6 +36,7 @@ _modules = defaultdict(dict)
 
 processing_cfg = Config("processing")
 reporting_cfg = Config("reporting")
+web_cfg = Config("web")
 
 config_mapper = {
     "processing": processing_cfg,
@@ -646,6 +647,9 @@ class RunReporting:
         # remove unwanted/duplicate information from reporting
         for process in results["behavior"]["processes"]:
             process["calls"].begin_reporting()
+            if web_cfg.web_reporting.get("enabled", True):
+                # required to convert object to list
+                process["calls"] = list(process["calls"])
 
         self.results = results
         self.analysis_path = os.path.join(CUCKOO_ROOT, "storage", "analyses", str(task["id"]))

--- a/lib/cuckoo/core/plugins.py
+++ b/lib/cuckoo/core/plugins.py
@@ -646,8 +646,6 @@ class RunReporting:
         # remove unwanted/duplicate information from reporting
         for process in results["behavior"]["processes"]:
             process["calls"].begin_reporting()
-            # required to convert object to list
-            process["calls"] = list(process["calls"])
 
         self.results = results
         self.analysis_path = os.path.join(CUCKOO_ROOT, "storage", "analyses", str(task["id"]))

--- a/modules/machinery/az.py
+++ b/modules/machinery/az.py
@@ -675,7 +675,7 @@ class Azure(Machinery):
                 raise CuckooGuestCriticalTimeout(
                     f"Machine {machine_name}: the guest initialization hit the critical " "timeout, analysis aborted."
                 )
-        log.debug(f"Machine {machine_name} was created and available in {round(time.time() - start)}")
+        log.debug(f"Machine {machine_name} was created and available in {round(time.time() - start)}s")
 
     @staticmethod
     def _azure_api_call(*args, **kwargs):

--- a/modules/processing/behavior.py
+++ b/modules/processing/behavior.py
@@ -260,7 +260,7 @@ class ParseProcessLog(list):
         if cfg.processing.ram_boost:
             idx = 0
             ent = self.api_call_cache[idx]
-            while not ent:
+            while ent:
                 # remove the values we don't want to encode in reports
                 for arg in ent["arguments"]:
                     del arg["raw_value"]

--- a/modules/processing/behavior.py
+++ b/modules/processing/behavior.py
@@ -1159,19 +1159,22 @@ class BehaviorAnalysis(Processing):
             Enhanced(),
             EncryptedBuffers(),
         ]
-        # Iterate calls and tell interested signatures about them
-        for process in behavior["processes"]:
-            for call in process["calls"]:
-                for instance in instances:
-                    try:
-                        instance.event_apicall(call, process)
-                    except Exception:
-                        log.exception('Failure in partial behavior "%s"', instance.key)
+        enabled_instances = [instance for instance in instances if getattr(cfg_process.behavior, instance.key, True)]
+
+        if enabled_instances:
+            # Iterate calls and tell interested signatures about them
+            for process in behavior["processes"]:
+                for call in process["calls"]:
+                    for instance in enabled_instances:
+                        try:
+                            instance.event_apicall(call, process)
+                        except Exception:
+                            log.exception('Failure in partial behavior "%s"', instance.key)
 
         for instance in instances:
             try:
                 behavior[instance.key] = instance.run()
-            except Exception:
-                log.exception('Failed to run partial behavior class "%s"', instance.key)
+            except Exception as e:
+                log.exception('Failed to run partial behavior class "%s" due to "%s"', instance.key, e)
 
         return behavior

--- a/utils/process.py
+++ b/utils/process.py
@@ -238,7 +238,10 @@ def autoprocess(parallel=1, failed_processing=False, maxtasksperchild=7, memory_
                     log.info("Processing analysis data for Task #%d", task.id)
                     if task.category != "url":
                         sample = db.view_sample(task.sample_id)
-                        copy_path = os.path.join(CUCKOO_ROOT, "storage", "binaries", str(task.id), sample.sha256)
+                        if sample:
+                            copy_path = os.path.join(CUCKOO_ROOT, "storage", "binaries", str(task.id), sample.sha256)
+                        else:
+                            copy_path = None
                     else:
                         copy_path = None
                     args = task.target, copy_path

--- a/web/apiv2/views.py
+++ b/web/apiv2/views.py
@@ -902,6 +902,7 @@ def tasks_view(request, task_id):
             sort=[("_id", -1)],
         )
 
+    rtmp = None
     if es_as_db:
         rtmp = es.search(
             index=get_analysis_index(),
@@ -1066,7 +1067,8 @@ def tasks_delete(request, task_id, status=False):
 
         if db.delete_task(task):
             delete_folder(os.path.join(CUCKOO_ROOT, "storage", "analyses", "%s" % task))
-            mongo_delete_data(task)
+            if web_conf.web_reporting.get("enabled", True):
+                mongo_delete_data(task)
 
             s_deleted.append(str(task))
         else:

--- a/web/web/settings.py
+++ b/web/web/settings.py
@@ -38,12 +38,14 @@ aux_cfg = Config("auxiliary")
 web_cfg = Config("web")
 api_cfg = Config("api")
 
-# Error handling for database backends
-if not cfg.mongodb.get("enabled") and not cfg.elasticsearchdb.get("enabled"):
-    raise Exception("No database backend reporting module is enabled! Please enable either ElasticSearch or MongoDB.")
+# If reporting is enabled via the web GUI, then require one of these to be enabled
+if web_cfg.web_reporting.get("enabled", True):
+    # Error handling for database backends
+    if not cfg.mongodb.get("enabled") and not cfg.elasticsearchdb.get("enabled"):
+        raise Exception("No database backend reporting module is enabled! Please enable either ElasticSearch or MongoDB.")
 
-if cfg.mongodb.get("enabled") and cfg.elasticsearchdb.get("enabled") and not cfg.elasticsearchdb.get("searchonly"):
-    raise Exception("Both database backend reporting modules are enabled. Please only enable ElasticSearch or MongoDB.")
+    if cfg.mongodb.get("enabled") and cfg.elasticsearchdb.get("enabled") and not cfg.elasticsearchdb.get("searchonly"):
+        raise Exception("Both database backend reporting modules are enabled. Please only enable ElasticSearch or MongoDB.")
 
 WEB_AUTHENTICATION = web_cfg.web_auth.get("enabled", False)
 WEB_OAUTH = web_cfg.oauth


### PR DESCRIPTION
- Configurable behaviour sub-modules
- Bugfix for `add_error` call
- Updating behaviour signature processing to be in-line with how Cuckoo does it
- Add `web_reporting` config to allow both mongodb and elasticsearch reporting to be disabled. This is useful for when you want the REST API that Django supplies, but you don't want the GUI.
- Adding `rtmp` default value
- Toggle the use of `list(process["calls"])` since it is only useful for certain reporting modules, like mongodb.
- Adding check if file exists for PE-parsing
- Adding a `finally` statement in the scheduler from Cuckoo that marks tasks as completed if there is an AnalysisManager error.
- Fixing ramboost bug
- Adding `matched` attribute to the `Signature` class to avoid duplication of signature hits
- Adding check for if sample doesn't exists in db

Something that I have noticed in CAPE which I don't think(?) was an issue in Cuckoo, is the length of time that it takes to iterate through the `calls` of a process here https://github.com/kevoreilly/CAPEv2/blob/1822c2ed8700548878dbedd6c676bb403e478961/lib/cuckoo/core/plugins.py#L494

For instance, I have a sample (a batch file with one line `start "" https://www.stackoverflow.com`) that creates a process which opens `iexplore.exe`. This process makes a lot of calls. Without `ramboost` turned on, the processing of the Bson logs in the `behavior.py` module takes ~2 seconds, and then the iteration of calls when applying evented signatures takes ~30 seconds (even with my improvements in this PR). When I turn `ramboost` on, the processing of the Bson logs takes ~30 seconds and the signatures take ~2 seconds. So basically it always takes 32 seconds, which _feels_ like that is too long to just parse/iterate through logs. Is this issue something that people are aware of / can duplicate?