### PR TITLE
Adding note about archive usage

### DIFF
--- a/docs/book/src/usage/packages.rst
+++ b/docs/book/src/usage/packages.rst
@@ -28,6 +28,9 @@ The following is a list of the existing packages in alphabetical order:
 
     * ``archive``: used to run and analyze **archives such as ISO, VHD and anything else that 7-Zip can extract**.
 
+        *NB*: Passing ``file=`` as a task option will ensure that the entire archive is passed to the victim VM and extracted there, 
+        prior to executing files of interest within in the extracted folder.
+
         **Options**:
             * ``file``: specify the name of the file contained in the archive to execute. If none is specified, CAPE will try to execute *sample.exe*.
             * ``free`` *[yes/no]*: if enabled, no behavioral logs will be produced and the malware will be executed freely.


### PR DESCRIPTION
I've made a few talks recently regarding the increased presence of non-zip archive files being used by malicious actors in present day. My work on the `archive.py` package provides CAPE's best chance of detecting these samples and network IOCs. This note is to assist those who are using a client to submit files to CAPE that is not [Assemblyline ](https://cyber.gc.ca/en/tools-services/assemblyline).