### PR TITLE
fix: retrieving mongodb config file

### DIFF
--- a/conf/reporting.conf
+++ b/conf/reporting.conf
@@ -84,7 +84,7 @@ db = cuckoo
 # authsource = cuckoo
 
 # Set this value if you are using mongodb with TLS enabled
-# tlsCAFile =
+# tlscafile =
 
 # Automatically delete large dict values that exceed mongos 16MB limitation
 # Note: This only deletes dict keys from data stored in MongoDB. You would

--- a/dev_utils/mongodb.py
+++ b/dev_utils/mongodb.py
@@ -45,7 +45,7 @@ def connect_to_mongo() -> MongoClient:
             username=repconf.mongodb.get("username"),
             password=repconf.mongodb.get("password"),
             authSource=repconf.mongodb.get("authsource", "cuckoo"),
-            tlsCAFile=repconf.mongodb.get("tlsCAFile", None),
+            tlsCAFile=repconf.mongodb.get("tlscafile", None),
             connect=False,
         )
     except (ConnectionFailure, ServerSelectionTimeoutError):

--- a/utils/admin.py
+++ b/utils/admin.py
@@ -24,7 +24,7 @@ if repconf.mongodb.enabled:
         username=repconf.mongodb.get("username"),
         password=repconf.mongodb.get("password"),
         authSource=repconf.mongodb.get("authsource", "cuckoo"),
-        tlsCAFile=repconf.mongodb.get("tlsCAFile", None),
+        tlsCAFile=repconf.mongodb.get("tlscafile", None),
     )[repconf.mongodb.db]
     FULL_DB = True
 


### PR DESCRIPTION
Apologies, but ConfigParser parses configuration files case-insensitively. I had set this behaviour globally on my testing environment and only saw the error when pushing to my production.

_Reference_: https://stackoverflow.com/a/19359720/19723226