### PR TITLE
Enable packet forwarding for IPv4

### DIFF
--- a/installer/cape2.sh
+++ b/installer/cape2.sh
@@ -813,6 +813,11 @@ EOF
         echo "net.bridge.bridge-nf-call-arptables = 0";
     } >> /etc/sysctl.conf
 
+    # enable packet forwarding for IPv4
+    if ! grep -q -E '^net.ipv4.ip_forward=1' /etc/sysctl.conf; then
+        echo "net.ipv4.ip_forward=1" >> /etc/sysctl.conf
+    fi
+
     sudo modprobe br_netfilter
     sudo sysctl -p
 


### PR DESCRIPTION
Always need to enable ip forwarding, so put it in the installation script.  