### PR TITLE
Specifying the exe that we want to use for analysis

### DIFF
--- a/analyzer/windows/modules/packages/applet.py
+++ b/analyzer/windows/modules/packages/applet.py
@@ -4,7 +4,7 @@
 
 import tempfile
 
-from lib.common.abstracts import Package
+from lib.common.abstracts import CuckooPackageError, Package
 
 
 class Applet(Package):
@@ -32,7 +32,11 @@ class Applet(Package):
         return file_path
 
     def start(self, path):
-        browser = self.get_path("browser")
+        try:
+            browser = self.get_path("firefox.exe")
+        except CuckooPackageError:
+            browser = self.get_path("iexplore.exe")
+
         class_name = self.options.get("class")
         html_path = self.make_html(path, class_name)
         return self.execute(browser, f'"{html_path}"', html_path)

--- a/analyzer/windows/modules/packages/chrome.py
+++ b/analyzer/windows/modules/packages/chrome.py
@@ -13,6 +13,6 @@ class Chrome(Package):
     ]
 
     def start(self, url):
-        chrome = self.get_path("Google Chrome")
+        chrome = self.get_path("chrome.exe")
         # pass the URL instead of a filename in this case
         return self.execute(chrome, f'"{url}"', url)

--- a/analyzer/windows/modules/packages/edge.py
+++ b/analyzer/windows/modules/packages/edge.py
@@ -9,5 +9,5 @@ class Edge(Package):
     ]
 
     def start(self, url):
-        edge = self.get_path("Microsoft Edge")
+        edge = self.get_path("msedge.exe")
         return self.execute(edge, f'"{url}"', url)

--- a/analyzer/windows/modules/packages/firefox.py
+++ b/analyzer/windows/modules/packages/firefox.py
@@ -13,6 +13,6 @@ class Firefox(Package):
     ]
 
     def start(self, url):
-        firefox = self.get_path("Mozilla Firefox")
+        firefox = self.get_path("firefox.exe")
         # pass the URL instead of a filename in this case
         return self.execute(firefox, f'"{url}"', url)

--- a/analyzer/windows/modules/packages/html.py
+++ b/analyzer/windows/modules/packages/html.py
@@ -18,7 +18,7 @@ class HTML(Package):
     ]
 
     def start(self, path):
-        iexplore = self.get_path("browser")
+        iexplore = self.get_path("iexplore.exe")
 
         # Travelling inside malware universe you should bring a towel with you.
         # If a file detected as HTML is submitted without a proper extension,

--- a/analyzer/windows/modules/packages/mht.py
+++ b/analyzer/windows/modules/packages/mht.py
@@ -14,7 +14,7 @@ class MHT(Package):
     ]
 
     def start(self, path):
-        iexplore = self.get_path("browser")
+        iexplore = self.get_path("iexplore.exe")
 
         # Travelling inside malware universe you should bring a towel with you.
         # If a file detected as HTML is submitted without a proper extension,

--- a/analyzer/windows/modules/packages/vawtrak.py
+++ b/analyzer/windows/modules/packages/vawtrak.py
@@ -16,7 +16,7 @@ class IE(Package):
     ]
 
     def start(self, path):
-        iexplore = self.get_path("Internet Explorer")
+        iexplore = self.get_path("iexplore.exe")
         # pass the URL instead of a filename in this case
         self.execute(iexplore, '"about:blank"', "about:blank")
 

--- a/analyzer/windows/modules/packages/vbejse.py
+++ b/analyzer/windows/modules/packages/vbejse.py
@@ -15,7 +15,7 @@ class VBSJSE(Package):
     ]
 
     def start(self, path):
-        wscript = self.get_path("WScript")
+        wscript = self.get_path("wscript.exe")
         # We are here bcz of no extension
         copyfile(path, f"{path}.vbe")
         copyfile(path, f"{path}.jse")

--- a/analyzer/windows/modules/packages/vbs.py
+++ b/analyzer/windows/modules/packages/vbs.py
@@ -18,7 +18,7 @@ class VBS(Package):
     ]
 
     def start(self, path):
-        wscript = self.get_path("WScript")
+        wscript = self.get_path("wscript.exe")
 
         # Check file extension.
         # If the file doesn't have the proper .vbs extension force it

--- a/analyzer/windows/modules/packages/wsf.py
+++ b/analyzer/windows/modules/packages/wsf.py
@@ -15,7 +15,7 @@ class WSF(Package):
     ]
 
     def start(self, path):
-        wscript = self.get_path("WScript")
+        wscript = self.get_path("wscript.exe")
         # Enforce the .wsf file extension as is required by wscript.
         path = check_file_extension(path, ".wsf")
         return self.execute(wscript, f'"{path}"', path)


### PR DESCRIPTION
There are several packages that weren't using the `get_path` method correctly, even before this PR https://github.com/kevoreilly/CAPEv2/commit/930c340ad7f14479a4779dabf3edbd6892139274. Now they should work correctly.