### PR TITLE
link configs to the file hashes they come from

### DIFF
--- a/lib/cuckoo/common/objects.py
+++ b/lib/cuckoo/common/objects.py
@@ -535,6 +535,19 @@ class File:
         # Close PE file and return RichPE hash digest
         return md5.hexdigest()
 
+    def get_all_hashe(self):
+        return {
+            "crc32": self.get_crc32(),
+            "md5": self.get_md5(),
+            "sha1": self.get_sha1(),
+            "sha256": self.get_sha256(),
+            "sha512": self.get_sha512(),
+            "rh_hash": self.get_rh_hash(),
+            "ssdeep": self.get_ssdeep(),
+            "tlsh": self.get_tlsh(),
+            "sha3_384": self.get_sha3_384(),
+        }
+
     def get_all(self):
         """Get all information available.
         @return: information dict.

--- a/modules/processing/CAPE.py
+++ b/modules/processing/CAPE.py
@@ -298,7 +298,7 @@ class CAPE(Processing):
 
             if cape_name and cape_name not in executed_config_parsers[tmp_path]:
                 tmp_config = static_config_parsers(cape_name, tmp_path, tmp_data)
-                self.update_cape_configs(cape_name, tmp_config, File(tmp_path))
+                self.update_cape_configs(cape_name, tmp_config, tmp_data)
                 executed_config_parsers[tmp_path].add(cape_name)
 
         if type_string:
@@ -311,7 +311,7 @@ class CAPE(Processing):
                 if tmp_config:
                     cape_names.add(cape_name)
                     log.info("CAPE: config returned for: %s", cape_name)
-                    self.update_cape_configs(cape_name, tmp_config, File(file_info["path"]))
+                    self.update_cape_configs(cape_name, tmp_config, tmp_data)
 
         self.add_family_detections(file_info, cape_names)
 
@@ -403,12 +403,8 @@ class CAPE(Processing):
 
         # first time a config for this cape_name was seen
         log.info("CAPE: new config found for: %s", cape_name)
-        associated_config_hashes = {
-            "md5": file_obj.get_md5(),
-            "sha1": file_obj.get_sha1(),
-            "sha256": file_obj.get_sha256(),
-            "sha512": file_obj.get_sha512(),
-            "sha3_384": file_obj.get_sha3_384(),
-        }
+        associated_config_hashes = {}
+        for hashtype in ("md5", "sha1", "sha256", "sha512", "sha3_384"):
+            associated_config_hashes.setdefault(hashtype, file_obj.get(hashtype, ""))
         config["associated_config_hashes"] = associated_config_hashes
         self.cape["configs"].append(config)

--- a/modules/processing/CAPE.py
+++ b/modules/processing/CAPE.py
@@ -298,7 +298,7 @@ class CAPE(Processing):
 
             if cape_name and cape_name not in executed_config_parsers[tmp_path]:
                 tmp_config = static_config_parsers(cape_name, tmp_path, tmp_data)
-                self.update_cape_configs(cape_name, tmp_config)
+                self.update_cape_configs(cape_name, tmp_config, File(tmp_path))
                 executed_config_parsers[tmp_path].add(cape_name)
 
         if type_string:
@@ -311,7 +311,7 @@ class CAPE(Processing):
                 if tmp_config:
                     cape_names.add(cape_name)
                     log.info("CAPE: config returned for: %s", cape_name)
-                    self.update_cape_configs(cape_name, tmp_config)
+                    self.update_cape_configs(cape_name, tmp_config, File(file_info["path"]))
 
         self.add_family_detections(file_info, cape_names)
 
@@ -389,7 +389,7 @@ class CAPE(Processing):
                             self.process_file(filepath, False, meta.get(filepath, {}), category=category, duplicated=duplicated)
         return self.cape
 
-    def update_cape_configs(self, cape_name, config):
+    def update_cape_configs(self, cape_name, config, file_obj):
         """Add the given config to self.cape["configs"]."""
         if not config:
             return
@@ -403,4 +403,12 @@ class CAPE(Processing):
 
         # first time a config for this cape_name was seen
         log.info("CAPE: new config found for: %s", cape_name)
+        associated_config_hashes = {
+            "md5": file_obj.get_md5(),
+            "sha1": file_obj.get_sha1(),
+            "sha256": file_obj.get_sha256(),
+            "sha512": file_obj.get_sha512(),
+            "sha3_384": file_obj.get_sha3_384(),
+        }
+        config["associated_config_hashes"] = associated_config_hashes
         self.cape["configs"].append(config)

--- a/modules/processing/CAPE.py
+++ b/modules/processing/CAPE.py
@@ -298,7 +298,7 @@ class CAPE(Processing):
 
             if cape_name and cape_name not in executed_config_parsers[tmp_path]:
                 tmp_config = static_config_parsers(cape_name, tmp_path, tmp_data)
-                self.update_cape_configs(cape_name, tmp_config, tmp_data)
+                self.update_cape_configs(cape_name, tmp_config, file_info)
                 executed_config_parsers[tmp_path].add(cape_name)
 
         if type_string:
@@ -311,7 +311,7 @@ class CAPE(Processing):
                 if tmp_config:
                     cape_names.add(cape_name)
                     log.info("CAPE: config returned for: %s", cape_name)
-                    self.update_cape_configs(cape_name, tmp_config, tmp_data)
+                    self.update_cape_configs(cape_name, tmp_config, file_info)
 
         self.add_family_detections(file_info, cape_names)
 

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -62,7 +62,7 @@ class TestConfigUpdates:
             f.write(b"fake file for configs")
             file_obj = File(f.name).calc_hashes()
             cfg = {"Family": {"SomeKey": "SomeValue"}}
-            cape_proc_module.update_cape_configs("Family", cfg, file_obj)
+            cape_proc_module.update_cape_configs("Family", cfg, file_obj.__dict__)
         actual_cfg = cape_proc_module.cape["configs"]
         assert "Family" in actual_cfg[0]
         assert "associated_config_hashes" in actual_cfg[0]

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -60,7 +60,7 @@ class TestConfigUpdates:
         cape_proc_module = CAPE()
         with NamedTemporaryFile(mode="wb") as f:
             f.write(b"fake file for configs")
-            file_obj = File(f.name)
+            file_obj = File(f.name).calc_hashes()
             cfg = {"Family": {"SomeKey": "SomeValue"}}
             cape_proc_module.update_cape_configs("Family", cfg, file_obj)
         actual_cfg = cape_proc_module.cape["configs"]

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -1,21 +1,25 @@
+from tempfile import NamedTemporaryFile
+from unittest.mock import ANY, MagicMock
+
+from lib.cuckoo.common.objects import File
 from modules.processing.CAPE import CAPE
 
 
 class TestConfigUpdates:
     def test_update_no_config(self):
         cape_proc_module = CAPE()
-        cape_proc_module.update_cape_configs("Family", None)
+        cape_proc_module.update_cape_configs("Family", None, MagicMock())
         assert cape_proc_module.cape["configs"] == []
 
     def test_update_empty_config(self):
         cape_proc_module = CAPE()
-        cape_proc_module.update_cape_configs("Family", {})
+        cape_proc_module.update_cape_configs("Family", {}, MagicMock())
         assert cape_proc_module.cape["configs"] == []
 
     def test_update_single_config(self):
         cape_proc_module = CAPE()
         cfg = {"Family": {"SomeKey": "SomeValue"}}
-        cape_proc_module.update_cape_configs("Family", cfg)
+        cape_proc_module.update_cape_configs("Family", cfg, MagicMock())
         expected_cfgs = [cfg]
         assert cape_proc_module.cape["configs"] == expected_cfgs
 
@@ -23,18 +27,21 @@ class TestConfigUpdates:
         cape_proc_module = CAPE()
         cfg1 = {"Family": {"SomeKey": "SomeValue"}}
         cfg2 = {"Family": {"AnotherKey": "AnotherValue"}}
-        cape_proc_module.update_cape_configs("Family", cfg1)
-        cape_proc_module.update_cape_configs("Family", cfg2)
-        expected_cfgs = [{"Family": {"AnotherKey": "AnotherValue", "SomeKey": "SomeValue"}}]
+        cape_proc_module.update_cape_configs("Family", cfg1, MagicMock())
+        cape_proc_module.update_cape_configs("Family", cfg2, MagicMock())
+        expected_cfgs = [{"Family": {"AnotherKey": "AnotherValue", "SomeKey": "SomeValue"}, "associated_config_hashes": ANY}]
         assert cape_proc_module.cape["configs"] == expected_cfgs
 
     def test_update_different_families(self):
         cape_proc_module = CAPE()
         cfg1 = {"Family1": {"SomeKey": "SomeValue"}}
         cfg2 = {"Family2": {"SomeKey": "SomeValue"}}
-        cape_proc_module.update_cape_configs("Family", cfg1)
-        cape_proc_module.update_cape_configs("Family", cfg2)
-        expected_cfgs = [{"Family1": {"SomeKey": "SomeValue"}}, {"Family2": {"SomeKey": "SomeValue"}}]
+        cape_proc_module.update_cape_configs("Family", cfg1, MagicMock())
+        cape_proc_module.update_cape_configs("Family", cfg2, MagicMock())
+        expected_cfgs = [
+            {"Family1": {"SomeKey": "SomeValue"}, "associated_config_hashes": ANY},
+            {"Family2": {"SomeKey": "SomeValue"}, "associated_config_hashes": ANY},
+        ]
         assert cape_proc_module.cape["configs"] == expected_cfgs
 
     def test_update_same_family_overwrites(self):
@@ -42,7 +49,26 @@ class TestConfigUpdates:
         cape_proc_module = CAPE()
         cfg1 = {"Family": {"SomeKey": "SomeValue"}}
         cfg2 = {"Family": {"SomeKey": "DifferentValue"}}
-        cape_proc_module.update_cape_configs("Family", cfg1)
-        cape_proc_module.update_cape_configs("Family", cfg2)
-        expected_cfg = [{"Family": {"SomeKey": "DifferentValue"}}]
+        cape_proc_module.update_cape_configs("Family", cfg1, MagicMock())
+        cape_proc_module.update_cape_configs("Family", cfg2, MagicMock())
+        expected_cfg = [
+            {"Family": {"SomeKey": "DifferentValue"}, "associated_config_hashes": ANY},
+        ]
         assert cape_proc_module.cape["configs"] == expected_cfg
+
+    def test_update_config_file_obj(self):
+        cape_proc_module = CAPE()
+        with NamedTemporaryFile(mode="wb") as f:
+            f.write(b"fake file for configs")
+            file_obj = File(f.name)
+            cfg = {"Family": {"SomeKey": "SomeValue"}}
+            cape_proc_module.update_cape_configs("Family", cfg, file_obj)
+        actual_cfg = cape_proc_module.cape["configs"]
+        assert "Family" in actual_cfg[0]
+        assert "associated_config_hashes" in actual_cfg[0]
+        hashes = actual_cfg[0]["associated_config_hashes"]
+        assert hashes["md5"].startswith("d41")
+        assert hashes["sha1"].startswith("da3")
+        assert hashes["sha256"].startswith("e3b")
+        assert hashes["sha512"].startswith("cf8")
+        assert hashes["sha3_384"].startswith("0c6")

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -62,7 +62,7 @@ class TestConfigUpdates:
             f.write(b"fake file for configs")
             file_obj = File(f.name).get_all_hashe()
             cfg = {"Family": {"SomeKey": "SomeValue"}}
-            cape_proc_module.update_cape_configs("Family", cfg, file_obj.__dict__)
+            cape_proc_module.update_cape_configs("Family", cfg, file_obj)
         actual_cfg = cape_proc_module.cape["configs"]
         assert "Family" in actual_cfg[0]
         assert "associated_config_hashes" in actual_cfg[0]

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -60,8 +60,7 @@ class TestConfigUpdates:
         cape_proc_module = CAPE()
         with NamedTemporaryFile(mode="wb") as f:
             f.write(b"fake file for configs")
-            file_obj = File(f.name)
-            file_obj.calc_hashes()
+            file_obj = File(f.name).get_all_hashe()
             cfg = {"Family": {"SomeKey": "SomeValue"}}
             cape_proc_module.update_cape_configs("Family", cfg, file_obj.__dict__)
         actual_cfg = cape_proc_module.cape["configs"]

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -60,7 +60,8 @@ class TestConfigUpdates:
         cape_proc_module = CAPE()
         with NamedTemporaryFile(mode="wb") as f:
             f.write(b"fake file for configs")
-            file_obj = File(f.name).calc_hashes()
+            file_obj = File(f.name)
+            file_obj.calc_hashes()
             cfg = {"Family": {"SomeKey": "SomeValue"}}
             cape_proc_module.update_cape_configs("Family", cfg, file_obj.__dict__)
         actual_cfg = cape_proc_module.cape["configs"]


### PR DESCRIPTION
Adds a "associated_config_hashes" key to the configs that are generated, to directly connect the config to the hash it came from.

![image](https://user-images.githubusercontent.com/1265294/217891284-3f5c1cab-ef02-4dcf-89d6-798f16f3bc71.png)
