### PR TITLE
ensure JsonDump run after the SubmitCAPE

### DIFF
--- a/modules/reporting/jsondump.py
+++ b/modules/reporting/jsondump.py
@@ -20,6 +20,9 @@ except ImportError:
 class JsonDump(Report):
     """Saves analysis results in JSON format."""
 
+    # ensure we run after the SubmitCAPE
+    order = 10
+
     def default(self, obj):
         if isinstance(obj, bytes):
             try:


### PR DESCRIPTION
When I submit a file, it triggered automatically submitting sub task, but I can not find "CAPE_children" in its report.json.  
The reason is JsonDump run before SubmitCAPE.  
Add order can fix it.  