### PR TITLE
fix: duplicate signatures under same TTP ID

### DIFF
--- a/modules/reporting/mitre.py
+++ b/modules/reporting/mitre.py
@@ -13,7 +13,7 @@ class MITRE_TTPS(Report):
         attck = {}
         ttp_dict = {}
         for ttp in results["ttps"]:
-            ttp_dict.setdefault(ttp["ttp"], []).append(ttp["signature"])
+            ttp_dict.setdefault(ttp["ttp"], set()).add(ttp["signature"])
         try:
             for technique in sorted(self.mitre.enterprise.techniques, key=lambda x: x.id):
                 if technique.id in list(ttp_dict.keys()):
@@ -23,7 +23,7 @@ class MITRE_TTPS(Report):
                                 "t_id": technique.id,
                                 "ttp_name": technique.name,
                                 "description": technique.description,
-                                "signature": ttp_dict[technique.id],
+                                "signature": list(ttp_dict[technique.id]),
                             }
                         )
             if attck:


### PR DESCRIPTION
Fixes the following bug:
![brave_pn2sj3RcCl](https://user-images.githubusercontent.com/29896527/182104633-dc413f42-8bc9-4c5d-9548-0df9628812c3.png)

Apologies for not fixing this bug earlier, my deployment of CAPE did not encounter this error.
