### PR TITLE
changed STAP.py to call self.stop to finish module and upload log

### DIFF
--- a/analyzer/linux/modules/auxiliary/stap.py
+++ b/analyzer/linux/modules/auxiliary/stap.py
@@ -70,6 +70,9 @@ class STAP(Auxiliary):
 
         stap_stop = timeit.default_timer()
         log.info("STAP aux module startup took %.2f seconds", stap_stop - stap_start)
+
+        self.stop()
+
         return True
 
     def stop(self):
@@ -83,4 +86,4 @@ class STAP(Auxiliary):
         except Exception as e:
             log.warning("Exception killing stap: %s", e)
 
-        upload_to_host("stap.log", "stap/stap.log", False)
+        upload_to_host("stap.log", "stap/stap.log", True)


### PR DESCRIPTION
the STAP module should call self.stop() before finishing self.run() to ensure the process is terminated and to upload the stap.log. If this is not done, the stap.log will not be collected because it is ignored under the FileCollector module.