### PR TITLE
fix #1254; submissions stay in pending

### DIFF
--- a/conf/cuckoo.conf
+++ b/conf/cuckoo.conf
@@ -35,6 +35,11 @@ terminate_processes = off
 # Each task found in status "processing" is re-queued for analysis.
 reschedule = off
 
+# Fail "unserviceable" tasks as they are queued.
+# Any task found that will never be analyzed based on the available analysis machines
+# will have its status set to "failed".
+fail_unserviceable = on
+
 # Limit the amount of analysis jobs a Cuckoo process goes through.
 # This can be used together with a watchdog to mitigate risk of memory leaks.
 max_analysis_count = 0

--- a/lib/cuckoo/core/database.py
+++ b/lib/cuckoo/core/database.py
@@ -823,6 +823,25 @@ class Database(object, metaclass=Singleton):
         return False
 
     @classlock
+    def is_serviceable(self, task: Task) -> bool:
+        """Checks if the task is serviceable.
+
+        This method is useful when there are tasks that will never be serviced
+        by any of the machines available. This allows callers to decide what to
+        do when tasks like this are created.
+
+        @return: boolean indicating if any machine could service the task in the future
+        """
+        task_archs = [tag.name for tag in task.tags if tag.name in ["x86", "x64"]]
+        task_tags = [tag.name for tag in task.tags if tag.name not in task_archs]
+        relevant_machines = self.list_machines(
+            label=task.machine, platform=task.platform, tags=task_tags, arch=task_archs
+        )
+        if len(relevant_machines) > 0:
+            return True
+        return False
+
+    @classlock
     def fetch_task(self, categories: list = []):
         """Fetches a task waiting to be processed and locks it for running.
         @return: None or task

--- a/lib/cuckoo/core/scheduler.py
+++ b/lib/cuckoo/core/scheduler.py
@@ -24,7 +24,13 @@ from lib.cuckoo.common.exceptions import (
 from lib.cuckoo.common.integrations.parse_pe import PortableExecutable
 from lib.cuckoo.common.objects import File
 from lib.cuckoo.common.utils import convert_to_printable, create_folder, free_space_monitor, get_memdump_path, load_categories
-from lib.cuckoo.core.database import TASK_COMPLETED, TASK_PENDING, Database, Task
+from lib.cuckoo.core.database import (
+    TASK_COMPLETED,
+    TASK_FAILED_ANALYSIS,
+    TASK_PENDING,
+    Database,
+    Task,
+)
 from lib.cuckoo.core.guest import GuestManager
 from lib.cuckoo.core.log import task_log_stop
 from lib.cuckoo.core.plugins import RunAuxiliary, list_plugins
@@ -856,6 +862,13 @@ class Scheduler:
                     for task in self.db.list_tasks(
                         status=TASK_PENDING, order_by=(Task.priority.desc(), Task.added_on), options_not_like="node="
                     ):
+                        # Can this task ever be serviced?
+                        if not self.db.is_serviceable(task):
+                            if self.cfg.cuckoo.fail_unserviceable:
+                                log.debug("Task #%s: Failing unserviceable task", task.id)
+                                self.db.set_status(task.id, TASK_FAILED_ANALYSIS)
+                                continue
+                            log.debug("Task #%s: Unserviceable task", task.id)
                         relevant_machine_is_available = self.db.is_relevant_machine_available(task)
                         if relevant_machine_is_available:
                             break

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -8,7 +8,7 @@ import shutil
 from tempfile import NamedTemporaryFile
 
 from lib.cuckoo.common.utils import store_temp_file
-from lib.cuckoo.core.database import Database, Task
+from lib.cuckoo.core.database import Database, Task, Tag
 
 
 class TestDatabaseEngine:
@@ -203,3 +203,41 @@ class TestDatabaseEngine:
             "tags": ["tag1tag2"],
             "arch": "x64",
         }
+
+    def test_is_serviceable(self):
+        self.d.add_machine(
+            name="win10-x64-1",
+            label="label",
+            ip="1.2.3.4",
+            platform="windows",
+            tags="tag1",
+            interface="int0",
+            snapshot="snap0",
+            resultserver_ip="5.6.7.8",
+            resultserver_port=2043,
+            arch="x64",
+        )
+        task = Task()
+        task.platform = "windows"
+        task.tags = [Tag("tag1")]
+        # tasks matching the available machines are serviceable
+        assert self.d.is_serviceable(task)
+
+    def test_is_not_serviceable(self):
+        self.d.add_machine(
+            name="win10-x64-1",
+            label="label",
+            ip="1.2.3.4",
+            platform="windows",
+            tags="tag1",
+            interface="int0",
+            snapshot="snap0",
+            resultserver_ip="5.6.7.8",
+            resultserver_port=2043,
+            arch="x64",
+        )
+        task = Task()
+        task.platform = "linux"
+        task.tags = [Tag("tag1")]
+        # tasks not matching the available machines aren't serviceable
+        assert not self.d.is_serviceable(task)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -128,6 +128,7 @@ class TestAnalysisManager:
             "max_analysis_count": 0,
             "freespace_processing": 15000,
             "periodic_log": False,
+            "fail_unserviceable": True,
         }
 
         assert analysis_man.task.id == 1234


### PR DESCRIPTION
A lot of the problems with submissions stuck in the pending state is due to the available machinery. Tweak the scheduler slightly to check the machinery is capable of processing a task and use a default configuration that sends these tasks to a failed processing state.