### PR TITLE
Fixing bugs to allow debugging of a single signature

### DIFF
--- a/lib/cuckoo/core/plugins.py
+++ b/lib/cuckoo/core/plugins.py
@@ -497,6 +497,10 @@ class RunSignatures:
         if test_signature:
             self.evented_list = next((sig for sig in self.evented_list if sig.name == test_signature), [])
             self.non_evented_list = next((sig for sig in self.non_evented_list if sig.name == test_signature), [])
+            if not isinstance(self.evented_list, list):
+                self.evented_list = [self.evented_list]
+            if not isinstance(self.non_evented_list, list):
+                self.non_evented_list = [self.non_evented_list]
 
         if self.evented_list and "behavior" in self.results:
             log.debug("Running %d evented signatures", len(self.evented_list))
@@ -535,6 +539,8 @@ class RunSignatures:
                             pretime = timeit.default_timer()
                             result = sig.on_call(call, proc)
                             timediff = timeit.default_timer() - pretime
+                            if sig.name not in stats:
+                                stats[sig.name] = 0
                             stats[sig.name] += timediff
                         except NotImplementedError:
                             result = False

--- a/utils/process.py
+++ b/utils/process.py
@@ -434,6 +434,9 @@ def main():
                         if report:
                             results = json.load(open(report))
                     if results is not None:
+                        # If the "statistics" key-value pair has not been set by now, set it here
+                        if "statistics" not in results:
+                            results["statistics"] = {"signatures": []}
                         RunSignatures(task=task.to_dict(), results=results).run(args.signature_name)
                 else:
                     process(task=task, report=args.report, capeproc=args.caperesubmit, memory_debugging=args.memory_debugging)


### PR DESCRIPTION
When attempting to debug a single signature with the latest code, I ran into several bugs.

If a test signature was provided, `self.evented_lis`t and `self.non_evented_list` were no longer lists, `stats` did not contain every signature name as a key, and the `statistics` key had the potential to not present in `self.results`.

These are all fixed in this PR.