### PR TITLE
Updating the techniques used for reimaging and deleting, etc.

### DIFF
--- a/conf/az.conf
+++ b/conf/az.conf
@@ -88,7 +88,7 @@ overprovision = 0
 # such that we can perform bulk reimaging.
 wait_time_to_reimage = 15
 
-# This boolean value is used to indicate if we want to use Azure Spot instances rather than 
+# This boolean value is used to indicate if we want to use Azure Spot instances rather than
 # normal instances
 spot_instances = false
 
@@ -98,6 +98,12 @@ wait_for_agent_before_starting = true
 
 # This is the value of the DNS server that you want the scale sets to use
 dns_server_ip = <dns_server_ip>
+
+# This is the number of seconds that we should wait between checking if there are relevant tasks for a VMSS in the queue
+scale_down_polling_period = 1
+
+# This is switch used for machinery debugging/development, and should only be set to "true" in these scenarios
+just_start = false
 
 [cuckoo1]
 # The gallery image name to use when creating the virtual machine scale set.

--- a/lib/cuckoo/core/scheduler.py
+++ b/lib/cuckoo/core/scheduler.py
@@ -883,14 +883,22 @@ class Scheduler:
                 specific_pending_task_counts[task.platform] += 1
             if task.machine:
                 specific_pending_task_counts[task.machine] += 1
+        specific_locked_machine_counts = defaultdict(int)
+        for machine in self.db.list_machines(locked=True):
+            for tag in machine.tags:
+                if tag:
+                    specific_locked_machine_counts[tag.name] += 1
+            if machine.platform:
+                specific_locked_machine_counts[machine.platform] += 1
 
         log.debug(
-            "# Pending Tasks: %d; # Specific Pending Tasks: %s; # Available Machines: %d; # Available Specific Machines: %s; # Locked Machines: %d; # Total Machines: %d;",
+            "# Pending Tasks: %d; # Specific Pending Tasks: %s; # Available Machines: %d; # Available Specific Machines: %s; # Locked Machines: %d; # Specific Locked Machines: %s; # Total Machines: %d;",
             self.db.count_tasks(status=TASK_PENDING),
             dict(specific_pending_task_counts),
             self.db.count_machines_available(),
             dict(specific_available_machine_counts),
             len(self.db.list_machines(locked=True)),
+            dict(specific_locked_machine_counts),
             len(self.db.list_machines()),
         )
         threading.Timer(10, self._thr_periodic_log).start()


### PR DESCRIPTION
A few things here:
- Using the most up-to-date credential technique
- Adding a configurable option for the number of seconds to wait for a new relevant task before setting a machine pool to "delete" mode
- Adding a developer option that can skip reimaging / updating VMSS VMs
- Adding a "specific locked machines" log in the periodic log
- Using the most up-to-date clients for Compute and Network management, so modifying models and methods to keep up
- Using VMSS with Flexible orchestration rather than the default Uniform method
- Setting the Azure timeout for operations to 2 minutes instead of 5
- Refactoring the way we do reimaging and deleting from batch to individual now that we are using Flexible orchestration