### PR TITLE
Updating scheduler/database to improve the time a machine is locked for

### DIFF
--- a/lib/cuckoo/core/database.py
+++ b/lib/cuckoo/core/database.py
@@ -1107,7 +1107,7 @@ class Database(object, metaclass=Singleton):
             if tags:
                 for tag in tags:
                     machines = machines.filter(Machine.tags.any(name=tag))
-            return machines.count()
+            return machines.session.execute(machines.statement.with_only_columns([func.count()]).order_by(None)).scalar()
         except SQLAlchemyError as e:
             log.debug("Database error counting machines: %s", e)
             return 0

--- a/lib/cuckoo/core/scheduler.py
+++ b/lib/cuckoo/core/scheduler.py
@@ -318,7 +318,7 @@ class AnalysisManager(threading.Thread):
         # Acquire analysis machine.
         try:
             self.acquire_machine()
-            # Mark the selected analysis machine in the database as started.
+            # Set task VM and mark the selected analysis machine in the database as started.
             guest_log = self.db.set_task_vm_and_guest_start(self.task.id, self.machine.name, self.machine.label, self.machine.id, machinery.__class__.__name__)
         # At this point we can tell the ResultServer about it.
         except CuckooOperationalError as e:

--- a/lib/cuckoo/core/scheduler.py
+++ b/lib/cuckoo/core/scheduler.py
@@ -790,7 +790,7 @@ class Scheduler:
 
         # This loop runs forever.
         while self.running:
-            time.sleep(1)
+
             # Wait until the machine lock is not locked. This is only the case
             # when all machines are fully running, rather that about to start
             # or still busy starting. This way we won't have race conditions


### PR DESCRIPTION
Something that I've noticed in the following environment:
- you have ~100 clients that submit tasks and poll until analysis completion,
- you have 100 machines that are eligible for all tasks
- each analysis runs for ~2 minutes

The logic in the `scheduler.py` with the `machine_lock` prevents 100 machines to be assigned a task, and reaches an equilibrium of ~50 tasks in the pending queue with ~30-50 machines in use. Here is why:
- It takes ~2 seconds for a task to be assigned to a machine, and the majority of this time is spent waiting to acquire the `machine_lock` https://github.com/kevoreilly/CAPEv2/blob/master/lib/cuckoo/core/scheduler.py#L184
    - Therefore every ten seconds, ~5 tasks are *always* assigned to a machine
- Analyses complete periodically, depending on the file type
    - Every ten seconds, >5 tasks are completed and machines are freed up

My proposition in this PR:
- Speed up the time that a `machine_lock` is acquired for by moving stuff that isn't required outside of the time when the `machine_lock` is locked.
    - Moving the `route_network` method does not need to be in this section and takes a bit of time, so that cuts the `machine_lock` blocking time.
    - Merging the `guest_start` and `set_task_vm` methods into one since both methods commit & refresh the DB for a Task row. This speeds up the blocking time a bit.
- Remove the time to sleep time between scheduler loops. This results in more DB calls, but removes an arbitrary sleep in the loop. There may be a way here to avoid sleeping in a smarter way? Any input is welcome.

Since the `availables()` method is called every iteration of the scheduler loop, the `<query>.count()` method in SQLAlchemy is known to be slow, so here is a thread talking about a way to speed it up: https://gist.github.com/hest/8798884

These modifications help a bit, sometimes 12 tasks are assigned within a 10 second period... which is great BUT I think there is a way to improve the use of the `machine_lock` usage. Maybe with semaphores? I'm not sure...


Maybe something smart like a bounded semaphore that can be acquired X times where X is the number of relevant available machines?