### PR TITLE
Fix regression in VM selection.

### DIFF
--- a/lib/cuckoo/core/database.py
+++ b/lib/cuckoo/core/database.py
@@ -947,6 +947,21 @@ class Database(object, metaclass=Singleton):
         finally:
             session.close()
 
+    @staticmethod
+    def filter_machines_by_arch(machines, arch):
+        """ Add a filter to the given query for the architecture of the machines.
+        Allow x64 machines to be returned when requesting x86.
+        """
+        if arch:
+            if arch == "x86":
+                # Prefer x86 machines over x64 if x86 is what was requested.
+                machines = machines.filter(Machine.arch.in_(("x64", "x86"))).order_by(
+                    Machine.arch.desc()
+                )
+            else:
+                machines = machines.filter_by(arch=arch)
+        return machines
+
     @classlock
     def list_machines(self, locked=None, label=None, platform=None, tags=[], arch=None):
         """Lists virtual machines.
@@ -961,8 +976,7 @@ class Database(object, metaclass=Singleton):
                 machines = machines.filter_by(label=label)
             if platform:
                 machines = machines.filter_by(platform=platform)
-            if arch:
-                machines = machines.filter_by(arch=arch)
+            machines = self.filter_machines_by_arch(machines, arch)
             if tags:
                 for tag in tags:
                     machines = machines.filter(Machine.tags.any(name=tag))
@@ -1002,8 +1016,7 @@ class Database(object, metaclass=Singleton):
                 machines = machines.filter_by(label=label)
             if platform:
                 machines = machines.filter_by(platform=platform)
-            if arch:
-                machines = machines.filter_by(arch=arch)
+            machines = self.filter_machines_by_arch(machines, arch)
             if tags:
                 for tag in tags:
                     machines = machines.filter(Machine.tags.any(name=tag))

--- a/lib/cuckoo/core/database.py
+++ b/lib/cuckoo/core/database.py
@@ -949,15 +949,13 @@ class Database(object, metaclass=Singleton):
 
     @staticmethod
     def filter_machines_by_arch(machines, arch):
-        """ Add a filter to the given query for the architecture of the machines.
+        """Add a filter to the given query for the architecture of the machines.
         Allow x64 machines to be returned when requesting x86.
         """
         if arch:
             if arch == "x86":
                 # Prefer x86 machines over x64 if x86 is what was requested.
-                machines = machines.filter(Machine.arch.in_(("x64", "x86"))).order_by(
-                    Machine.arch.desc()
-                )
+                machines = machines.filter(Machine.arch.in_(("x64", "x86"))).order_by(Machine.arch.desc())
             else:
                 machines = machines.filter_by(arch=arch)
         return machines


### PR DESCRIPTION
https://github.com/kevoreilly/CAPEv2/pull/1020 introduced a regression
in selection of VM's for x86 tasks where it would no longer allow
selection of an x64 VM. This reintroduces that ability so that x86 tasks
will select x86 OR x64 machines, preferring x86 over x64.