### PR TITLE
fix: "RuntimeWarning: line buffering (buffering=1) isn't supported in…

### DIFF
--- a/lib/cuckoo/common/files.py
+++ b/lib/cuckoo/common/files.py
@@ -31,22 +31,22 @@ def temppath():
     return tmppath
 
 
-def open_exclusive(path, mode="xb", bufsize=-1):
+def open_exclusive(path, mode="xb"):
     """Open a file with O_EXCL, failing if it already exists
     [In Python 3, use open with x]"""
     fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
     try:
-        return os.fdopen(fd, mode, bufsize)
+        return os.fdopen(fd, mode)
     except OSError as e:
         log.error(e, "You might need to add whitelist folder in resultserver.py")
         os.close(fd)
         raise
 
 
-def open_inclusive(path, mode="ab", bufsize=-1):
+def open_inclusive(path, mode="ab"):
     fd = os.open(path, os.O_CREAT | os.O_APPEND | os.O_WRONLY, 0o644)
     try:
-        return os.fdopen(fd, mode, bufsize)
+        return os.fdopen(fd, mode)
     except OSError as e:
         log.error(e, "You might need to add whitelist folder in resultserver.py")
         os.close(fd)

--- a/lib/cuckoo/core/resultserver.py
+++ b/lib/cuckoo/core/resultserver.py
@@ -251,7 +251,7 @@ class LogHandler(ProtocolHandler):
     def init(self):
         self.logpath = os.path.join(self.handler.storagepath, "analysis.log")
         try:
-            self.fd = open_exclusive(self.logpath, bufsize=1)
+            self.fd = open_exclusive(self.logpath)
         except OSError:
             log.error("Task #%s: attempted to reopen live log analysis.log", self.task_id)
             return

--- a/modules/processing/network.py
+++ b/modules/processing/network.py
@@ -56,7 +56,7 @@ try:
     except (ImportError, GeoIP.error):
         IS_GEOIP = False
 except NameError:
-    print("Can't import GeoIP")
+    print("OPTIONAL! Can't import GeoIP")
 
 try:
     import dpkt

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -161,4 +161,4 @@ def test_open_exclusive():
     _ = path_write_file(fpath, "42421337Test", mode="text")
 
     with pytest.raises(OSError):
-        open_exclusive(fpath, bufsize=1)
+        open_exclusive(fpath)


### PR DESCRIPTION
… binary mode, the default buffer size will be used"

fixes
```
RuntimeWarning: line buffering (buffering=1) isn't supported in binary mode, the default buffer size will be used
```