### PR TITLE
Bug fix for fetch_task args and setting task to updated value

### DIFF
--- a/lib/cuckoo/core/scheduler.py
+++ b/lib/cuckoo/core/scheduler.py
@@ -838,8 +838,10 @@ class Scheduler:
                             break
                     if not relevant_machine_is_available:
                         task = None
+                    else:
+                        task = self.db.view_task(task.id)
                 else:
-                    task = self.db.fetch_task(False, categories=self.analyzing_categories, need_VM=False)
+                    task = self.db.fetch_task(self.analyzing_categories)
                 if task:
                     log.debug("Task #%s: Processing task", task.id)
                     self.total_analysis_count += 1


### PR DESCRIPTION
Two bug fixes in the scheduler:
- The `fetch_task` method takes only `categories` as an argument
- If there is a relevant machine available, we need to grab the task from the db after we update the status, instead of using the task prior to its status being set