### PR TITLE
fix: fix config errors with %%

### DIFF
--- a/analyzer/windows/lib/core/config.py
+++ b/analyzer/windows/lib/core/config.py
@@ -8,7 +8,7 @@ import configparser
 class Config:
     def __init__(self, cfg):
         """@param cfg: configuration file."""
-        config = configparser.ConfigParser(allow_no_value=True)
+        config = configparser.ConfigParser(allow_no_value=True, interpolation=None)
         config.read(cfg)
 
         for section in config.sections():


### PR DESCRIPTION
There was a typo in 41e0b3dcb9afce6d278c9a689d9f7a764eec0201, apologies.
Fixes configparser parsing of % symbol