### PR TITLE
Logic improvements for tasking

### DIFF
--- a/conf/az.conf
+++ b/conf/az.conf
@@ -2,8 +2,12 @@
 # Specify the Azure Region (for example, CanadaCentral). This is case-sensitive
 region_name = <region_name>
 
-# Resource Group for Azure
-resource_group = <resource_group>
+# Resource Groups for Azure
+# The service principal that controls the Azure resources should have READ
+# access on the virtual network where it lives, which should be in a different resource
+# group than where the sandbox resources live.
+vnet_resource_group = <resource_group>
+sandbox_resource_group = <resource_group>
 
 # Subscription ID for Azure
 subscription_id = <subscription_id>
@@ -37,6 +41,20 @@ total_machines_limit = 50
 # Specify the machine's instance type(for example, Standard_F2s_v2, Standard_DS3_v2)
 instance_type = <instance_type>
 
+# This boolean flag is used to indicate if we want to programmatically determine how many cores are used
+# per VM of the instance_type mentioned above.
+# NOTE: If enabled, this is a long call that takes ~ 1 minute to complete. It takes place at
+# the initialization of the machinery. If disabled, you need to specify the instance_type_cores below.
+find_number_of_cores_for_sku = true
+
+# The number of cores (vCPUs) that a VM of the instance_type mentioned above uses.
+# If find_number_of_cores_for_sku is enabled, this value will be ignored.
+# Set to 0 if you want to programmatically determine this value.
+# See note above. Otherwise, set to an integer.
+# For example for the instance_type Standard_F2s_v2, there are 2 cores per VM so the value for
+# instance_type_cores should be 2.
+instance_type_cores = 0
+
 # Specify the IP of the Result Server, as your virtual machine sees it.
 # It should be the nest ip address.
 resultserver_ip = <resultserver_ip>
@@ -53,9 +71,13 @@ storage_account_type = <storage_account_type>
 # Initial virtual machine pool size for each scale set
 initial_pool_size = 1
 
+# Reset pool size to initial_pool_size on CAPE restart
+reset_pool_size = true
+
 # Specify a comma-separated list of scale sets to be used, either available or to be created.
 # For each specified ID you have to define a dedicated section containing the details
 # about the respective scale set. (E.g. cuckoo1,cuckoo2,cuckoo3)
+# NOTE: NO SPACES
 scale_sets = cuckoo1
 
 # A percentage to be used for overprovisioning a scale set. To disable overprovisiong, set to 0
@@ -68,6 +90,10 @@ wait_time_to_reimage = 15
 # This boolean value is used to indicate if we want to use Azure Spot instances rather than 
 # normal instances
 spot_instances = false
+
+# This boolean value is used to indicate if we want to wait for each VM to have its agent running before we
+# start pulling tasks off of the stack
+wait_for_agent_before_starting = true
 
 [cuckoo1]
 # The gallery image name to use when creating the virtual machine scale set.
@@ -84,4 +110,4 @@ arch = x64
 
 # A tag used to specify on which guest scale set a sample should be run. All 
 # virtual machines in this scale set will have this tag
-tag = <tag>
+pool_tag = <tag>

--- a/conf/web.conf
+++ b/conf/web.conf
@@ -38,6 +38,10 @@ hostname = https://127.0.0.1/
 ;hostname = https://www.capesandbox.com/
 # Check if config exists or try to extract before accept task as static
 check_config_exists = no
+# Assign architecture to task to fetch correct VM type
+dynamic_arch_determination = yes
+# Assign platform to task to fetch correct VM type
+dynamic_platform_determination = yes
 
 # ratelimit for anon users
 [ratelimit]

--- a/lib/cuckoo/common/abstracts.py
+++ b/lib/cuckoo/common/abstracts.py
@@ -265,19 +265,20 @@ class Machinery:
         """
         return self.db.count_machines_available()
 
-    def acquire(self, machine_id=None, platform=None, tags=None):
+    def acquire(self, machine_id=None, platform=None, tags=None, arch=None):
         """Acquire a machine to start analysis.
         @param machine_id: machine ID.
         @param platform: machine platform.
         @param tags: machine tags
+        @param arch: machine arch
         @return: machine or None.
         """
         if machine_id:
             return self.db.lock_machine(label=machine_id)
         elif platform:
-            return self.db.lock_machine(platform=platform, tags=tags)
+            return self.db.lock_machine(platform=platform, tags=tags, arch=arch)
         else:
-            return self.db.lock_machine(tags=tags)
+            return self.db.lock_machine(tags=tags, arch=arch)
 
     def release(self, label=None):
         """Release a machine.

--- a/lib/cuckoo/common/web_utils.py
+++ b/lib/cuckoo/common/web_utils.py
@@ -59,6 +59,8 @@ rpm = web_cfg.ratelimit.get("rpm", "5/rpm")
 
 db = Database()
 
+DYNAMIC_PLATFORM_DETERMINATION = web_cfg.general.dynamic_platform_determination
+
 HAVE_DIST = False
 # Distributed CAPE
 if repconf.distributed.enabled:
@@ -655,7 +657,8 @@ def download_file(**kwargs):
     if not kwargs.get("task_machines", []):
         kwargs["task_machines"] = [None]
 
-    platform = get_platform(magic_type)
+    if DYNAMIC_PLATFORM_DETERMINATION:
+        platform = get_platform(magic_type)
     if platform == "linux" and not linux_enabled and "Python" not in magic_type:
         return "error", {"error": "Linux binaries analysis isn't enabled"}
 
@@ -1084,9 +1087,9 @@ def force_bool(value):
     if not value:
         return False
 
-    if value in ("False", "false", "FALSE"):
+    if value.lower() in ("false", "no", "off", "0"):
         return False
-    elif value in ("True", "true", "TRUE"):
+    elif value.lower() in ("true", "yes", "on", "1"):
         return True
     else:
         log.warning("Value of %s cannot be converted from string to bool", value)

--- a/lib/cuckoo/common/web_utils.py
+++ b/lib/cuckoo/common/web_utils.py
@@ -666,7 +666,7 @@ def download_file(**kwargs):
         kwargs["task_machines"] = [vm.name for vm in db.list_machines(platform=platform)]
     elif machine:
         machine_details = db.view_machine(machine)
-        if hasattr(machine_details, "platform") and not machine_details.platform == platform:
+        if platform and hasattr(machine_details, "platform") and not machine_details.platform == platform:
             return "error", {"error": f"Wrong platform, {machine_details.platform} VM selected for {platform} sample"}
         else:
             kwargs["task_machines"] = [machine]

--- a/lib/cuckoo/core/database.py
+++ b/lib/cuckoo/core/database.py
@@ -107,7 +107,7 @@ if repconf.elasticsearchdb.enabled:
 
     es = elastic_handler
 
-SCHEMA_VERSION = "8537286ff4d5"
+SCHEMA_VERSION = "02af0b0ec686"
 TASK_BANNED = "banned"
 TASK_PENDING = "pending"
 TASK_RUNNING = "running"

--- a/lib/cuckoo/core/database.py
+++ b/lib/cuckoo/core/database.py
@@ -807,7 +807,13 @@ class Database(object, metaclass=Singleton):
         # Are there available machines that match up with a task?
         task_arch = next((tag.name for tag in task.tags if tag.name in ["x86", "x64"]), "")
         task_tags = [tag.name for tag in task.tags if tag.name != task_arch]
-        relevant_available_machines = self.list_machines(locked=False, platform=task.platform, tags=task_tags, arch=task_arch)
+        relevant_available_machines = self.list_machines(
+            locked=False,
+            label=task.machine,
+            platform=task.platform,
+            tags=task_tags,
+            arch=task_arch
+        )
         if len(relevant_available_machines) > 0:
             # There are? Awesome!
             self.set_status(task_id=task.id, status=TASK_RUNNING)
@@ -946,7 +952,7 @@ class Database(object, metaclass=Singleton):
             session.close()
 
     @classlock
-    def list_machines(self, locked=None, platform="", tags=[], arch=""):
+    def list_machines(self, locked=None, label=None, platform=None, tags=[], arch=None):
         """Lists virtual machines.
         @return: list of virtual machines
         """
@@ -955,6 +961,8 @@ class Database(object, metaclass=Singleton):
             machines = session.query(Machine).options(joinedload("tags"))
             if locked is not None and isinstance(locked, bool):
                 machines = machines.filter_by(locked=locked)
+            if label:
+                machines = machines.filter_by(label=label)
             if platform:
                 machines = machines.filter_by(platform=platform)
             if arch:

--- a/lib/cuckoo/core/database.py
+++ b/lib/cuckoo/core/database.py
@@ -360,7 +360,7 @@ class Error(Base):
     __tablename__ = "errors"
 
     id = Column(Integer(), primary_key=True)
-    message = Column(String(512), nullable=False)
+    message = Column(String(1024), nullable=False)
     task_id = Column(Integer, ForeignKey("tasks.id"), nullable=False)
 
     def to_dict(self):

--- a/lib/cuckoo/core/plugins.py
+++ b/lib/cuckoo/core/plugins.py
@@ -184,7 +184,7 @@ class RunAuxiliary:
             except NotImplementedError:
                 pass
             except Exception as e:
-                log.warning("Unable to stop auxiliary module: %s", e)
+                log.warning("Unable to stop auxiliary module: %s", e, exc_info=True)
             else:
                 log.debug("Stopped auxiliary module: %s", module.__class__.__name__)
 

--- a/lib/cuckoo/core/resultserver.py
+++ b/lib/cuckoo/core/resultserver.py
@@ -326,7 +326,7 @@ class GeventResultServerWorker(gevent.server.StreamServer):
             if self.tasks.pop(ipaddr, None) is None:
                 log.warning("ResultServer did not have a task with ID %s and IP %s", task_id, ipaddr)
             else:
-                log.debug("Task %s: Stopped tracking machine %s", task_id, ipaddr)
+                log.debug("Task #%s: Stopped tracking machine %s", task_id, ipaddr)
             ctxs = self.handlers.pop(task_id, set())
             for ctx in ctxs:
                 log.debug("Task #%s: Cancel %s", task_id, ctx)

--- a/lib/cuckoo/core/scheduler.py
+++ b/lib/cuckoo/core/scheduler.py
@@ -850,12 +850,18 @@ class Scheduler:
         specific_available_machine_counts = defaultdict(int)
         for machine in self.db.get_available_machines():
             for tag in machine.tags:
-                specific_available_machine_counts[tag.name] += 1
+                if tag:
+                    specific_available_machine_counts[tag.name] += 1
+            if machine.platform:
+                specific_available_machine_counts[machine.platform] += 1
         specific_pending_task_counts = defaultdict(int)
         for task in self.db.list_tasks(status=TASK_PENDING):
             for tag in task.tags:
-                specific_pending_task_counts[tag.name] += 1
-            specific_pending_task_counts[task.platform] += 1
+                if tag:
+                    specific_pending_task_counts[tag.name] += 1
+            if task.platform:
+                specific_pending_task_counts[task.platform] += 1
+            specific_pending_task_counts[task.machine] += 1
 
         log.debug(
             "# Pending Tasks: %d; # Specific Pending Tasks: %s; # Available Machines: %d; # Available Specific Machines: %s; # Locked Machines: %d; # Total Machines: %d;",

--- a/lib/cuckoo/core/scheduler.py
+++ b/lib/cuckoo/core/scheduler.py
@@ -22,7 +22,7 @@ from lib.cuckoo.common.exceptions import (
 from lib.cuckoo.common.integrations.parse_pe import PortableExecutable
 from lib.cuckoo.common.objects import File
 from lib.cuckoo.common.utils import convert_to_printable, create_folder, free_space_monitor, get_memdump_path, load_categories
-from lib.cuckoo.core.database import TASK_COMPLETED, TASK_PENDING, Database
+from lib.cuckoo.core.database import TASK_COMPLETED, TASK_PENDING, Database, Task
 from lib.cuckoo.core.guest import GuestManager
 from lib.cuckoo.core.log import task_log_stop
 from lib.cuckoo.core.plugins import RunAuxiliary, list_plugins
@@ -191,12 +191,14 @@ class AnalysisManager(threading.Thread):
 
             # If the user specified a specific machine ID, a platform to be
             # used or machine tags acquire the machine accordingly.
-            machine = machinery.acquire(machine_id=self.task.machine, platform=self.task.platform, tags=self.task.tags)
+            task_arch = next((tag.name for tag in self.task.tags if tag.name in ["x86", "x64"]), "")
+            task_tags = [tag.name for tag in self.task.tags if tag.name != task_arch]
+            machine = machinery.acquire(machine_id=self.task.machine, platform=self.task.platform, tags=task_tags, arch=task_arch)
 
             # If no machine is available at this moment, wait for one second and try again.
             if not machine:
                 machine_lock.release()
-                log.debug("Task #%s: no machine available yet. Verify that arch value is set in hypervisor config", self.task.id)
+                log.debug("Task #%s: no machine available yet for machine '%s', platform '%s' or tags '%s'.", self.task.id, self.task.machine, self.task.platform, self.task.tags)
                 time.sleep(1)
             else:
                 log.info(
@@ -239,7 +241,7 @@ class AnalysisManager(threading.Thread):
             options["exports"] = PortableExecutable(self.task.target).get_dll_exports()
             del file_obj
 
-        # options from auxiliar.conf
+        # options from auxiliary.conf
         for plugin in self.aux_cfg.auxiliary_modules.keys():
             options[plugin] = self.aux_cfg.auxiliary_modules[plugin]
 
@@ -810,15 +812,16 @@ class Scheduler:
                 if active_analysis_count <= 0:
                     self.stop()
             else:
-                # Fetch a pending analysis task.
-                # TODO: this fixes only submissions by --machine, need to add other attributes (tags etc.)
                 if self.categories_need_VM:
-                    for machine in self.db.get_available_machines():
-                        task = self.db.fetch(machine, self.analyzing_categories)
-                        if task:
+                    # First things first, are there pending tasks?
+                    if not self.db.count_tasks(status=TASK_PENDING):
+                        continue
+                    # There are? Great, let's get them, ordered by priority and then oldest to newest
+                    for task in self.db.list_tasks(status=TASK_PENDING, order_by=(Task.priority.desc(), Task.added_on), options_not_like="node="):
+                        if self.db.is_relevant_machine_available(task):
                             break
                 else:
-                    task = self.db.fetch(False, categories=self.analyzing_categories, need_VM=False)
+                    task = self.db.fetch_task(False, categories=self.analyzing_categories, need_VM=False)
                 if task:
                     log.debug("Task #%s: Processing task", task.id)
                     self.total_analysis_count += 1

--- a/lib/cuckoo/core/scheduler.py
+++ b/lib/cuckoo/core/scheduler.py
@@ -861,7 +861,8 @@ class Scheduler:
                     specific_pending_task_counts[tag.name] += 1
             if task.platform:
                 specific_pending_task_counts[task.platform] += 1
-            specific_pending_task_counts[task.machine] += 1
+            if task.machine:
+                specific_pending_task_counts[task.machine] += 1
 
         log.debug(
             "# Pending Tasks: %d; # Specific Pending Tasks: %s; # Available Machines: %d; # Available Specific Machines: %s; # Locked Machines: %d; # Total Machines: %d;",

--- a/lib/cuckoo/core/scheduler.py
+++ b/lib/cuckoo/core/scheduler.py
@@ -857,7 +857,7 @@ class Scheduler:
                 specific_pending_task_counts[tag.name] += 1
             specific_pending_task_counts[task.platform] += 1
 
-        log.warning(
+        log.debug(
             "# Pending Tasks: %d; # Specific Pending Tasks: %s; # Available Machines: %d; # Available Specific Machines: %s; # Locked Machines: %d; # Total Machines: %d;",
             self.db.count_tasks(status=TASK_PENDING),
             dict(specific_pending_task_counts),

--- a/modules/machinery/az.py
+++ b/modules/machinery/az.py
@@ -519,7 +519,7 @@ class Azure(Machinery):
                 # Start it and forget about it
                 threading.Thread(
                     target=self._thr_scale_machine_pool,
-                    args=(self.options.az.scale_sets[vmss_name].tag, True if platform else False),
+                    args=(self.options.az.scale_sets[vmss_name].pool_tag, True if platform else False),
                 ).start()
 
         return base_class_return_value

--- a/modules/machinery/az.py
+++ b/modules/machinery/az.py
@@ -507,6 +507,7 @@ class Azure(Machinery):
         @param machine_id: the name of the machine to be acquired
         @param platform: the platform of the machine's operating system to be acquired
         @param tags: any tags that are associated with the machine to be acquired
+        @param arch: the architecture of the operating system
         @return: dict representing machine object from DB
         """
         base_class_return_value = super(Azure, self).acquire(machine_id=machine_id, platform=platform, tags=tags, arch=arch)

--- a/modules/machinery/az.py
+++ b/modules/machinery/az.py
@@ -129,7 +129,7 @@ class Azure(Machinery):
                 for key, value in scale_set_opts.items():
                     if value and isinstance(value, str):
                         scale_set_opts[key] = value.strip()
-                
+
                 # Insert the scale_set_opts into the module.scale_sets attribute
                 mmanager_opts["scale_sets"][scale_set_id] = scale_set_opts
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -207,7 +207,7 @@ class TestAnalysisManager:
             def availables(self):
                 return True
 
-            def acquire(self, machine_id, platform, tags):
+            def acquire(self, machine_id, platform, tags, arch):
                 class mock_acquire:
                     name = "mock_mach"
                     label = "mock_label"
@@ -223,7 +223,14 @@ class TestAnalysisManager:
             platform = "plat"
 
         class mock_tags:
-            tags = "tags"
+            class mock_tag:
+                def __init__(self, name):
+                    self.name = name
+
+            tags = [mock_tag("tag1"), mock_tag("tag2")]
+            def __iter__(self):
+                for tag in self.tags:
+                    yield tag
 
         class mock_arch:
             arch = "x64"

--- a/utils/cleaners.py
+++ b/utils/cleaners.py
@@ -36,6 +36,7 @@ log = logging.getLogger(__name__)
 
 cuckoo = Config()
 repconf = Config("reporting")
+webconf = Config("web")
 resolver_pool = ThreadPool(50)
 atexit.register(resolver_pool.close)
 
@@ -66,6 +67,8 @@ def connect_to_es():
 
 def is_reporting_db_connected():
     try:
+        if not webconf.web_reporting.enabled:
+            return True
         if repconf.mongodb.enabled:
             results_db = connect_to_mongo()[mdb]
             # Database objects do not implement truth value testing or bool(). Please compare with None instead: database is not None

--- a/utils/db_migration/versions/2_3_3_expand_error_message.py
+++ b/utils/db_migration/versions/2_3_3_expand_error_message.py
@@ -1,0 +1,27 @@
+# Copyright (C) 2010-2015 Cuckoo Foundation.
+# This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
+# See the file 'docs/LICENSE' for copying permission.
+
+"""2.3.3 expand error message
+
+Revision ID: 02af0b0ec686
+Revises: 8537286ff4d5
+Create Date: 2022-07-28 18:46:00.169029
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '02af0b0ec686'
+down_revision = '8537286ff4d5'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.alter_column("errors", "message", existing_type=sa.String(length=255), type_=sa.String(length=512), existing_nullable=True)
+
+
+def downgrade():
+    op.alter_column("errors", "message", existing_type=sa.String(length=512), type_=sa.String(length=255), existing_nullable=True)
+

--- a/utils/db_migration/versions/2_3_3_expand_error_message.py
+++ b/utils/db_migration/versions/2_3_3_expand_error_message.py
@@ -19,9 +19,9 @@ import sqlalchemy as sa
 
 
 def upgrade():
-    op.alter_column("errors", "message", existing_type=sa.String(length=255), type_=sa.String(length=512), existing_nullable=True)
+    op.alter_column("errors", "message", existing_type=sa.String(length=255), type_=sa.String(length=1024), existing_nullable=True)
 
 
 def downgrade():
-    op.alter_column("errors", "message", existing_type=sa.String(length=512), type_=sa.String(length=255), existing_nullable=True)
+    op.alter_column("errors", "message", existing_type=sa.String(length=1024), type_=sa.String(length=255), existing_nullable=True)
 


### PR DESCRIPTION
The goal of this PR started out as being able to handle tasks that require machines with specific tags, but then it got WAY bigger!

Things that I have improved:
- `conf/az.conf`, `modules/machinery/az.py`
    - Added more configurations and abilities to the Azure machinery
        - Added ability to use different resource groups for the virtual network and the resources associated with sandboxing (virtual machine scale sets, disks, network interface cards, etc)
        - Added the ability to manually enter the number of cores for an instance type rather than programmatically finding this value
        - Added the ability to not reset the pool size of each virtual machine scale set when CAPE restarts
        - Added the ability to wait or not wait for victim agents when CAPE restarts
- `conf/web.conf`, `lib/cuckoo/common/web_utils.py`, `lib/cuckoo/core/database.py`
    - Added configurations to web.conf that will toggle the dynamic assignments of required machine platform and architecture for a task
- `lib/cuckoo/common/abstracts.py`, `lib/cuckoo/core/database.py`
    - Added ability to acquire/lock/list machines based on the architecture
- `lib/cuckoo/common/web_utils`
    - If a value representing a boolean is passed to the REST API, it can be `true`/`false`, `yes`/`no`, `on`/`off`, `0`/`1` and can be any case.
- `utils/db_migration/versions/2_3_3_expand_error_message.py`, `lib/cuckoo/core/database.py`
    - Changed the size of the Error table `message` field because it could not contain the `CuckooGuestCriticalTimeout` error
        - Created a migration script with `alembic`
        - Updated the `SCHEMA_VERSION` of the `database.py` file
- `lib/cuckoo/core/scheduler.py`, `lib/cuckoo/core/database.py`
    - Refactored the way that tasks are assigned to machines. The reason behind this is because the original way of doing this was to iterate through available machines and then determine if there was a task that matched up with a machine. This logic is flawed because it is inefficient - we should be iterating through pending tasks rather than available machines. My solution:
        - Use a `is_relevant_machine_available` method that determines if a machine is relevant to a task and available to be assigned
        - Reworked the `fetch` method into `fetch_task` for tasks that do not require a VM. This really simplifies the logic for this method.
- `lib/cuckoo/core/database.py`
    - In the `guest_stop` method, we should check if the guest exists before trying to shut it down. This can occur in dynamic machineries such as `az` or `aws`.
    - Modified the logic of `list_machines` so that you can also filter by `locked` as `True`/`False`, machine label and the machine architecture
    - Improved the logging in `lock_machine` to include the selection criteria that was attempted
    - Just like in Cuckoo, `get_available_machines` now joins on `tags`
    - Added `options_not_like` in `list_tasks` since this is a way that we can replicate the use of `not_("node=")` in the original `fetch` method https://github.com/kevoreilly/CAPEv2/blob/master/lib/cuckoo/core/database.py#L815
    - Added the ability for a tuple representing the `order_by` keyword argument in `list_tasks`, so that we can pass multiple items to `list_tasks` to order tasks by
- `lib/cuckoo/core/plugins.py`
    - Improving exception logging
- `lib/cuckoo/core/resultserver.py`
    - Nitpick here for consistency across logs
- `lib/cuckoo/core/scheduler.py`
    - In the `check_file` method, we should check if sample exists before trying to access it's `sha256` attribute.
    - Before calling `acquire`, determine which task tags are the architecture and which are just tags, and then pass these values to `acquire`
    - Improve logging by detailing what the task requires if it has been selected off of the stack and there is no machine available yet
    - Just like in Cuckoo, add exception clause for the `CuckooGuestCriticalTimeout` error that will unlock the machine
    - Improved the periodic log so that it includes details about tasks and machines that are useful in determining why tasks are not being pulled off of the stack
- `modules/machinery/az.py`
    - Check if the `number_of_new_cpus_available` according to the quota is less than 0, and if so, set the minimum `number_of_relevant_machines_required`. This was causing errors when the 5 VM buffer was too close to the limit.
    - Improving the logging of exceptions
- `tests/test_scheduler.py`
    - Fixing test for `acquire` and `mock_tags`
- `utils/cleaners.py`
    - If both mongodb and elasticsearch are disabled, pending tasks were unable to be deleted using this utility, so check if web reporting is enabled first.