### PR TITLE
Oversized PE trimming on submission

### DIFF
--- a/conf/web.conf
+++ b/conf/web.conf
@@ -28,6 +28,8 @@ disposable_domain_list = data/safelist/disposable_domain_list.txt
 
 [general]
 max_sample_size = 30000000
+# Try to trim huge binaries that bigger than max_sample_size or enable allow_ingore_size and specify that option
+enable_trim = no
 # Required to be enabled and option set to bypass_size_check=1
 allow_ignore_size = no
 # Number of results to show on webgui on search action

--- a/lib/cuckoo/common/integrations/parse_pe.py
+++ b/lib/cuckoo/common/integrations/parse_pe.py
@@ -217,6 +217,15 @@ class PortableExecutable:
 
         return None
 
+    def get_overlay_raw(self, pe: pefile.PE) -> int:
+        """Get information on the PE overlay
+        @return: overlay offset or None.
+        """
+        if not pe:
+            return None
+
+        return pe.sections[pe.FILE_HEADER.NumberOfSections-1].PointerToRawData + pe.sections[pe.FILE_HEADER.NumberOfSections-1].SizeOfRawData
+
     def get_overlay(self, pe: pefile.PE) -> dict:
         """Get information on the PE overlay
         @return: overlay dict or None.

--- a/lib/cuckoo/common/integrations/parse_pe.py
+++ b/lib/cuckoo/common/integrations/parse_pe.py
@@ -143,14 +143,17 @@ def IsPEImage(buf: bytes, size: int = False) -> bool:
 class PortableExecutable:
     """PE analysis."""
 
-    def __init__(self, file_path: str):
+    def __init__(self, file_path: str = False, data: bytes = False):
         """@param file_path: file path."""
         self.file_path = file_path
         self._file_data = None
         self.pe = None
         self.HAVE_PE = False
         try:
-            self.pe = pefile.PE(self.file_path)
+            if data:
+                self.pe = pefile.PE(data=data)
+            else:
+                self.pe = pefile.PE(self.file_path)
             self.HAVE_PE = True
         except Exception as e:
             log.error("PE type not recognised: %s", e)
@@ -217,14 +220,14 @@ class PortableExecutable:
 
         return None
 
-    def get_overlay_raw(self, pe: pefile.PE) -> int:
+    def get_overlay_raw(self) -> int:
         """Get information on the PE overlay
         @return: overlay offset or None.
         """
-        if not pe:
+        if not self.pe:
             return None
 
-        return pe.sections[pe.FILE_HEADER.NumberOfSections-1].PointerToRawData + pe.sections[pe.FILE_HEADER.NumberOfSections-1].SizeOfRawData
+        return self.pe.sections[self.pe.FILE_HEADER.NumberOfSections-1].PointerToRawData + self.pe.sections[self.pe.FILE_HEADER.NumberOfSections-1].SizeOfRawData
 
     def get_overlay(self, pe: pefile.PE) -> dict:
         """Get information on the PE overlay

--- a/lib/cuckoo/common/web_utils.py
+++ b/lib/cuckoo/common/web_utils.py
@@ -1263,19 +1263,30 @@ def process_new_task_files(request, samples, details, opt_filename, unique):
     for sample in samples:
         # Error if there was only one submitted sample and it's empty.
         # But if there are multiple and one was empty, just ignore it.
-        if not sample.size:
+        size = sample.size
+        data = sample.read()
+        if not size:
             details["errors"].append({sample.name: "You uploaded an empty file."})
             continue
-
         elif not web_cfg.general.allow_ignore_size and "ignore_size_check" not in details["options"]:
-            if sample.size > web_cfg.general.max_sample_size:
-                details["errors"].append(
-                    {
-                        sample.name: f"You uploaded a file that exceeds the maximum allowed upload size specified in conf/web.conf. Sample size is: {sample.size/float(1<<20):,.0f} Allowed size is:{web_cfg.general.max_sample_size/float(1<<20):,.0f} "
-                    }
-                )
-                continue
-
+            if size > web_cfg.general.max_sample_size:
+                if web_cfg.general.enable_trim and HAVE_PEFILE:
+                    try:
+                        pe = pefile.PE(data=data, fast_load=True)
+                        if pe:
+                            overlay_data_offset = pe.get_overlay_data_start_offset()
+                            if overlay_data_offset is not None:
+                                size = overlay_data_offset
+                            pe.close()
+                    except Exception as e:
+                        log.info(e)
+                if size > web_cfg.general.max_sample_size:
+                    details["errors"].append(
+                        {
+                            sample.name: f"You uploaded a file that exceeds the maximum allowed upload size specified in conf/web.conf. Sample size is: {sample.size/float(1<<20):,.0f} Allowed size is:{web_cfg.general.max_sample_size/float(1<<20):,.0f} "
+                        }
+                    )
+                    continue
         if opt_filename:
             filename = opt_filename
         else:
@@ -1283,7 +1294,7 @@ def process_new_task_files(request, samples, details, opt_filename, unique):
 
         # Moving sample from django temporary file to CAPE temporary storage to let it persist between reboot (if user like to configure it in that way).
         try:
-            path = store_temp_file(sample.read(), filename)
+            path = store_temp_file(data[:size], filename)
         except OSError:
             details["errors"].append(
                 {filename: "Your specified temp folder, disk is out of space. Clean some space before continue."}

--- a/lib/cuckoo/common/web_utils.py
+++ b/lib/cuckoo/common/web_utils.py
@@ -1272,7 +1272,6 @@ def process_new_task_files(request, samples, details, opt_filename, unique):
                 size = sample.size
                 if web_cfg.general.enable_trim and HAVE_PEFILE and IsPEImage(data):
                     try:
-                        # check if we deal with PE/DLL
                         pe = pefile.PE(data=sample.chunks().__next__(), fast_load=True)
                         if pe:
                             overlay_data_offset = pe.get_overlay_data_start_offset()

--- a/lib/cuckoo/common/web_utils.py
+++ b/lib/cuckoo/common/web_utils.py
@@ -1258,6 +1258,22 @@ def download_from_vt(vtdl, details, opt_filename, settings):
     return details
 
 
+def trim_sample(sample, first_chunk: bytes, size: int):
+    data = False
+    try:
+        pe = pefile.PE(data=first_chunk, fast_load=True)
+        if pe:
+            overlay_data_offset = pe.get_overlay_data_start_offset()
+            if overlay_data_offset is not None:
+                # print(f"Sample size was: {size/float(1<<20):,.0f} and now is {overlay_data_offset/float(1<<20):,.0f}")
+                size = overlay_data_offset
+                data = sample.read()[:size]
+            pe.close()
+    except Exception as e:
+        log.info(e)
+
+    return data, size
+
 def process_new_task_files(request, samples, details, opt_filename, unique):
     list_of_files = []
     for sample in samples:
@@ -1270,17 +1286,9 @@ def process_new_task_files(request, samples, details, opt_filename, unique):
         elif not web_cfg.general.allow_ignore_size and "ignore_size_check" not in details["options"]:
             if sample.size > web_cfg.general.max_sample_size:
                 size = sample.size
-                if web_cfg.general.enable_trim and HAVE_PEFILE and IsPEImage(data):
-                    try:
-                        pe = pefile.PE(data=sample.chunks().__next__(), fast_load=True)
-                        if pe:
-                            overlay_data_offset = pe.get_overlay_data_start_offset()
-                            if overlay_data_offset is not None:
-                                size = overlay_data_offset
-                                data = data[:size]
-                            pe.close()
-                    except Exception as e:
-                        log.info(e)
+                first_chunk = sample.chunks().__next__()
+                if web_cfg.general.enable_trim and HAVE_PEFILE and IsPEImage(first_chunk):
+                    data, size = trim_sample(sample, first_chunk, size)
                 if size > web_cfg.general.max_sample_size:
                     details["errors"].append(
                         {

--- a/lib/cuckoo/common/web_utils.py
+++ b/lib/cuckoo/common/web_utils.py
@@ -1258,17 +1258,18 @@ def download_from_vt(vtdl, details, opt_filename, settings):
     return details
 
 
-def trim_sample(data):
-    data = False
+def trim_sample(data, size):
     try:
         pe = pefile.PE(data=data, fast_load=True)
         if pe:
             data = pe.trim()
+            # print(f"Sample size was: {size/float(1<<20):,.0f} and now is {len(data)/float(1<<20):,.0f}")
             pe.close()
+            size = len(data)
     except Exception as e:
         log.info(e)
 
-    return data
+    return data, size
 
 def process_new_task_files(request, samples, details, opt_filename, unique):
     list_of_files = []
@@ -1283,7 +1284,8 @@ def process_new_task_files(request, samples, details, opt_filename, unique):
         elif not web_cfg.general.allow_ignore_size and "ignore_size_check" not in details["options"]:
             if size > web_cfg.general.max_sample_size:
                 if web_cfg.general.enable_trim and HAVE_PEFILE and IsPEImage(data):
-                    data = trim_sample(data)
+                    data, size = trim_sample(data, size)
+
                 if size > web_cfg.general.max_sample_size:
                     details["errors"].append(
                         {

--- a/lib/cuckoo/common/web_utils.py
+++ b/lib/cuckoo/common/web_utils.py
@@ -712,7 +712,7 @@ def download_file(**kwargs):
             cape=cape,
             user_id=kwargs.get("user_id"),
             username=username,
-            source_url=kwargs.get("source_url", False)
+            source_url=kwargs.get("source_url", False),
             # parent_id=kwargs.get("parent_id"),
             sample_parent_id=kwargs.get("sample_parent_id")
         )

--- a/modules/processing/parsers/CAPE/QakBot.py
+++ b/modules/processing/parsers/CAPE/QakBot.py
@@ -57,7 +57,7 @@ def parse_config(data):
                 config[CONFIG.get(k, k)] = datetime.datetime.fromtimestamp(int(v)).strftime("%H:%M:%S %d-%m-%Y")
             else:
                 k = k[-2:]
-                config[CONFIG.get(k, f"ukn_{k.decode()}")] = v
+                config[CONFIG.get(k.decode(), f"ukn_{k.decode()}")] = v
         except Exception:
             log.info("Failed to parse config entry: %s", entry)
 
@@ -94,22 +94,20 @@ def parse_binary_c2_2(data):
     """
     Parses the binary CNC block format introduced April'21
     """
-    c2_data = data
-
-    expected_sha1 = c2_data[:0x14]
-    c2_data = c2_data[0x14:]
-    actual_sha1 = hashlib.sha1(c2_data).digest()
+    expected_sha1 = data[:0x14]
+    data = data[0x14:]
+    actual_sha1 = hashlib.sha1(data).digest()
 
     if actual_sha1 != expected_sha1:
         log.error("Expected sha1: %s actual: %s", expected_sha1, actual_sha1)
         return
 
-    length = len(c2_data)
+    length = len(data)
 
     controllers = []
     for c2_offset in range(0, length, 7):
-        ip = socket.inet_ntoa(struct.pack("!L", struct.unpack(">I", c2_data[c2_offset + 1 : c2_offset + 5])[0]))
-        port = str(struct.unpack(">H", c2_data[c2_offset + 5 : c2_offset + 7])[0])
+        ip = socket.inet_ntoa(struct.pack("!L", struct.unpack(">I", data[c2_offset + 1 : c2_offset + 5])[0]))
+        port = str(struct.unpack(">H", data[c2_offset + 5 : c2_offset + 7])[0])
         controllers.append(f"{ip}:{port}")
     return controllers
 
@@ -118,6 +116,8 @@ def decompress(data):
     """
     Decompress data with blzpack decompression
     """
+    if not HAVE_BLZPACK:
+        return
     return blzpack.decompress_data(BRIEFLZ_HEADER.join(data.split(QAKBOT_HEADER)))
 
 
@@ -154,7 +154,6 @@ def decrypt_data2(data):
 
     return decrypted_data
 
-
 def decrypt_data3(data):
     if not data:
         return
@@ -166,71 +165,127 @@ def decrypt_data3(data):
     if not decrypted_data:
         return
 
+    if hashlib.sha1(decrypted_data[0x14:]).digest() == decrypted_data[:0x14]:
+        return decrypted_data
+
+    # From around 403.902 onwards (30-09-2022)
+    hash_obj = hashlib.sha1(b"Muhcu#YgcdXubYBu2@2ub4fbUhuiNhyVtcd")
+    rc4_key = hash_obj.digest()
+    decrypted_data = ARC4.new(rc4_key).decrypt(data)
+
+    if not decrypted_data:
+        return
+
+    if rc4_key == decrypted_data[:0x14]:
+        return decrypted_data
+
+    decrypted_data = ARC4.new(decrypted_data[0x14:0x28]).decrypt(decrypted_data[0x28:])
+    sha1 = hashlib.sha1(decrypted_data).digest()
+
+    if not decrypted_data:
+        return
+
+    if hashlib.sha1(decrypted_data[0x14:]).digest() != decrypted_data[:0x14]:
+        return
+
     return decrypted_data
 
+def decrypt_data4(data):
+    if not data:
+        return
+
+    hash_obj = hashlib.sha1(b"bUdiuy81gYguty@4frdRdpfko(eKmudeuMncueaN")
+    rc4_key = hash_obj.digest()
+    decrypted_data = ARC4.new(rc4_key).decrypt(data)
+
+    if not decrypted_data:
+        return
+
+    decrypted_data = ARC4.new(decrypted_data[0x14:0x28]).decrypt(decrypted_data[0x28:])
+    sha1 = hashlib.sha1(decrypted_data).digest()
+
+    if not decrypted_data:
+        return
+
+    if hashlib.sha1(decrypted_data[0x14:]).digest() != decrypted_data[:0x14]:
+        return
+
+    return decrypted_data
 
 def extract_config(filebuf):
     end_config = {}
-    if not HAVE_BLZPACK:
-        return
-    try:
-        pe = pefile.PE(data=filebuf, fast_load=False)
-        # image_base = pe.OPTIONAL_HEADER.ImageBase
-        for rsrc in pe.DIRECTORY_ENTRY_RESOURCE.entries:
-            for entry in rsrc.directory.entries:
-                if entry.name is not None:
-                    # log.info("id: %s", entry.name)
-                    controllers = []
-                    config = {}
-                    offset = entry.directory.entries[0].data.struct.OffsetToData
-                    size = entry.directory.entries[0].data.struct.Size
-                    res_data = pe.get_memory_mapped_image()[offset : offset + size]
-                    if str(entry.name) == "307":
-                        # we found the parent process and still need to decrypt/(blzpack) decompress the main DLL
-                        dec_bytes = decrypt_data(res_data)
-                        decompressed = decompress(dec_bytes)
+    if filebuf[:2] == b'MZ':
+        try:
+            pe = pefile.PE(data=filebuf, fast_load=False)
+            # image_base = pe.OPTIONAL_HEADER.ImageBase
+            for rsrc in pe.DIRECTORY_ENTRY_RESOURCE.entries:
+                for entry in rsrc.directory.entries:
+                    if entry.name is not None:
+                        # log.info("id: %s", entry.name)
+                        controllers = []
+                        config = {}
+                        offset = entry.directory.entries[0].data.struct.OffsetToData
+                        size = entry.directory.entries[0].data.struct.Size
+                        res_data = pe.get_memory_mapped_image()[offset : offset + size]
+                        if str(entry.name) == "307":
+                            # we found the parent process and still need to decrypt/(blzpack) decompress the main DLL
+                            dec_bytes = decrypt_data(res_data)
+                            decompressed = decompress(dec_bytes)
+                            end_config["Loader Build"] = parse_build(pe).decode()
+                            pe2 = pefile.PE(data=decompressed)
+                            for rsrc in pe2.DIRECTORY_ENTRY_RESOURCE.entries:
+                                for entry in rsrc.directory.entries:
+                                    if entry.name is not None:
+                                        offset = entry.directory.entries[0].data.struct.OffsetToData
+                                        size = entry.directory.entries[0].data.struct.Size
+                                        res_data = pe2.get_memory_mapped_image()[offset : offset + size]
+                                        if str(entry.name) == "308":
+                                            dec_bytes = decrypt_data(res_data)
+                                            config = parse_config(dec_bytes)
+                                            # log.info("qbot_config: %s", config)
+                                            end_config["Core DLL Build"] = parse_build(pe2).decode()
+                                        elif str(entry.name) == "311":
+                                            dec_bytes = decrypt_data(res_data)
+                                            controllers = parse_controllers(dec_bytes)
+                        elif str(entry.name) == "308":
+                            dec_bytes = decrypt_data(res_data)
+                            config = parse_config(dec_bytes)
+                        elif str(entry.name) == "311":
+                            dec_bytes = decrypt_data(res_data)
+                            controllers = parse_binary_c2(dec_bytes)
+                        elif str(entry.name) in ("118", "3719"):
+                            dec_bytes = decrypt_data2(res_data)
+                            controllers = parse_binary_c2_2(dec_bytes)
+                        elif str(entry.name) in ("524", "5812"):
+                            dec_bytes = decrypt_data2(res_data)
+                            config = parse_config(dec_bytes)
+                        elif str(entry.name) in ("18270D2E", "BABA", "103", "89210AF9"):
+                            dec_bytes = decrypt_data3(res_data)
+                            config = parse_config(dec_bytes)
+                        elif str(entry.name) in ("26F517AB", "EBBA", "102", "3C91E639"):
+                            dec_bytes = decrypt_data3(res_data)
+                            controllers = parse_binary_c2_2(dec_bytes)
+                        elif str(entry.name) in ("89290AF9"):
+                            dec_bytes = decrypt_data4(res_data)
+                            config = parse_config(dec_bytes)
+                        elif str(entry.name) in ("3C91E539"):
+                            dec_bytes = decrypt_data4(res_data)
+                            controllers = parse_binary_c2_2(dec_bytes)
                         end_config["Loader Build"] = parse_build(pe).decode()
-                        pe2 = pefile.PE(data=decompressed)
-                        for rsrc in pe2.DIRECTORY_ENTRY_RESOURCE.entries:
-                            for entry in rsrc.directory.entries:
-                                if entry.name is not None:
-                                    offset = entry.directory.entries[0].data.struct.OffsetToData
-                                    size = entry.directory.entries[0].data.struct.Size
-                                    res_data = pe2.get_memory_mapped_image()[offset : offset + size]
-                                    if str(entry.name) == "308":
-                                        dec_bytes = decrypt_data(res_data)
-                                        config = parse_config(dec_bytes)
-                                        # log.info("qbot_config: %s", config)
-                                        end_config["Core DLL Build"] = parse_build(pe2).decode()
-                                    elif str(entry.name) == "311":
-                                        dec_bytes = decrypt_data(res_data)
-                                        controllers = parse_controllers(dec_bytes)
-                    elif str(entry.name) == "308":
-                        dec_bytes = decrypt_data(res_data)
-                        config = parse_config(dec_bytes)
-                    elif str(entry.name) == "311":
-                        dec_bytes = decrypt_data(res_data)
-                        controllers = parse_binary_c2(dec_bytes)
-                    elif str(entry.name) in ("118", "3719"):
-                        dec_bytes = decrypt_data2(res_data)
-                        controllers = parse_binary_c2_2(dec_bytes)
-                    elif str(entry.name) in ("524", "5812"):
-                        dec_bytes = decrypt_data2(res_data)
-                        config = parse_config(dec_bytes)
-                    elif str(entry.name) in ("18270D2E", "BABA", "103", "89210AF9"):
-                        dec_bytes = decrypt_data3(res_data)
-                        config = parse_config(dec_bytes)
-                    elif str(entry.name) in ("26F517AB", "EBBA", "102", "3C91E639"):
-                        dec_bytes = decrypt_data3(res_data)
-                        controllers = parse_binary_c2_2(dec_bytes)
-                    end_config["Loader Build"] = parse_build(pe).decode()
-                    for k, v in config.items():
-                        # log.info({ k: v })
-                        end_config.setdefault(k, v)
-                    # log.info("controllers: %s", controllers)
-                    for controller in controllers:
-                        end_config.setdefault("address", []).append(controller)
-    except Exception as e:
-        log.warning(e)
-
+                        for k, v in config.items():
+                            # log.info({ k: v })
+                            end_config.setdefault(k, v)
+                        # log.info("controllers: %s", controllers)
+                        for controller in controllers:
+                            end_config.setdefault("address", []).append(controller)
+        except Exception as e:
+            log.warning(e)
+    elif filebuf[:1] == b'\x01':
+        controllers = parse_binary_c2(filebuf[:len(filebuf)-20])
+        for controller in controllers:
+            end_config.setdefault("address", []).append(controller)
+    elif b'=' in filebuf:
+        config = parse_config(filebuf[:len(filebuf)-20])
+        for k, v in config.items():
+            end_config.setdefault(k, v)
     return end_config

--- a/web/submission/views.py
+++ b/web/submission/views.py
@@ -270,7 +270,7 @@ def index(request, resubmit_hash=False):
             task_category = "vtdl"
             samples = request.POST.get("vtdl").strip()
 
-        list_of_files = []
+        list_of_tasks = []
         if task_category in ("url", "dlnexec"):
             if not samples:
                 return render(request, "error.html", {"error": "You specified an invalid URL!"})
@@ -280,12 +280,12 @@ def index(request, resubmit_hash=False):
                 if task_category == "dlnexec":
                     path, content, sha256 = process_new_dlnexec_task(url, route, options, custom)
                     if path:
-                        list_of_files.append((content, path, sha256))
+                        list_of_tasks.append((content, path, sha256, None))
                 elif task_category == "url":
-                    list_of_files.append(("", url, ""))
+                    list_of_tasks.append(("", url, "", None))
 
         elif task_category in ("sample", "quarantine", "static", "pcap"):
-            list_of_files, details = process_new_task_files(request, samples, details, opt_filename, unique)
+            list_of_tasks, details = process_new_task_files(request, samples, details, opt_filename, unique)
 
         elif task_category == "resubmit":
             for hash in samples:
@@ -334,14 +334,14 @@ def index(request, resubmit_hash=False):
                 else:
                     filename = base_dir + "/" + sanitize_filename(hash)
                 path = store_temp_file(content, filename)
-                list_of_files.append((content, path, hash))
+                list_of_tasks.append((content, path, hash, None))
 
         # Hack for resubmit first find all files and then put task as proper category
         if job_category and job_category in ("resubmit", "sample", "quarantine", "static", "pcap", "dlnexec", "vtdl"):
             task_category = job_category
 
         if task_category == "resubmit":
-            for content, path, sha256 in list_of_files:
+            for content, path, sha256, _ in list_of_tasks:
                 details["path"] = path
                 details["content"] = content
                 status, task_ids_tmp = download_file(**details)
@@ -356,7 +356,7 @@ def index(request, resubmit_hash=False):
 
         elif task_category == "sample":
             details["service"] = "WebGUI"
-            for content, path, sha256 in list_of_files:
+            for content, path, sha256, sample_parent_id in list_of_tasks:
                 if web_conf.pre_script.enabled and "pre_script" in request.FILES:
                     pre_script = request.FILES["pre_script"]
                     details["pre_script_name"] = request.FILES["pre_script"].name
@@ -370,6 +370,7 @@ def index(request, resubmit_hash=False):
                 if timeout and web_conf.public.enabled and web_conf.public.timeout and timeout > web_conf.public.timeout:
                     timeout = web_conf.public.timeout
 
+                details["sample_parent_id"] = sample_parent_id
                 details["path"] = path
                 details["content"] = content
                 status, task_ids_tmp = download_file(**details)
@@ -384,7 +385,7 @@ def index(request, resubmit_hash=False):
                     details["task_ids"] = task_ids_tmp
 
         elif task_category == "quarantine":
-            for content, tmp_path, sha256 in list_of_files:
+            for content, tmp_path, sha256, _ in list_of_tasks:
                 path = unquarantine(tmp_path)
                 try:
                     os.remove(tmp_path)
@@ -404,14 +405,15 @@ def index(request, resubmit_hash=False):
                     details["task_ids"] = task_ids_tmp
 
         elif task_category == "static":
-            for content, path, sha256 in list_of_files:
+            for content, path, sha256, sample_parent_id in list_of_tasks:
                 task_id = db.add_static(file_path=path, priority=priority, tlp=tlp, user_id=request.user.id or 0)
                 if not task_id:
                     return render(request, "error.html", {"error": "We don't have static extractor for this"})
                 details["task_ids"] += task_id
+                details["sample_parent_id"] = sample_parent_id
 
         elif task_category == "pcap":
-            for content, path, sha256 in list_of_files:
+            for content, path, sha256, _ in list_of_tasks:
                 if path.lower().endswith(b".saz"):
                     saz = saz_to_pcap(path)
                     if saz:
@@ -429,7 +431,7 @@ def index(request, resubmit_hash=False):
                     details["task_ids"].append(task_id)
 
         elif task_category == "url":
-            for _, url, _ in list_of_files:
+            for _, url, _, _ in list_of_tasks:
                 if machine.lower() == "all":
                     machines = [vm.name for vm in db.list_machines(platform=platform)]
                 elif machine:
@@ -470,7 +472,8 @@ def index(request, resubmit_hash=False):
                     details["task_ids"].append(task_id)
 
         elif task_category == "dlnexec":
-            for content, path, sha256 in list_of_files:
+            for content, path, sha256, sample_parent_id in list_of_tasks:
+                details["sample_parent_id"] = sample_parent_id
                 details["path"] = path
                 details["content"] = content
                 details["service"] = "DLnExec"


### PR DESCRIPTION
Basic implementation that trims PE files that are over the submission size limit using uses pefile to find end of the last PE section.

Loads entire PE into memory using ``read()`` - could be improved by instead using ``chunks()``.