### PR TITLE
fix suricata-update in crontab line added each time cape2.sh is executed

### DIFF
--- a/installer/cape2.sh
+++ b/installer/cape2.sh
@@ -509,7 +509,7 @@ function install_suricata() {
     # Download etupdate to update Emerging Threats Open IDS rules:
     pip3 install suricata-update
     mkdir -p "/etc/suricata/rules"
-    if ! crontab -l | grep -q '15 * * * * /usr/bin/suricata-update'; then
+    if ! crontab -l | grep -q -F '15 * * * * /usr/bin/suricata-update'; then
         crontab -l | { cat; echo "15 * * * * /usr/bin/suricata-update --suricata /usr/bin/suricata --suricata-conf /etc/suricata/suricata.yaml -o /etc/suricata/rules/ && /usr/bin/suricatasc -c reload-rules /tmp/suricata-command.socket &>/dev/null"; } | crontab -
     fi
     if [ -d /usr/share/suricata/rules/ ]; then


### PR DESCRIPTION
Grep is interpreting the "*" and it is not finding the line when it is already in the crontab. Adding -F flag to grep will avoid adding the suricata-update like multiple times to crontab. 

-F, --fixed-strings
          Interpret  PATTERN  as  a  list  of  fixed strings, separated by
          newlines, any of which is to be matched.  (-F  is  specified  by
          POSIX.)