### PR TITLE
Fixing paths in UWSGI setup

### DIFF
--- a/docs/book/src/usage/dist.rst
+++ b/docs/book/src/usage/dist.rst
@@ -281,7 +281,7 @@ Installation of "uwsgi"::
 
 It's better if you run "web" and "dist.py" as uwsgi application
 
-uwsgi config for dist.py - Paste the following into /opt/CAPE/utils/dist.ini::
+uwsgi config for dist.py - Found at ``/opt/CAPE/uwsgi/capedist.ini``::
 
         [uwsgi]
         ; you might need to adjust plugin-dir path for your system
@@ -317,11 +317,11 @@ uwsgi config for dist.py - Paste the following into /opt/CAPE/utils/dist.ini::
 To run your api with config just execute as::
 
     # WEBGUI is started by systemd as cape-web.service
-    $ uwsgi --ini /opt/CAPEv2/utils/dist.ini
+    $ uwsgi --ini /opt/CAPEv2/uwsgi/capedist.ini
 
 To add your application to auto start after boot, copy your config file to::
 
-    cp /opt/CAPEv2/utils/dist.ini /etc/uwsgi/apps-available/cape_dist.ini
+    cp /opt/CAPEv2/uwsgi/capedist.ini /etc/uwsgi/apps-available/cape_dist.ini
     ln -s /etc/uwsgi/apps-available/cape_dist.ini /etc/uwsgi/apps-enabled
 
     service uwsgi restart

--- a/docs/book/src/usage/web.rst
+++ b/docs/book/src/usage/web.rst
@@ -104,7 +104,7 @@ Instalation::
     # nginx is optional
     # sudo apt-get install uwsgi uwsgi-plugin-python nginx
 
-To enable ``uwsgi`` create ``/etc/uwsgi/apps-enabled/cape.ini``:
+To enable ``uwsgi`` copy ``/opt/CAPE/uwsgi/cape.ini`` to ``/etc/uwsgi/apps-enabled/cape.ini``:
 
 .. code-block:: python
 


### PR DESCRIPTION
Also, I was having difficulty running UWSGI initially because all the required dependencies for the REST API were installed using `poetry`, and the UWSGI config uses `python38` as the plugin (which doesn't have those dependencies installed). My work-around was to just `python38 -m pip install -r /opt/CAPEv2/requirements.txt`. Just something to consider.