### PR TITLE
Use runserver_plus for web so that we can see exceptions

### DIFF
--- a/docs/book/src/usage/dist.rst
+++ b/docs/book/src/usage/dist.rst
@@ -19,7 +19,7 @@ Starting the Distributed REST API
 
 The Distributed REST API requires a few commandline options in order to run::
 
-    $ cd /opt/CAPEv2/web && python3 manage.py runserver 0.0.0.0:8000
+    $ cd /opt/CAPEv2/web && python3 manage.py runserver_plus 0.0.0.0:8000 --traceback --keep-meta-shutdown
 
 
 RESTful resources

--- a/docs/book/src/usage/web.rst
+++ b/docs/book/src/usage/web.rst
@@ -78,13 +78,13 @@ Usage
 To start the web interface, you can simply run the following command
 from the ``web/`` directory::
 
-    $ python3 manage.py runserver
+    $ python3 manage.py runserver_plus --traceback --keep-meta-shutdown
 
 If you want to configure the web interface as listening for any IP on a
 specified port, you can start it with the following command (replace PORT
 with the desired port number)::
 
-    $ python3 manage.py runserver 0.0.0.0:PORT
+    $ python3 manage.py runserver_plus 0.0.0.0:PORT --traceback --keep-meta-shutdown
 
 You can serve CAPE's web interface using WSGI interface with common web servers:
 Apache, Nginx, Unicorn, and so on.

--- a/supervisor.conf
+++ b/supervisor.conf
@@ -10,7 +10,7 @@ stderr_logfile=/var/log/supervisor/cuckoo.err.log
 stdout_logfile=/var/log/supervisor/cuckoo.out.log
 
 [program:web]
-command=python3 manage.py runserver 0.0.0.0:8000 --insecure
+command=python3 manage.py runserver_plus 0.0.0.0:8000 --traceback --keep-meta-shutdown
 directory=/opt/CAPEv2/web
 user=cape
 priority=500

--- a/systemd/cape-web.service
+++ b/systemd/cape-web.service
@@ -6,7 +6,7 @@ After=cape-rooter.service
 
 [Service]
 WorkingDirectory=/opt/CAPEv2/web
-ExecStart=/usr/bin/python3 -m poetry run python manage.py runserver 0.0.0.0:8000
+ExecStart=/usr/bin/python3 -m poetry run python manage.py runserver_plus 0.0.0.0:8000 --traceback --keep-meta-shutdown
 User=cape
 Group=cape
 Restart=always

--- a/web/web/settings.py
+++ b/web/web/settings.py
@@ -94,7 +94,7 @@ ADMIN = web_cfg.admin.enabled
 ANON_VIEW = web_cfg.general.anon_viewable
 
 # If false run next command
-# python3 manage.py runserver 0.0.0.0:8000 --insecure
+# python3 manage.py runserver_plus 0.0.0.0:8000 --traceback --keep-meta-shutdown
 DEBUG = True
 
 # Database settings. We don't need it.
@@ -223,7 +223,7 @@ X_FRAME_OPTIONS = "DENY"
 
 ROOT_URLCONF = "web.urls"
 
-# Python dotted path to the WSGI application used by Django's runserver.
+# Python dotted path to the WSGI application used by Django's runserver_plus.
 WSGI_APPLICATION = "web.wsgi.application"
 
 INSTALLED_APPS = [

--- a/web/web/wsgi.py
+++ b/web/web/wsgi.py
@@ -7,7 +7,7 @@ WSGI config for web project.
 
 This module contains the WSGI application used by Django's development server
 and any production WSGI deployments. It should expose a module-level variable
-named ``application``. Django's ``runserver`` and ``runfcgi`` commands discover
+named ``application``. Django's ``runserver_plus`` and ``runfcgi`` commands discover
 this application via the ``WSGI_APPLICATION`` setting.
 
 Usually you will have the standard Django WSGI application here, but it also


### PR DESCRIPTION
We are importing the `django-extensions` package, which provides `runserver_plus`. This module allows us to see the stacktraces for REST exceptions, which are incredibly useful compared to not having them.

The --keep-meta-shutdown is to address this bug for older versions of Python3 https://stackoverflow.com/questions/72166259/werkzeug-server-is-shutting-down-in-django-application