### PR TITLE
ensure reject_hostports is a string

### DIFF
--- a/lib/cuckoo/core/scheduler.py
+++ b/lib/cuckoo/core/scheduler.py
@@ -531,7 +531,7 @@ class AnalysisManager(threading.Thread):
             if routing.routing.reject_segments != "none":
                 self.reject_segments = routing.routing.reject_segments
             if routing.routing.reject_hostports != "none":
-                self.reject_hostports = routing.routing.reject_hostports
+                self.reject_hostports = str(routing.routing.reject_hostports)
         elif self.route in vpns:
             self.interface = vpns[self.route].interface
             self.rt_table = vpns[self.route].rt_table


### PR DESCRIPTION
When reject_hostports is a single port, CAPE will turn it to a number. We need to ensure reject_hostports is a string. 