### PR TITLE
Fix bugs/speed up/clean up generic file extractors.

### DIFF
--- a/modules/processing/CAPE.py
+++ b/modules/processing/CAPE.py
@@ -19,11 +19,12 @@ import os
 import timeit
 from pathlib import Path
 from contextlib import suppress
+import typing
 
 from lib.cuckoo.common.abstracts import Processing
 from lib.cuckoo.common.cape_utils import pe_map, static_config_parsers, cape_name_from_yara
 from lib.cuckoo.common.config import Config
-from lib.cuckoo.common.integrations.file_extra_info import static_file_info
+from lib.cuckoo.common.integrations.file_extra_info import static_file_info, DuplicatesType
 from lib.cuckoo.common.objects import File
 from lib.cuckoo.common.utils import (
     add_family_detection,
@@ -156,7 +157,7 @@ class CAPE(Processing):
 
         return type_string, append_file
 
-    def process_file(self, file_path, append_file, metadata: dict = {}, category: str = False, duplicated: dict = {}) -> dict:
+    def process_file(self, file_path, append_file, metadata: dict, *, category: str, duplicated: DuplicatesType) -> dict:
         """Process file.
         @return: file_info
         """
@@ -173,9 +174,10 @@ class CAPE(Processing):
         sha256 = f.get_sha256()
 
         if sha256 in duplicated["sha256"]:
+            log.debug("Skipping file that has already been processed: %s", sha256)
             return
         else:
-            duplicated["sha256"].append(sha256)
+            duplicated["sha256"].add(sha256)
 
         file_info, pefile_object = f.get_all()
 
@@ -309,7 +311,11 @@ class CAPE(Processing):
                         )
                         append_file = False
                 if file_info.get("entrypoint") and file_info.get("ep_bytes") and cape_file.get("entrypoint"):
-                    if file_info["entrypoint"] == cape_file["entrypoint"] and file_info["cape_type_code"] == cape_file["cape_type_code"] and file_info["ep_bytes"] == cape_file["ep_bytes"]:
+                    if (
+                        file_info["entrypoint"] == cape_file["entrypoint"]
+                        and file_info["cape_type_code"] == cape_file["cape_type_code"]
+                        and file_info["ep_bytes"] == cape_file["ep_bytes"]
+                    ):
                         log.debug("CAPE duplicate output file skipped: matching entrypoint")
                         append_file = False
 
@@ -334,7 +340,7 @@ class CAPE(Processing):
 
         meta = {}
         # Required to control files extracted by selfextract.conf as we store them in dropped
-        duplicated = {"sha256": []}
+        duplicated: DuplicatesType = collections.defaultdict(set)
         if Path(self.files_metadata).exists():
             for line in open(self.files_metadata, "rb"):
                 entry = json.loads(line)


### PR DESCRIPTION
This addresses some issues with how the generic file extractors were being handled and cleans up the code to make them behave a bit more consistently.
 - It was often the case, on a somewhat loaded system, that the first task to be checked for "ready()" status would not be ready and the timeout would not have elapsed. In this case, we would sleep for 5 seconds. For samples where there are many files to process, we would end up waiting these extra 5 seconds for every one. This adds up quickly. The method for handling the child processes is improved so that we don't need to do that.
 - The "took_seconds" calculation was inaccurate because it would be counting from when the process pool was created, not from when we starting trying to run the tool, which could be later based on how many workers are in the pool.
 - Factored out lots of code so that the unique tool-handling functions are limited to their specific duties.
 - Go back to using a ProcessPool but fix how the 'results' and 'duplicated' objects are being handled. They were previously being updated in child processes. These updates would not be reflected in the parent process, essentially losing this data. This was recently addressed by using a ThreadPool instead, which is certainly one way to do it, but this addresses the other issues mentioned above as well and cleans up how the 'results' and 'duplicated' objects are being handled without having to deal with race conditions, which, I believe, are possible in the ThreadPool version.
 - Add some additional logging.