### PR TITLE
Fix flare/capa signatures path

### DIFF
--- a/utils/community.py
+++ b/utils/community.py
@@ -52,7 +52,7 @@ def flare_capa(proxy=None):
         os.rename(os.path.join(dest_folder, "capa-rules-master"), os.path.join(dest_folder, "capa-rules"))
 
         # shutil.rmtree((os.path.join(dest_folder, "capa-signatures")), ignore_errors=True)
-        capa_sigs_path = os.path.join(dest_folder, "capa-signatures")
+        capa_sigs_path = os.path.join(dest_folder, "flare-signatures")
         if not os.path.isdir(capa_sigs_path):
             path_mkdir(capa_sigs_path)
         for url in signature_urls:


### PR DESCRIPTION
from changelog:
### [11-7-2022]
* __ACTION REQUIRED__ * Now that CAPA and Floss uses the same signatures we renamed `capa-signatures` to `flare-signatures` * `python3 utils/community.py -cr`