### PR TITLE
Changing the column type of Task.options to Text with no length limit

### DIFF
--- a/lib/cuckoo/core/database.py
+++ b/lib/cuckoo/core/database.py
@@ -114,7 +114,7 @@ if repconf.elasticsearchdb.enabled:
 
     es = elastic_handler
 
-SCHEMA_VERSION = "d6aa5d949b70"
+SCHEMA_VERSION = "a8441ab0fd0f"
 TASK_BANNED = "banned"
 TASK_PENDING = "pending"
 TASK_RUNNING = "running"
@@ -413,7 +413,7 @@ class Task(Base):
     tags_tasks = Column(String(256), nullable=True)
     # Virtual machine tags
     tags = relationship("Tag", secondary=tasks_tags, backref="tasks", lazy="subquery")
-    options = Column(String(1024), nullable=True)
+    options = Column(Text(), nullable=True)
     platform = Column(String(255), nullable=True)
     memory = Column(Boolean, nullable=False, default=False)
     enforce_timeout = Column(Boolean, nullable=False, default=False)

--- a/utils/db_migration/versions/2_4_0_change_options_to_text.py
+++ b/utils/db_migration/versions/2_4_0_change_options_to_text.py
@@ -1,0 +1,26 @@
+# Copyright (C) 2010-2015 Cuckoo Foundation.
+# This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
+# See the file 'docs/LICENSE' for copying permission.
+
+"""2_4_0_change_options_to_text
+
+Revision ID: a8441ab0fd0f
+Revises: 02af0b0ec686
+Create Date: 2023-02-24 16:59:10.667367
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'a8441ab0fd0f'
+down_revision = '02af0b0ec686'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.alter_column("tasks", "options", existing_type=sa.String(length=1024), type_=sa.Text(), existing_nullable=True)
+
+
+def downgrade():
+    op.alter_column("tasks", "options", existing_type=sa.Text(), type_=sa.String(length=1024), existing_nullable=True)

--- a/utils/db_migration/versions/2_4_0_change_options_to_text.py
+++ b/utils/db_migration/versions/2_4_0_change_options_to_text.py
@@ -5,14 +5,14 @@
 """2_4_0_change_options_to_text
 
 Revision ID: a8441ab0fd0f
-Revises: 02af0b0ec686
+Revises: d6aa5d949b70
 Create Date: 2023-02-24 16:59:10.667367
 
 """
 
 # revision identifiers, used by Alembic.
 revision = 'a8441ab0fd0f'
-down_revision = '02af0b0ec686'
+down_revision = 'd6aa5d949b70'
 
 from alembic import op
 import sqlalchemy as sa


### PR DESCRIPTION
When submitting multiple exports to be executed in a Dll (fixed in https://github.com/kevoreilly/CAPEv2/pull/1392 and https://github.com/kevoreilly/CAPEv2/pull/1390/commits/8c9e9182ec8c1ef8b97b2908e44a0027fb6d18d4), the "options" field can get larger than 1024, therefore convert to Text so that we can add these tasks to the database.

This is on par with how Cuckoo handles the options column https://github.com/cuckoosandbox/cuckoo/blob/master/cuckoo/core/database.py#L331