### PR TITLE
If evtx is enabled, collect windows logs

### DIFF
--- a/analyzer/windows/modules/auxiliary/evtx.py
+++ b/analyzer/windows/modules/auxiliary/evtx.py
@@ -229,5 +229,6 @@ class Evtx(Thread, Auxiliary):
         return False
 
     def stop(self):
-        self.collect_windows_logs()
+        if self.enabled:
+            self.collect_windows_logs()
         return True


### PR DESCRIPTION
Even if evtx was disabled in `auxiliary.conf`, evtx logs were collected. This is the fix.