### PR TITLE
Run all interesting files in an archive, adding udf support

### DIFF
--- a/lib/cuckoo/core/database.py
+++ b/lib/cuckoo/core/database.py
@@ -94,6 +94,7 @@ sandbox_packages = (
     "generic",
     "iso",
     "vhd",
+    "udf",
 )
 
 log = logging.getLogger(__name__)
@@ -1616,7 +1617,7 @@ class Database(object, metaclass=Singleton):
                             package = "regsvr"
                         elif "xlAutoOpen" in dll_exports:
                             package = "xls"
-                    if package in ["iso", "vhd"]:
+                    if package in ["iso", "udf", "vhd"]:
                         package = "archive"
 
                 # ToDo better solution? - Distributed mode here:


### PR DESCRIPTION
UDF identification dependent on the resolution of https://github.com/doomedraven/sflock/issues/25

In the meantime, for UDF files just force the use of the `archive` package when submitting the task.

This package update runs all interesting files as separate processes, similar to the DLL package with multiple exports.