### PR TITLE
Adding configurable default throttle limits

### DIFF
--- a/conf/api.conf
+++ b/conf/api.conf
@@ -1,6 +1,12 @@
 [api]
 # IP-based rate limiting
 ratelimit = yes
+
+# Default throttle limits at the user and subscription-level.
+# token_auth_enabled must be enabled
+default_user_ratelimit = 5/m
+default_subscription_ratelimit = 5/m
+
 # IP/Domain to be used for help page + callback URL's
 url = http://example.tld
 

--- a/docs/book/src/usage/api.rst
+++ b/docs/book/src/usage/api.rst
@@ -42,8 +42,9 @@ To generate a user authorization token:
 `CAPE throttling`_, aka requests per minute/hour/day.
 =====================================================
 
-* Requires authentication enabled in ``web.conf``
+* Requires token authentication enabled in ``api.conf``
 * Default 5/m
+* You can change the default throttle limits in ``api.conf``
 * To change the user limit go to django admin ``/admin/`` if you didn't change the path, and set the limit per user in the user profile at the bottom.
 
 .. _`CAPE throttling`: https://github.com/kevoreilly/CAPEv2/blob/master/web/apiv2/throttling.py

--- a/web/web/settings.py
+++ b/web/web/settings.py
@@ -365,8 +365,8 @@ if api_cfg.api.token_auth_enabled:
         "DEFAULT_PERMISSION_CLASSES": ("rest_framework.permissions.IsAuthenticated",),
         "DEFAULT_THROTTLE_CLASSES": ["rest_framework.throttling.UserRateThrottle", "apiv2.throttling.SubscriptionRateThrottle"],
         "DEFAULT_THROTTLE_RATES": {
-            "user": "5/m",
-            "subscription": "5/m",
+            "user": api_cfg.api.default_user_ratelimit,
+            "subscription": api_cfg.api.default_subscription_ratelimit,
         },
     }
 


### PR DESCRIPTION
Even if the `ratelimit` value was disabled, the default throttle limit was blocking requests. This value should be configurable for those who do want to adjust limits when using token-based auth.