### PR TITLE
tweak installer/cape2.sh so it will read in a config file if present

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ storage/
 web/web/secret_key.py
 tests/test_bson.bson.compressed
 *~
+
+installer/cape-config.sh

--- a/installer/cape2.sh
+++ b/installer/cape2.sh
@@ -24,9 +24,15 @@ node_exporter_version=1.0.1
 guacamole_version=1.4.0
 
 DIE_VERSION="3.07"
-UBUNTU_VERSION=$(lsb_release -rs)
 
 TOR_SOCKET_TIMEOUT="60"
+
+# if a config file is present, read it in
+if [ -f "./cape-config.sh" ]; then
+	. ./cape-config.sh
+fi
+
+UBUNTU_VERSION=$(lsb_release -rs)
 OS="$(uname -s)"
 MAINTAINER="$(whoami)"_"$(hostname)"
 ARCH="$(dpkg --print-architecture)"


### PR DESCRIPTION
Modded this for making it easier to spin up a instance via Ansible. Don't need to deal with tracking this file or modding. Drop the config file in the directory, give it a kick, and one is good to go.