### PR TITLE
Create xlsx.py

### DIFF
--- a/analyzer/windows/modules/packages/xlsx.py
+++ b/analyzer/windows/modules/packages/xlsx.py
@@ -1,0 +1,27 @@
+# Copyright (C) 2010-2015 Cuckoo Foundation.
+# This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
+# See the file 'docs/LICENSE' for copying permission.
+
+from lib.common.abstracts import Package
+from lib.common.common import check_file_extension
+
+
+class XLSX(Package):
+    """Excel analysis package."""
+
+    def __init__(self, options=None, config=None):
+        if options is None:
+            options = {}
+        self.config = config
+        self.options = options
+
+    PATHS = [
+        ("ProgramFiles", "Microsoft Office", "EXCEL.EXE"),
+        ("ProgramFiles", "Microsoft Office", "Office*", "EXCEL.EXE"),
+        ("ProgramFiles", "Microsoft Office*", "root", "Office*", "EXCEL.EXE"),
+    ]
+
+    def start(self, path):
+        path = check_file_extension(path, ".xlsx")
+        excel = self.get_path_glob("Microsoft Office Excel")
+        return self.execute(excel, f'"{path}" /dde', path)


### PR DESCRIPTION
I noticed that when you upload a file with .xlsx it will be renamed in file.xlsx.xls;

In my production env I edited the xls.py as following:

```
# Copyright (C) 2010-2015 Cuckoo Foundation.
# This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
# See the file 'docs/LICENSE' for copying permission.

import os
from lib.common.abstracts import Package
from lib.common.common import check_file_extension


class XLS(Package):
    """Excel analysis package."""

    def __init__(self, options=None, config=None):
        if options is None:
            options = {}
        self.config = config
        self.options = options

    PATHS = [
        ("ProgramFiles", "Microsoft Office", "EXCEL.EXE"),
        ("ProgramFiles", "Microsoft Office", "Office*", "EXCEL.EXE"),
        ("ProgramFiles", "Microsoft Office*", "root", "Office*", "EXCEL.EXE"),
    ]

    def start(self, path):
        if os.path.splitext(path)[-1].lower() != ".xlsx":
            path = check_file_extension(path, ".xls")
        excel = self.get_path_glob("Microsoft Office Excel")
        return self.execute(excel, f'"{path}" /dde', path)
```

But the most elegant way I think is to create a new class for that extension.

I don't know how to fully implementing it but I hope it could help.