### PR TITLE
document LibreNMS monitoring integration for CAPEv2

### DIFF
--- a/docs/book/src/integrations/index.rst
+++ b/docs/book/src/integrations/index.rst
@@ -11,3 +11,4 @@ to fit the needs of all users.
 
     box-js
     curtain
+    librenms

--- a/docs/book/src/integrations/librenms.rst
+++ b/docs/book/src/integrations/librenms.rst
@@ -1,0 +1,52 @@
+========
+LibreNMS
+========
+
+LibreNMS is capable of monitoring stats for CAPEv2. This is handled
+by a SNMP extend.
+
+    wget https://raw.githubusercontent.com/librenms/librenms-agent/master/snmp/cape -O /etc/snmp/cape
+	chmod +x /etc/snmp/cape
+    apt-get install libfile-readbackwards-perl libjson-perl \
+	    libconfig-tiny-perl libdbi-perl libfile-slurp-perl \
+    	libstatistics-lite-perl libdbi-perl libdbd-pg-perl
+
+With that all in place, you will then need to create a config file for
+it at ``/usr/local/etc/cape_extend.ini``. Unless you are doing
+anything custom DB wise, the settings below, but with the proper PW
+will work.
+
+    # DBI connection DSN
+    dsn=dbi:Pg:dbname=cape;host=127.0.0.1
+    
+    # DB user
+	user=cape
+    
+    # DB PW
+	pass=12345
+
+This module will also send warnings, errors, and criticals found in
+the logs to LibreNMS. To filter these,
+``/usr/local/etc/cape_extend.ignores`` can be used. The format for
+that is as below.
+
+    <ignore level> <pattern>
+
+This the ignore level will be lower cased. The seperator bween the
+level and the regexp pattern is /[\ \t]+/. So if you want to ignore
+the two warnings generated when VM traffic is dropped, you would use
+the two lines such as below.
+
+    WARNING PCAP file does not exist at path
+    WARNING Unable to Run Suricata: Pcap file
+
+On the CAPEv2 side, you will need to make a few tweaks to ``reporting.conf``.
+``litereport`` will need enabled and  ``eys_to_copy`` should include
+'signatures' and 'detections'.
+
+Finally will need to enable the extend for your 
+	
+    extend cape /etc/snmp/extends/cape
+
+Once snmpd is restarted and the the device rediscovered via LibreNMS,
+you will then be able to 

--- a/docs/book/src/integrations/librenms.rst
+++ b/docs/book/src/integrations/librenms.rst
@@ -47,7 +47,7 @@ the two lines such as below.
     WARNING Unable to Run Suricata: Pcap file
 
 On the CAPEv2 side, you will need to make a few tweaks to ``reporting.conf``.
-``litereport`` will need enabled and  ``eys_to_copy`` should include
+``litereport`` will need enabled and  ``keys_to_copy`` should include
 'signatures' and 'detections'.
 
 Finally will need to enable the extend for your

--- a/docs/book/src/integrations/librenms.rst
+++ b/docs/book/src/integrations/librenms.rst
@@ -63,4 +63,4 @@ For more detailed monitoring, if using KVM, you will likely want to
 also considering using `HV::Monitor`, which will allow detailed
 monitoring various stats VMs.
 
-.. _`HV::Monitor`:https://docs.librenms.org/Extensions/Applications/#hv-monitor
+.. _`HV::Monitor`: https://docs.librenms.org/Extensions/Applications/#hv-monitor

--- a/docs/book/src/integrations/librenms.rst
+++ b/docs/book/src/integrations/librenms.rst
@@ -8,8 +8,8 @@ by a SNMP extend.
     wget https://raw.githubusercontent.com/librenms/librenms-agent/master/snmp/cape -O /etc/snmp/cape
 	chmod +x /etc/snmp/cape
     apt-get install libfile-readbackwards-perl libjson-perl \
-	    libconfig-tiny-perl libdbi-perl libfile-slurp-perl \
-    	libstatistics-lite-perl libdbi-perl libdbd-pg-perl
+        libconfig-tiny-perl libdbi-perl libfile-slurp-perl \
+        libstatistics-lite-perl libdbi-perl libdbd-pg-perl
 
 With that all in place, you will then need to create a config file for
 it at ``/usr/local/etc/cape_extend.ini``. Unless you are doing
@@ -20,10 +20,10 @@ will work.
     dsn=dbi:Pg:dbname=cape;host=127.0.0.1
     
     # DB user
-	user=cape
+    user=cape
     
     # DB PW
-	pass=12345
+    pass=12345
 
 This module will also send warnings, errors, and criticals found in
 the logs to LibreNMS. To filter these,
@@ -50,3 +50,9 @@ Finally will need to enable the extend for your
 
 Once snmpd is restarted and the the device rediscovered via LibreNMS,
 you will then be able to 
+
+For more detailed monitoring, if using KVM, you will likely want to
+also considering using `HV::Monitor`, which will allow detailed
+monitoring various stats VMs.
+
+.. _`HV::Monitor`:https://docs.librenms.org/Extensions/Applications/#hv-monitor

--- a/docs/book/src/integrations/librenms.rst
+++ b/docs/book/src/integrations/librenms.rst
@@ -33,7 +33,7 @@ that is as below.
     <ignore level> <pattern>
 
 This the ignore level will be lower cased. The seperator bween the
-level and the regexp pattern is /[\ \t]+/. So if you want to ignore
+level and the regexp pattern is ``/[\ \t]+/``. So if you want to ignore
 the two warnings generated when VM traffic is dropped, you would use
 the two lines such as below.
 

--- a/docs/book/src/integrations/librenms.rst
+++ b/docs/book/src/integrations/librenms.rst
@@ -20,10 +20,10 @@ will work.
 
     # DBI connection DSN
     dsn=dbi:Pg:dbname=cape;host=127.0.0.1
-    
+
     # DB user
     user=cape
-    
+
     # DB PW
     pass=12345
 
@@ -41,6 +41,8 @@ level and the regexp pattern is ``/[\ \t]+/``. So if you want to ignore
 the two warnings generated when VM traffic is dropped, you would use
 the two lines such as below.
 
+::
+
     WARNING PCAP file does not exist at path
     WARNING Unable to Run Suricata: Pcap file
 
@@ -48,14 +50,14 @@ On the CAPEv2 side, you will need to make a few tweaks to ``reporting.conf``.
 ``litereport`` will need enabled and  ``eys_to_copy`` should include
 'signatures' and 'detections'.
 
-Finally will need to enable the extend for your 
+Finally will need to enable the extend for your
 
 ::
 
     extend cape /etc/snmp/extends/cape
 
 Once snmpd is restarted and the the device rediscovered via LibreNMS,
-you will then be able to 
+you will then be able to
 
 For more detailed monitoring, if using KVM, you will likely want to
 also considering using `HV::Monitor`, which will allow detailed

--- a/docs/book/src/integrations/librenms.rst
+++ b/docs/book/src/integrations/librenms.rst
@@ -5,16 +5,18 @@ LibreNMS
 LibreNMS is capable of monitoring stats for CAPEv2. This is handled
 by a SNMP extend.
 
+::
+
     wget https://raw.githubusercontent.com/librenms/librenms-agent/master/snmp/cape -O /etc/snmp/cape
-	chmod +x /etc/snmp/cape
-    apt-get install libfile-readbackwards-perl libjson-perl \
-        libconfig-tiny-perl libdbi-perl libfile-slurp-perl \
-        libstatistics-lite-perl libdbi-perl libdbd-pg-perl
+    chmod +x /etc/snmp/cape
+    apt-get install libfile-readbackwards-perl libjson-perl libconfig-tiny-perl libdbi-perl libfile-slurp-perl libstatistics-lite-perl libdbi-perl libdbd-pg-perl
 
 With that all in place, you will then need to create a config file for
 it at ``/usr/local/etc/cape_extend.ini``. Unless you are doing
 anything custom DB wise, the settings below, but with the proper PW
 will work.
+
+::
 
     # DBI connection DSN
     dsn=dbi:Pg:dbname=cape;host=127.0.0.1
@@ -29,6 +31,8 @@ This module will also send warnings, errors, and criticals found in
 the logs to LibreNMS. To filter these,
 ``/usr/local/etc/cape_extend.ignores`` can be used. The format for
 that is as below.
+
+::
 
     <ignore level> <pattern>
 
@@ -45,7 +49,9 @@ On the CAPEv2 side, you will need to make a few tweaks to ``reporting.conf``.
 'signatures' and 'detections'.
 
 Finally will need to enable the extend for your 
-	
+
+::
+
     extend cape /etc/snmp/extends/cape
 
 Once snmpd is restarted and the the device rediscovered via LibreNMS,


### PR DESCRIPTION
CAPEv2 support has now been committed to LibreNMS.

Monitors....

- pending (this one is especially handy... will give 25th/50th/75th percentile and 2hr/daily/weekly averages)
- log line count/type
- run status types
- run stats(anti_issues etc) by both total and by package
- package type
- malscore
