### PR TITLE
Update LokiBot to handling .x section not be xored

### DIFF
--- a/modules/processing/parsers/CAPE/LokiBot.py
+++ b/modules/processing/parsers/CAPE/LokiBot.py
@@ -127,12 +127,14 @@ def decoder(data):
     else:
         x = bytearray(img)
 
-    for i in range(len(x)):
-        x[i] ^= 0xFF
+    url_re = rb"https?:\/\/[a-zA-Z0-9\/\.:?\-_]+"
+    urls = re.findall(url_re, x)
+    if not urls:
+        for i in range(len(x)):
+            x[i] ^= 0xFF
 
-    temp = re.findall(rb"https?:\/\/[a-zA-Z0-9\/\.:?\-_]+", x)
-    for url in temp:
-        if url not in [b"http://www.ibsensoftware.com/", b""]:
+        temp = re.findall(url_re, x)
+        for url in temp:
             urls.append(url)
 
     # Try to decrypt onboard config


### PR DESCRIPTION
I found a new LokiBot sample, and it's .x section not be xored.  
You can test it by this sample: e6178c1a6ef5a907b991674d7b59f97fe62482bd038cb382fbbeae0ed038a453  