### PR TITLE
Added: CSRF Protection

### DIFF
--- a/web/web/local_settings.py
+++ b/web/web/local_settings.py
@@ -4,7 +4,6 @@
 
 LOCAL_SETTINGS = True
 from .settings import *  # noqa: F403
-from lib.cuckoo.common.config import Config
 
 # If you want to customize your cuckoo path set it here.
 # CUCKOO_PATH = "/where/cuckoo/is/placed/"
@@ -22,12 +21,6 @@ ADMINS = (
 )
 
 MANAGERS = ADMINS
-
-# For requests that include the Origin header, Django’s CSRF protection 
-# requires that header match the origin present in the Host header.
-hostname = Config("web").general.hostname
-CSRF_TRUSTED_ORIGINS = [hostname]
-CSRF_COOKIE_SECURE = "True"
 
 # Allow verbose debug error message in case of application fault.
 # It's strongly suggested to set it to False if you are serving the

--- a/web/web/local_settings.py
+++ b/web/web/local_settings.py
@@ -4,6 +4,7 @@
 
 LOCAL_SETTINGS = True
 from .settings import *  # noqa: F403
+from lib.cuckoo.common.config import Config
 
 # If you want to customize your cuckoo path set it here.
 # CUCKOO_PATH = "/where/cuckoo/is/placed/"
@@ -21,6 +22,12 @@ ADMINS = (
 )
 
 MANAGERS = ADMINS
+
+# For requests that include the Origin header, Django’s CSRF protection 
+# requires that header match the origin present in the Host header.
+hostname = Config("web").general.hostname
+CSRF_TRUSTED_ORIGINS = [hostname]
+CSRF_COOKIE_SECURE = "True"
 
 # Allow verbose debug error message in case of application fault.
 # It's strongly suggested to set it to False if you are serving the

--- a/web/web/settings.py
+++ b/web/web/settings.py
@@ -34,6 +34,12 @@ aux_cfg = Config("auxiliary")
 web_cfg = Config("web")
 api_cfg = Config("api")
 
+# CSRF TRUSTED ORIGINS
+# For requests that include the Origin header, Django’s CSRF protection 
+# requires that header match the origin present in the Host header.
+CSRF_TRUSTED_ORIGINS = [web_cfg.general.hostname]
+CSRF_COOKIE_SECURE = "True"
+
 # If reporting is enabled via the web GUI, then require one of these to be enabled
 if web_cfg.web_reporting.get("enabled", True):
     # Error handling for database backends


### PR DESCRIPTION
I had some problems during the submit of the files using dns-name:

With this code you can get rid of the CSRF error if you set the allowed hostname in `CAPEv2/config/web.conf` as follows:
```
# hostname of the cape instance
hostname = https://example.com
```

I hope that helps