### PR TITLE
Setting a default package if sflock throws an exception when identifying a file

### DIFF
--- a/lib/cuckoo/core/database.py
+++ b/lib/cuckoo/core/database.py
@@ -1595,7 +1595,13 @@ class Database(object, metaclass=Singleton):
             if not config and not only_extraction:
                 if not package:
                     f = SflockFile.from_path(file)
-                    tmp_package = sflock_identify(f)
+
+                    try:
+                        tmp_package = sflock_identify(f)
+                    except Exception as e:
+                        log.error(f"Failed to sflock_ident due to {e}")
+                        tmp_package = "cmd"
+
                     if tmp_package and tmp_package in sandbox_packages:
                         package = tmp_package
                     else:

--- a/lib/cuckoo/core/database.py
+++ b/lib/cuckoo/core/database.py
@@ -91,6 +91,7 @@ sandbox_packages = (
     "xslt",
     "Shellcode",
     "Shellcode_x64",
+    "generic",
 )
 
 log = logging.getLogger(__name__)
@@ -1600,7 +1601,7 @@ class Database(object, metaclass=Singleton):
                         tmp_package = sflock_identify(f)
                     except Exception as e:
                         log.error(f"Failed to sflock_ident due to {e}")
-                        tmp_package = "cmd"
+                        tmp_package = "generic"
 
                     if tmp_package and tmp_package in sandbox_packages:
                         package = tmp_package


### PR DESCRIPTION
If sflock fails to identify something because of a 3rd party package exception, the REST API returns a 500. But we should at least TRY to run this sample rather than not add it to the database at all.