### PR TITLE
Bump libvirt-python version to 8.10.0

### DIFF
--- a/extra/poetry_libvirt_installer.sh
+++ b/extra/poetry_libvirt_installer.sh
@@ -3,7 +3,7 @@
 # run this via...
 # cd /opt/CAPEv2/ ; sudo -u cape poetry run extra/poetry_libvirt_installer.sh
 
-LIB_VERSION=8.2.0
+LIB_VERSION=8.10.0
 
 cd /tmp
 wget "https://github.com/libvirt/libvirt-python/archive/v${LIB_VERSION}.zip"


### PR DESCRIPTION
To keep it the same version as 
https://github.com/doomedraven/Tools/blob/master/Virtualization/kvm-qemu.sh#L65 as mentioned in
https://github.com/kevoreilly/CAPEv2/pull/952#issuecomment-1163430794

Fixes the following error:
```
Missing type converters:
virTypedParameterPtr:2
ERROR: failed virDomainRestoreParams
ERROR: failed virDomainSaveParams
```