### PR TITLE
Adding the os_version kw to overloaded abstract methods

### DIFF
--- a/modules/machinery/az.py
+++ b/modules/machinery/az.py
@@ -443,7 +443,7 @@ class Azure(Machinery):
         else:
             self.delete_machine(label)
 
-    def availables(self, label=None, platform=None, tags=None, arch=None, include_reserved=False):
+    def availables(self, label=None, platform=None, tags=None, arch=None, include_reserved=False, os_version=[]):
         """
         Overloading abstracts.py:availables() to utilize the auto-scale option.
         """
@@ -458,10 +458,10 @@ class Azure(Machinery):
                     return 0
 
         return super(Azure, self).availables(
-            label=label, platform=platform, tags=tags, arch=arch, include_reserved=include_reserved
+            label=label, platform=platform, tags=tags, arch=arch, include_reserved=include_reserved, os_version=os_version
         )
 
-    def acquire(self, machine_id=None, platform=None, tags=None, arch=None):
+    def acquire(self, machine_id=None, platform=None, tags=None, arch=None, os_version=[]):
         """
         Overloading abstracts.py:acquire() to utilize the auto-scale option.
         @param machine_id: the name of the machine to be acquired
@@ -470,7 +470,7 @@ class Azure(Machinery):
         @param arch: the architecture of the operating system
         @return: dict representing machine object from DB
         """
-        base_class_return_value = super(Azure, self).acquire(machine_id=machine_id, platform=platform, tags=tags, arch=arch)
+        base_class_return_value = super(Azure, self).acquire(machine_id=machine_id, platform=platform, tags=tags, arch=arch, os_version=os_version)
         if base_class_return_value and base_class_return_value.name:
             vmss_name, _ = base_class_return_value.name.split("_")
 


### PR DESCRIPTION
Bugfix caused by https://github.com/kevoreilly/CAPEv2/commit/b387b75fe08abc11a9d362a6eaff92fa82f2d683#diff-842d5ac54e999bd860cb253148ca2e72dd9bd1ca3e0d0f570eb05c8a2ed9668e