### PR TITLE
add tests for config updates, simplify the update, and log the potential for data loss

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -2,7 +2,7 @@ name: Python package
 
 on:
   push:
-    branches: '**'
+    branches: [ master ]
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -2,7 +2,7 @@ name: Python package
 
 on:
   push:
-    branches: [ master ]
+    branches: '**'
   pull_request:
     branches: [ master ]
 

--- a/modules/processing/CAPE.py
+++ b/modules/processing/CAPE.py
@@ -84,6 +84,11 @@ unpack_map = {
 class CAPE(Processing):
     """CAPE output file processing."""
 
+    def __init__(self):
+        super().__init__()
+        self.key = "CAPE"
+        self.cape = {"payloads": [], "configs": []}
+
     def add_family_detections(self, file_info, cape_names):
         for cape_name in cape_names:
             if cape_name != "UPX" and cape_name:
@@ -342,12 +347,6 @@ class CAPE(Processing):
         """Run analysis.
         @return: list of CAPE output files with related information.
         """
-        self.key = "CAPE"
-
-        self.cape = {}
-        self.cape["payloads"] = []
-        self.cape["configs"] = []
-
         meta = {}
         # Required to control files extracted by selfextract.conf as we store them in dropped
         duplicated: DuplicatesType = collections.defaultdict(set)

--- a/modules/processing/CAPE.py
+++ b/modules/processing/CAPE.py
@@ -298,7 +298,7 @@ class CAPE(Processing):
 
             if cape_name and cape_name not in executed_config_parsers[tmp_path]:
                 tmp_config = static_config_parsers(cape_name, tmp_path, tmp_data)
-                self.update_cape_configs(tmp_config)
+                self.update_cape_configs(cape_name, tmp_config)
                 executed_config_parsers[tmp_path].add(cape_name)
 
         if type_string:
@@ -311,7 +311,7 @@ class CAPE(Processing):
                 if tmp_config:
                     cape_names.add(cape_name)
                     log.info("CAPE: config returned for: %s", cape_name)
-                    self.update_cape_configs(tmp_config)
+                    self.update_cape_configs(cape_name, tmp_config)
 
         self.add_family_detections(file_info, cape_names)
 
@@ -389,23 +389,16 @@ class CAPE(Processing):
                             self.process_file(filepath, False, meta.get(filepath, {}), category=category, duplicated=duplicated)
         return self.cape
 
-    def update_cape_configs(self, config):
+    def update_cape_configs(self, cape_name, config):
         """Add the given config to self.cape["configs"]."""
         if not config:
             return
 
-        updated = False
+        # look for an existing config matching cape_name; merge them if found
+        for existing_config in self.cape["configs"]:
+            if cape_name in existing_config:
+                existing_config[cape_name].update(config[cape_name])
+                return
 
-        for name, data in config.items():
-            break
-
-        # Some families may have multiple configs. Squash them all together.
-        if name not in self.cape["configs"]:
-            for current in self.cape["configs"]:
-                if name == list(current.keys())[0]:
-                    current[name].update(data)
-                    updated = True
-                    break
-
-        if updated is False:
-            self.cape["configs"].append(config)
+        # first time this cape_name config was seen
+        self.cape["configs"].append(config)

--- a/modules/processing/CAPE.py
+++ b/modules/processing/CAPE.py
@@ -394,11 +394,13 @@ class CAPE(Processing):
         if not config:
             return
 
-        # look for an existing config matching cape_name; merge them if found
+        # look for an existing config matching this cape_name; merge them if found
         for existing_config in self.cape["configs"]:
             if cape_name in existing_config:
+                log.warning("CAPE: data loss may occur, existing config found for: %s", cape_name)
                 existing_config[cape_name].update(config[cape_name])
                 return
 
-        # first time this cape_name config was seen
+        # first time a config for this cape_name was seen
+        log.info("CAPE: new config found for: %s", cape_name)
         self.cape["configs"].append(config)

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -40,3 +40,12 @@ class TestConfigUpdates:
         cape_proc_module.update_cape_configs(cfg2)
         expected_cfgs = [{"Family1": {"SomeKey": "SomeValue"}}, {"Family2": {"SomeKey": "SomeValue"}}]
         assert cape_proc_module.cape["configs"] == expected_cfgs
+
+    def test_update_same_family(self):
+        cape_proc_module = CAPE()
+        cfg1 = {"Family": {"SomeKey": "SomeValue"}}
+        cfg2 = {"Family": {"SomeKey": "DifferentValue"}}
+        cape_proc_module.update_cape_configs(cfg1)
+        cape_proc_module.update_cape_configs(cfg2)
+        expected_cfg = [{"Family": {"SomeKey": ["SomeValue", "DifferentValue"]}}]
+        assert cape_proc_module.cape["configs"] == expected_cfg

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -38,6 +38,7 @@ class TestConfigUpdates:
         assert cape_proc_module.cape["configs"] == expected_cfgs
 
     def test_update_same_family_overwrites(self):
+        # see https://github.com/kevoreilly/CAPEv2/pull/1357
         cape_proc_module = CAPE()
         cfg1 = {"Family": {"SomeKey": "SomeValue"}}
         cfg2 = {"Family": {"SomeKey": "DifferentValue"}}

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -7,19 +7,19 @@ class TestConfigUpdates:
     def test_update_no_config(self):
         cape_proc_module = CAPE()
         name, config = "Family", None
-        cape_proc_module.update_cape_configs(config)
+        cape_proc_module.update_cape_configs("Family", config)
         assert cape_proc_module.cape["configs"] == []
 
     def test_update_empty_config(self):
         cape_proc_module = CAPE()
         name, config = "Family", {}
-        cape_proc_module.update_cape_configs(config)
+        cape_proc_module.update_cape_configs("Family", config)
         assert cape_proc_module.cape["configs"] == []
 
     def test_update_single_config(self):
         cape_proc_module = CAPE()
         cfg = {"Family": {"SomeKey": "SomeValue"}}
-        cape_proc_module.update_cape_configs(cfg)
+        cape_proc_module.update_cape_configs("Family", cfg)
         expected_cfgs = [cfg]
         assert cape_proc_module.cape["configs"] == expected_cfgs
 
@@ -27,8 +27,8 @@ class TestConfigUpdates:
         cape_proc_module = CAPE()
         cfg1 = {"Family": {"SomeKey": "SomeValue"}}
         cfg2 = {"Family": {"AnotherKey": "AnotherValue"}}
-        cape_proc_module.update_cape_configs(cfg1)
-        cape_proc_module.update_cape_configs(cfg2)
+        cape_proc_module.update_cape_configs("Family", cfg1)
+        cape_proc_module.update_cape_configs("Family", cfg2)
         expected_cfgs = [{"Family": {"AnotherKey": "AnotherValue", "SomeKey": "SomeValue"}}]
         assert cape_proc_module.cape["configs"] == expected_cfgs
 
@@ -36,16 +36,16 @@ class TestConfigUpdates:
         cape_proc_module = CAPE()
         cfg1 = {"Family1": {"SomeKey": "SomeValue"}}
         cfg2 = {"Family2": {"SomeKey": "SomeValue"}}
-        cape_proc_module.update_cape_configs(cfg1)
-        cape_proc_module.update_cape_configs(cfg2)
+        cape_proc_module.update_cape_configs("Family", cfg1)
+        cape_proc_module.update_cape_configs("Family", cfg2)
         expected_cfgs = [{"Family1": {"SomeKey": "SomeValue"}}, {"Family2": {"SomeKey": "SomeValue"}}]
         assert cape_proc_module.cape["configs"] == expected_cfgs
 
-    def test_update_same_family(self):
+    def test_update_same_family_overwrites(self):
         cape_proc_module = CAPE()
         cfg1 = {"Family": {"SomeKey": "SomeValue"}}
         cfg2 = {"Family": {"SomeKey": "DifferentValue"}}
-        cape_proc_module.update_cape_configs(cfg1)
-        cape_proc_module.update_cape_configs(cfg2)
-        expected_cfg = [{"Family": {"SomeKey": ["SomeValue", "DifferentValue"]}}]
+        cape_proc_module.update_cape_configs("Family", cfg1)
+        cape_proc_module.update_cape_configs("Family", cfg2)
+        expected_cfg = [{"Family": {"SomeKey": "DifferentValue"}}]
         assert cape_proc_module.cape["configs"] == expected_cfg

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -1,19 +1,15 @@
-import pytest
-
 from modules.processing.CAPE import CAPE
 
 
 class TestConfigUpdates:
     def test_update_no_config(self):
         cape_proc_module = CAPE()
-        name, config = "Family", None
-        cape_proc_module.update_cape_configs("Family", config)
+        cape_proc_module.update_cape_configs("Family", None)
         assert cape_proc_module.cape["configs"] == []
 
     def test_update_empty_config(self):
         cape_proc_module = CAPE()
-        name, config = "Family", {}
-        cape_proc_module.update_cape_configs("Family", config)
+        cape_proc_module.update_cape_configs("Family", {})
         assert cape_proc_module.cape["configs"] == []
 
     def test_update_single_config(self):

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -1,0 +1,42 @@
+import pytest
+
+from modules.processing.CAPE import CAPE
+
+
+class TestConfigUpdates:
+    def test_update_no_config(self):
+        cape_proc_module = CAPE()
+        name, config = "Family", None
+        cape_proc_module.update_cape_configs(config)
+        assert cape_proc_module.cape["configs"] == []
+
+    def test_update_empty_config(self):
+        cape_proc_module = CAPE()
+        name, config = "Family", {}
+        cape_proc_module.update_cape_configs(config)
+        assert cape_proc_module.cape["configs"] == []
+
+    def test_update_single_config(self):
+        cape_proc_module = CAPE()
+        cfg = {"Family": {"SomeKey": "SomeValue"}}
+        cape_proc_module.update_cape_configs(cfg)
+        expected_cfgs = [cfg]
+        assert cape_proc_module.cape["configs"] == expected_cfgs
+
+    def test_update_multiple_configs(self):
+        cape_proc_module = CAPE()
+        cfg1 = {"Family": {"SomeKey": "SomeValue"}}
+        cfg2 = {"Family": {"AnotherKey": "AnotherValue"}}
+        cape_proc_module.update_cape_configs(cfg1)
+        cape_proc_module.update_cape_configs(cfg2)
+        expected_cfgs = [{"Family": {"AnotherKey": "AnotherValue", "SomeKey": "SomeValue"}}]
+        assert cape_proc_module.cape["configs"] == expected_cfgs
+
+    def test_update_different_families(self):
+        cape_proc_module = CAPE()
+        cfg1 = {"Family1": {"SomeKey": "SomeValue"}}
+        cfg2 = {"Family2": {"SomeKey": "SomeValue"}}
+        cape_proc_module.update_cape_configs(cfg1)
+        cape_proc_module.update_cape_configs(cfg2)
+        expected_cfgs = [{"Family1": {"SomeKey": "SomeValue"}}, {"Family2": {"SomeKey": "SomeValue"}}]
+        assert cape_proc_module.cape["configs"] == expected_cfgs


### PR DESCRIPTION
When multiple configs are generated for a specific family, there's a potential for data loss when keys collide.

For example, with these two separate configs the last one wins:

```json
{"SomeFamily": {"Encryption Type": "0 - everything"}
```

```json
{"SomeFamily": {"Encryption Type": "1 - partial"}
```

This PR adds test coverage for this behavior, makes the code behind it more straightforward, and emits warnings if the potential for data loss is encountered. There's no functional change in the configs that are generated.