### PR TITLE
Adding ps1 to exe_regex and bugfix for file_name in zip package

### DIFF
--- a/analyzer/windows/modules/packages/Unpacker_zip.py
+++ b/analyzer/windows/modules/packages/Unpacker_zip.py
@@ -104,7 +104,7 @@ class Unpacker_zip(Package):
     def start(self, path):
         root = os.environ["TEMP"]
         password = self.options.get("password")
-        exe_regex = re.compile(r"(\.exe|\.scr|\.msi|\.bat|\.lnk|\.js|\.jse|\.vbs|\.vbe|\.wsf)$", flags=re.IGNORECASE)
+        exe_regex = re.compile(r"(\.exe|\.scr|\.msi|\.bat|\.lnk|\.js|\.jse|\.vbs|\.vbe|\.wsf\.ps1)$", flags=re.IGNORECASE)
         dll_regex = re.compile(r"(\.dll|\.ocx)$", flags=re.IGNORECASE)
         zipinfos = self.get_infos(path)
         self.extract_zip(path, root, password, 0)

--- a/analyzer/windows/modules/packages/zip.py
+++ b/analyzer/windows/modules/packages/zip.py
@@ -118,13 +118,13 @@ class Zip(Package):
         password = self.options.get("password", "")
         appdata = self.options.get("appdata")
         root = os.environ["APPDATA"] if appdata else os.environ["TEMP"]
-        exe_regex = re.compile(r"(\.exe|\.dll|\.scr|\.msi|\.bat|\.lnk|\.js|\.jse|\.vbs|\.vbe|\.wsf)$", flags=re.IGNORECASE)
+        exe_regex = re.compile(r"(\.exe|\.dll|\.scr|\.msi|\.bat|\.lnk|\.js|\.jse|\.vbs|\.vbe|\.wsf|\.ps1)$", flags=re.IGNORECASE)
         zipinfos = self.get_infos(path)
         self.extract_zip(path, root, password, 0)
 
         file_name = self.options.get("file")
         # If no file name is provided via option, take the first file.
-        if file_name is None:
+        if not file_name:
             # No name provided try to find a better name.
             if not len(zipinfos):
                 raise CuckooPackageError("Empty ZIP archive")


### PR DESCRIPTION
To run a .ps1 file, the `.ps1` extension needs to be in the `exe_regex`. 

Also if you pass `file=` as a task option, the `file_name` is interpreted as `""`, rather than `None`. 