### PR TITLE
If a dead machine exists, we should delete from all tables

### DIFF
--- a/lib/cuckoo/common/abstracts.py
+++ b/lib/cuckoo/common/abstracts.py
@@ -361,6 +361,11 @@ class Machinery:
             waitme += 1
             current = self._status(label)
 
+    def delete_machine(self, name):
+        """Delete a virtual machine.
+        @param name: virtual machine name
+        """
+        _ = self.db.delete_machine(name)
 
 class LibVirtMachinery(Machinery):
     """Libvirt based machine manager.

--- a/lib/cuckoo/common/abstracts.py
+++ b/lib/cuckoo/common/abstracts.py
@@ -260,11 +260,15 @@ class Machinery:
         """
         return self.db.list_machines()
 
-    def availables(self):
-        """How many machines are free.
+    def availables(self, machine_id=None, platform=None, tags=None, arch=None):
+        """How many (relevant) machines are free.
+        @param machine_id: machine ID.
+        @param platform: machine platform.
+        @param tags: machine tags
+        @param arch: machine arch
         @return: free machines count.
         """
-        return self.db.count_machines_available()
+        return self.db.count_machines_available(machine_id=machine_id, platform=platform, tags=tags, arch=arch)
 
     def acquire(self, machine_id=None, platform=None, tags=None, arch=None):
         """Acquire a machine to start analysis.

--- a/lib/cuckoo/core/database.py
+++ b/lib/cuckoo/core/database.py
@@ -653,17 +653,21 @@ class Database(object, metaclass=Singleton):
             session.close()
 
     @classlock
-    def delete_machine(self, name):
+    def delete_machine(self, name) -> bool:
         """Delete a single machine entry from DB."""
 
         session = self.Session()
         try:
             machine = session.query(Machine).filter_by(name=name).first()
-            session.delete(machine)
-            session.commit()
-            return "success"
+            if machine:
+                session.delete(machine)
+                session.commit()
+                return True
+            else:
+                log.warning(f"{name} does not exist in the database.")
+                return False
         except SQLAlchemyError as e:
-            log.info("Database error deleting machine: %s", e)
+            log.debug("Database error deleting machine: %s", e)
             session.rollback()
         finally:
             session.close()

--- a/lib/cuckoo/core/scheduler.py
+++ b/lib/cuckoo/core/scheduler.py
@@ -369,6 +369,7 @@ class AnalysisManager(threading.Thread):
             if not unlocked:
                 machine_lock.release()
             log.error(str(e), extra={"task_id": self.task.id}, exc_info=True)
+            dead_machine = True
         except CuckooGuestError as e:
             if not unlocked:
                 machine_lock.release()
@@ -416,6 +417,7 @@ class AnalysisManager(threading.Thread):
                 # new guest when the task is being analyzed with another
                 # machine.
                 self.db.guest_remove(guest_log)
+                machinery.delete_machine(self.machine.name)
 
                 # Remove the analysis directory that has been created so
                 # far, as launch_analysis() is going to be doing that again.

--- a/lib/cuckoo/core/scheduler.py
+++ b/lib/cuckoo/core/scheduler.py
@@ -183,18 +183,26 @@ class AnalysisManager(threading.Thread):
         while True:
             machine_lock.acquire()
 
-            # In some cases it's possible that we enter this loop without
-            # having any available machines. We should make sure this is not
-            # such case, or the analysis task will fail completely.
-            if not machinery.availables():
-                machine_lock.release()
-                time.sleep(1)
-                continue
-
             # If the user specified a specific machine ID, a platform to be
             # used or machine tags acquire the machine accordingly.
             task_arch = next((tag.name for tag in self.task.tags if tag.name in ["x86", "x64"]), "")
             task_tags = [tag.name for tag in self.task.tags if tag.name != task_arch]
+
+            # In some cases it's possible that we enter this loop without
+            # having any available machines. We should make sure this is not
+            # such case, or the analysis task will fail completely.
+            if not machinery.availables(machine_id=self.task.machine, platform=self.task.platform, tags=task_tags, arch=task_arch):
+                machine_lock.release()
+                log.debug(
+                    "Task #%s: no machine available yet for machine '%s', platform '%s' or tags '%s'.",
+                    self.task.id,
+                    self.task.machine,
+                    self.task.platform,
+                    self.task.tags,
+                )
+                time.sleep(1)
+                continue
+
             machine = machinery.acquire(machine_id=self.task.machine, platform=self.task.platform, tags=task_tags, arch=task_arch)
 
             # If no machine is available at this moment, wait for one second and try again.

--- a/modules/machinery/az.py
+++ b/modules/machinery/az.py
@@ -458,11 +458,7 @@ class Azure(Machinery):
                 with reimage_lock:
                     label_in_reimage_vm_list = label in [f"{vm['vmss']}_{vm['id']}" for vm in reimage_vm_list]
         else:
-            self._delete_machine_from_db(label)
-            with vms_currently_being_deleted_lock:
-                vms_currently_being_deleted.append(label)
-            with delete_lock:
-                delete_vm_list.append({"vmss": vmss_name, "id": instance_id, "time_added": time.time()})
+            self.delete_machine(label)
 
     def availables(self, label=None, platform=None, tags=None):
         if all(param is None for param in [label, platform, tags]):
@@ -647,30 +643,21 @@ class Azure(Machinery):
         for machine in self.db.list_machines():
             # If machine entry in database is part of VMSS but machine in VMSS does not exist, delete
             if vmss_name in machine.label and machine.label not in vmss_vm_names:
-                self._delete_machine_from_db(machine.label)
+                self.delete_machine(machine.label, delete_from_vmss=False)
 
-    def _delete_machine_from_db(self, machine_name):
+    def delete_machine(self, label, delete_from_vmss=True):
         """
-        Implementing machine deletion from Cuckoo's database.
-        This was not implemented in database.py, so implemented here in the machinery
-        TODO: move this method to database.py
-        @param machine_name: the name of the machine to be deleted
-        @return: End method call
+        Overloading abstracts.py:delete_machine()
         """
-        session = self.db.Session()
-        try:
-            machine = session.query(Machine).filter_by(label=machine_name).first()
-            if machine:
-                session.delete(machine)
-                session.commit()
-            else:
-                log.warning(f"{machine_name} does not exist in the database.")
-        except SQLAlchemyError as exc:
-            log.debug(f"Database error removing machine: '{exc}'.")
-            session.rollback()
-            return
-        finally:
-            session.close()
+        _ = super(Azure, self).delete_machine(label)
+
+        if delete_from_vmss:
+            vmss_name, instance_id = label.split("_")
+            with vms_currently_being_deleted_lock:
+                vms_currently_being_deleted.append(label)
+            with delete_lock:
+                delete_vm_list.append({"vmss": vmss_name, "id": instance_id, "time_added": time.time()})
+
 
     @staticmethod
     def _thr_wait_for_ready_machine(machine_name, machine_ip):
@@ -1256,7 +1243,7 @@ class Azure(Machinery):
                         with delete_lock:
                             delete_vm_list.append({"vmss": vmss_to_reimage, "id": instance_id, "time_added": time.time()})
 
-                    self._delete_machine_from_db(f"{vmss_to_reimage}_{instance_id}")
+                    self.delete_machine(f"{vmss_to_reimage}_{instance_id}", delete_from_vmss=False)
                     vms_currently_being_reimaged.remove(f"{vmss_to_reimage}_{instance_id}")
                     instance_ids.remove(instance_id)
 
@@ -1274,11 +1261,7 @@ class Azure(Machinery):
                     )
                     # That sucks, now we have to delete each one
                     for instance_id in instance_ids:
-                        self._delete_machine_from_db(f"{vmss_to_reimage}_{instance_id}")
-                        with vms_currently_being_deleted_lock:
-                            vms_currently_being_deleted.append(f"{vmss_to_reimage}_{instance_id}")
-                        with delete_lock:
-                            delete_vm_list.append({"vmss": vmss_to_reimage, "id": instance_id, "time_added": time.time()})
+                        self.delete_machine(f"{vmss_to_reimage}_{instance_id}")
                     break
                 time.sleep(2)
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -204,7 +204,7 @@ class TestAnalysisManager:
 
     def test_acquire_machine(self, setup_machinery, setup_machine_lock):
         class mock_machinery:
-            def availables(self):
+            def availables(self, machine_id, platform, tags, arch):
                 return True
 
             def acquire(self, machine_id, platform, tags, arch):


### PR DESCRIPTION
- `abstracts.py`
    - Added a `delete_machine` method to the Machinery class
    - Add logic to `availables` method so that relevant available machines can be counted
- `database.py`
    - Slight modifications to the `delete_machine()` method
        - Return True if machine exists and was deleted. If machine does not exist, return False
        - The only use of this method elsewhere is https://github.com/kevoreilly/CAPEv2/blob/40c2624ed2d938dc23cc8129f53236bba1350eb7/utils/dist.py#L1341
    - Add ability for `count_machines_available()` to find specific machines based on label, platform, tags, or arch
- `scheduler.py`
    - Set `dead_machine = True` if the guest timed out to start when assigned a task
    - Since the machine is dead, we should delete the VM from the `machines` table as well as the `guests` 
table, so that the machine cannot be assigned again in the future
    - Before we acquire a machine, we should check if there is a relevant available machine. This comes into play after a dead machine is deleted from the DB and a task's analysis has already been launched.
- `az.py`
    - Use the overload of `delete_machine()` to delete the VM from the database table as well as from the virtual machine scale set
    - Use the overload of `availables()` to check if a virtual machine scale set is in the "wait" phase


Currently testing this in production