### PR TITLE
Fixing HTTP path parsing

### DIFF
--- a/modules/processing/network.py
+++ b/modules/processing/network.py
@@ -541,10 +541,16 @@ class Pcap:
             if entry["port"] != 80 and ":" not in netloc:
                 netloc += f":{entry['port']}"
 
-            entry["data"] = convert_to_printable(tcpdata)
-            entry["uri"] = convert_to_printable(urlunparse(("http", netloc, http.uri, None, None, None)))
+            # Sometimes the host is found inside the path in the HTTP headers. When that happens, parse the host outside of the path.
+            path = http.uri
+            if netloc and netloc in http.uri:
+                path = http.uri.split(netloc)[1]
+            elif entry["host"] and entry["host"] in http.uri:
+                path = http.uri.split(entry["host"])[1]
+
+            entry["uri"] = convert_to_printable(urlunparse(("http", netloc, path, None, None, None)))
             entry["body"] = convert_to_printable(http.body)
-            entry["path"] = convert_to_printable(http.uri)
+            entry["path"] = convert_to_printable(path)
             entry["user-agent"] = convert_to_printable(http.headers["user-agent"]) if "user-agent" in http.headers else ""
             entry["version"] = convert_to_printable(http.version)
             entry["method"] = convert_to_printable(http.method)


### PR DESCRIPTION
The CAPE version of https://github.com/cuckoosandbox/cuckoo/pull/3199

This sample https://www.virustotal.com/gui/file/a076938fa168d283115525aebeb972f8eba151566a82e06503c23e0d95c4dffa when run on Win7x64 calls out to http[://]208[.]67[.]105[.]179/damianozx[.]exe on port 8080. 

The `tcpdata` for this network call (https://github.com/kevoreilly/CAPEv2/blob/master/modules/processing/network.py#L515) looks like this:
```
b'GET http[://]208[.]67[.]105[.]179/damianozx[.]exe HTTP/1.1\r\nAccept: */*\r\nAccept-Encoding: gzip, deflate\r\nUser-Agent: Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.1; WOW64; Trident/7.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C; .NET4.0E)\r\nHost: 208[.]67[.]105[.]179\r\nProxy-Connection: Keep-Alive\r\n\r\n'
```

As you can see, the host is found within the "URI" portion of "GET <URI>" where the "URI" is supposed to be just the path, in this case "/damianozx[.]exe". When these components get put together using `urlunparse` (https://github.com/kevoreilly/CAPEv2/blob/master/modules/processing/network.py#L545), the resulting URL looks like this http[://]208[.]67[.]105[.]179[:[8080/http[://]208[.]67[.]105[.]179/damianozx[.]exe which is obviously incorrect. 

We need to pop the host out of the path if it is in there. The `elif` is for when a non-80 port is used.