### PR TITLE
Don't allow 7z to ask questions.

### DIFF
--- a/lib/cuckoo/common/integrations/file_extra_info.py
+++ b/lib/cuckoo/common/integrations/file_extra_info.py
@@ -577,6 +577,7 @@ def SevenZip_unpack(file: str, destination_folder: str, filetype: str, data_dict
                         file,
                         password,
                         f"-o{tempdir}",
+                        "-y",
                     ],
                     universal_newlines=True,
                 )


### PR DESCRIPTION
If there are multiple files with the same name but in different
directories within the archive, then using 'e' mode for 7z will prompt
the user with what to do. It blocks execution waiting for user input.
Use the "-y" flag to answer yes to all questions.