### PR TITLE
feat: add TLS support for mongodb

### DIFF
--- a/conf/reporting.conf
+++ b/conf/reporting.conf
@@ -83,6 +83,8 @@ db = cuckoo
 # password =
 # authsource = cuckoo
 
+# Set this value if you are using mongodb with TLS enabled
+# tlsCAFile =
 
 # Automatically delete large dict values that exceed mongos 16MB limitation
 # Note: This only deletes dict keys from data stored in MongoDB. You would

--- a/dev_utils/mongodb.py
+++ b/dev_utils/mongodb.py
@@ -45,6 +45,7 @@ def connect_to_mongo() -> MongoClient:
             username=repconf.mongodb.get("username"),
             password=repconf.mongodb.get("password"),
             authSource=repconf.mongodb.get("authsource", "cuckoo"),
+            tlsCAFile=repconf.mongodb.get("tlsCAFile", None),
             connect=False,
         )
     except (ConnectionFailure, ServerSelectionTimeoutError):

--- a/utils/admin.py
+++ b/utils/admin.py
@@ -24,6 +24,7 @@ if repconf.mongodb.enabled:
         username=repconf.mongodb.get("username"),
         password=repconf.mongodb.get("password"),
         authSource=repconf.mongodb.get("authsource", "cuckoo"),
+        tlsCAFile=repconf.mongodb.get("tlsCAFile", None),
     )[repconf.mongodb.db]
     FULL_DB = True
 


### PR DESCRIPTION
From pymongo's `MongoClient` class documentation:

```
          | **TLS/SSL configuration:**

          - `tlsCAFile`: A file containing a single or a bundle of
            "certification authority" certificates, which are used to validate
            certificates passed from the other end of the connection.
            Implies ``tls=True``. Defaults to ``None``.
```