### PR TITLE
Adding the mark_call method from Cuckoo

### DIFF
--- a/lib/cuckoo/common/abstracts.py
+++ b/lib/cuckoo/common/abstracts.py
@@ -759,6 +759,11 @@ class Signature:
         self.machinery_conf = machinery_conf
         self.matched = False
 
+        # These are set during the iteration of evented signatures
+        self.pid = None
+        self.cid = None
+        self.call = None
+
     def statistics_custom(self, pretime, extracted: bool = False):
         """
         Aux function for custom stadistics on signatures

--- a/lib/cuckoo/common/abstracts.py
+++ b/lib/cuckoo/common/abstracts.py
@@ -1517,6 +1517,24 @@ class Signature:
                     break
         return res
 
+    def mark_call(self, *args, **kwargs):
+        """Mark the current call as explanation as to why this signature
+        matched."""
+        mark = {
+            "type": "call",
+            "pid": self.pid,
+            "cid": self.cid,
+            "call": self.call,
+        }
+
+        if args or kwargs:
+            log.warning(
+                "You have provided extra arguments to the mark_call() method "
+                "which does not support doing so."
+            )
+
+        self.data.append(mark)
+
     def add_match(self, process, type, match):
         """Adds a match to the signature data.
         @param process: The process triggering the match.

--- a/lib/cuckoo/core/plugins.py
+++ b/lib/cuckoo/core/plugins.py
@@ -522,8 +522,9 @@ class RunSignatures:
             # Iterate calls and tell interested signatures about them.
             for proc in self.results["behavior"]["processes"]:
                 process_name = proc["process_name"]
+                process_id = proc["process_id"]
                 calls = proc.get("calls", [])
-                for call in calls:
+                for idx, call in enumerate(calls):
                     api = call.get("api")
                     sigs = self.api_sigs.get(api)
                     if sigs is None:
@@ -535,6 +536,11 @@ class RunSignatures:
                             self.call_for_processname.get(process_name, set()),
                         )
                     for sig in sigs:
+                        # Setting signature attributes per call
+                        sig.cid = idx
+                        sig.call = call
+                        sig.pid = process_id
+
                         if sig.matched:
                             continue
                         try:


### PR DESCRIPTION
The Signature.mark_call() method is something that exists in Cuckoo, and is critical in linking signatures to processes. It also provides evidence for why the signature was raised, based on the call.