### PR TITLE
Improve handling of signature call data.

### DIFF
--- a/conf/cuckoo.conf
+++ b/conf/cuckoo.conf
@@ -91,11 +91,6 @@ max_len = 196
 sanitize_len = 32
 sanitize_to_len = 24
 
-# Add apicall details to signature?
-# Enabling this can result in data loss if using MongoDB as it can generate a lot of data.
-# See https://github.com/kevoreilly/CAPEv2/issues/1340.
-apicall_details = off
-
 [resultserver]
 # The Result Server is used to receive in real time the behavioral logs
 # produced by the analyzer.

--- a/lib/cuckoo/common/abstracts.py
+++ b/lib/cuckoo/common/abstracts.py
@@ -1508,14 +1508,10 @@ class Signature:
     def mark_call(self, *args, **kwargs):
         """Mark the current call as explanation as to why this signature matched."""
 
-        if not cfg.cuckoo.apicall_details:
-            return
-
         mark = {
             "type": "call",
             "pid": self.pid,
             "cid": self.cid,
-            "call": self.call,
         }
 
         if args or kwargs:

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -109,7 +109,6 @@ class TestAnalysisManager:
         analysis_man = AnalysisManager(task=mock_task(), error_queue=queue.Queue())
 
         assert analysis_man.cfg.cuckoo == {
-            "apicall_details": False,
             "categories": "static, pcap, url, file",
             "freespace": 50000,
             "delete_original": False,

--- a/web/analysis/urls.py
+++ b/web/analysis/urls.py
@@ -17,6 +17,7 @@ urlpatterns = [
     re_path(r"^antivirus/(?P<task_id>\d+)/$", views.antivirus, name="antivirus"),
     re_path(r"^shrike/(?P<task_id>\d+)/$", views.shrike, name="shrike"),
     re_path(r"^remove/(?P<task_id>\d+)/$", views.remove, name="remove"),
+    re_path(r"^signature-calls/(?P<task_id>\d+)/$", views.signature_calls, name="signature-calls"),
     re_path(r"^chunk/(?P<task_id>\d+)/(?P<pid>\d+)/(?P<pagenum>\d+)/$", views.chunk, name="chunk"),
     re_path(
         r"^filtered/(?P<task_id>\d+)/(?P<pid>\d+)/(?P<category>\w+)/(?P<apilist>[!]?[A-Za-z_0-9,%]*)/(?P<caller>\w+)/(?P<tid>\w+)/$",

--- a/web/templates/analysis/overview/_signatures.html
+++ b/web/templates/analysis/overview/_signatures.html
@@ -71,6 +71,28 @@
                     </tbody>
                 </table>
             {% endif %}
+            {% if signature.calls %}
+                <div id="signature-calls_{{signature.name}}"></div>
+                {% with data_id="signature-calls-data_"|add:signature.name %}
+                    {{ signature.calls | json_script:data_id }}
+                    <script type="text/javascript">
+                        $("#signature_{{signature.name}}").on("show.bs.collapse", function() {
+                            $.ajax(
+                                "{% url "signature-calls" task_id=analysis.info.id %}",
+                                {
+                                    contentType: "application/json",
+                                    data: document.getElementById("{{data_id}}").textContent,
+                                    dataType: "html",
+                                    method: "POST",
+                                    success: function(responseText) {
+                                        $("#signature-calls_{{signature.name}}").html(responseText);
+                                    }
+                                }
+                            );
+                        });
+                    </script>
+                {% endwith %}
+            {% endif %}
             </div>
         {% endfor %}
     {% else %}


### PR DESCRIPTION
- Unconditionally *don't* store the call details in the "signatures" key of the analysis collection. Instead, only store the pid (process ID) and cid (chunk ID) of the call. That information alone allows us to query the behavior.processes.calls object for the ObjectID of the chunk and the index of the specific call within that chunk that triggered the signature.
- When rendering the signatures, don't immediately render the call data. Instead, use an AJAX call when a signature is expanded to query for its rendered HTML. To maintain backwards compatibility with documents that already contain the embedded call details, return the rendered HTML using the same template as before. Otherwise, we'll query Mongo or ES for the signature's call details first.
- Note that this also changes the display of signatures' call details to show it in tabular form like on the "Behavioral Analysis" tab.

![Screenshot_20230213_162824](https://user-images.githubusercontent.com/4206917/218578595-83c33acc-a062-4f2b-8e1f-c9da9e91492f.png)
