### PR TITLE
Clean cape_name when have exception or yara rule do not have cape_type

### DIFF
--- a/modules/processing/CAPE.py
+++ b/modules/processing/CAPE.py
@@ -290,16 +290,15 @@ class CAPE(Processing):
         executed_config_parsers = collections.defaultdict(set)
         for tmp_path, tmp_data, hit in all_files:
             # Check for a payload or config hit
+            cape_name = None
             try:
                 if File.yara_hit_provides_detection(hit):
                     file_info["cape_type"] = hit["meta"]["cape_type"]
                     cape_name = File.get_cape_name_from_yara_hit(hit)
                     cape_names.add(cape_name)
-                else:
-                    cape_name = None
+
             except Exception as e:
                 log.error(f"Cape type error: {e}")
-                cape_name = None
             type_strings = file_info["type"].split()
             if "-bit" not in file_info["cape_type"]:
                 if type_strings[0] in ("PE32+", "PE32"):

--- a/modules/processing/CAPE.py
+++ b/modules/processing/CAPE.py
@@ -295,8 +295,11 @@ class CAPE(Processing):
                     file_info["cape_type"] = hit["meta"]["cape_type"]
                     cape_name = File.get_cape_name_from_yara_hit(hit)
                     cape_names.add(cape_name)
+                else:
+                    cape_name = None
             except Exception as e:
-                print(f"Cape type error: {e}")
+                log.error(f"Cape type error: {e}")
+                cape_name = None
             type_strings = file_info["type"].split()
             if "-bit" not in file_info["cape_type"]:
                 if type_strings[0] in ("PE32+", "PE32"):


### PR DESCRIPTION
UPX rule do not have cape_type, so if sample packed by UPX, will mess up config extract result.

Test sample : d607e4cf6254db79c5a50a6e59c25f9387951f545da0b1475719209d8d357f64