### PR TITLE
Add conf whether to open top_detections

### DIFF
--- a/conf/web.conf
+++ b/conf/web.conf
@@ -38,6 +38,7 @@ search_limit = 50
 # Allow anon users to browser site but not submit/download
 anon_viewable = no
 existent_tasks = yes
+top_detections = yes
 # hostname of the cape instance
 hostname = https://127.0.0.1/
 ;hostname = https://www.capesandbox.com/

--- a/lib/cuckoo/common/web_utils.py
+++ b/lib/cuckoo/common/web_utils.py
@@ -217,6 +217,8 @@ all_vms_tags_str = ",".join(all_vms_tags)
 
 
 def top_detections(date_since: datetime = False, results_limit: int = 20) -> dict:
+    if web_cfg.general.get("top_detections", False) == False:
+        return False
 
     t = int(time.time())
 


### PR DESCRIPTION
When there are a large number of reports, top_detections spends too much time.  
Add a conf so that top_detections can be disabled by modifying the conf.  