### PR TITLE
Checking for application in `get_path_glob`

### DIFF
--- a/analyzer/windows/lib/common/abstracts.py
+++ b/analyzer/windows/lib/common/abstracts.py
@@ -85,7 +85,7 @@ class Package:
         """
         for path in self.enum_paths():
             for path in glob.iglob(path):
-                if os.path.isfile(path):
+                if os.path.isfile(path) and (not application or application.lower() in path.lower()):
                     return path
 
         raise CuckooPackageError(f"Unable to find any {application} executable")

--- a/analyzer/windows/modules/packages/access.py
+++ b/analyzer/windows/modules/packages/access.py
@@ -23,6 +23,6 @@ class ACCESS(Package):
     ]
 
     def start(self, path):
-        access = self.get_path_glob("Microsoft Office Access")
+        access = self.get_path_glob("MSACCESS.EXE")
         path = check_file_extension(path, ".accdr")
         return self.execute(access, f'"{path}"', path)

--- a/analyzer/windows/modules/packages/doc.py
+++ b/analyzer/windows/modules/packages/doc.py
@@ -4,6 +4,7 @@
 
 from lib.common.abstracts import Package
 from lib.common.common import check_file_extension
+from lib.common.exceptions import CuckooPackageError
 
 
 class DOC(Package):
@@ -23,6 +24,11 @@ class DOC(Package):
     ]
 
     def start(self, path):
-        word = self.get_path_glob("Microsoft Office Word")
+        # Try getting winword or wordview as a backup
+        try:
+            word = self.get_path_glob("WINWORD.EXE")
+        except CuckooPackageError:
+            word = self.get_path_glob("WORDVIEW.EXE")
+
         path = check_file_extension(path, ".doc")
         return self.execute(word, f'"{path}" /q', path)

--- a/analyzer/windows/modules/packages/doc2016.py
+++ b/analyzer/windows/modules/packages/doc2016.py
@@ -20,6 +20,6 @@ class DOC2016(Package):
     ]
 
     def start(self, path):
-        word = self.get_path_glob("Microsoft Office Word")
+        word = self.get_path_glob("WINWORD.EXE")
         path = check_file_extension(path, ".doc")
         return self.execute(word, f'"{path}" /q /dde /n', path)

--- a/analyzer/windows/modules/packages/doc_antivm.py
+++ b/analyzer/windows/modules/packages/doc_antivm.py
@@ -3,6 +3,7 @@ import time
 
 from lib.common.abstracts import Package
 from lib.common.common import check_file_extension
+from lib.common.exceptions import CuckooPackageError
 
 
 class DOC_ANTIVM(Package):
@@ -53,6 +54,11 @@ class DOC_ANTIVM(Package):
             self.options["free"] = 0
 
         time.sleep(5)
-        word = self.get_path_glob("Microsoft Office Word")
+        # Try getting winword or wordview as a backup
+        try:
+            word = self.get_path_glob("WINWORD.EXE")
+        except CuckooPackageError:
+            word = self.get_path_glob("WORDVIEW.EXE")
+
         path = check_file_extension(path, ".doc")
         return self.execute(word, f'"{path}" /q', path)

--- a/analyzer/windows/modules/packages/eml.py
+++ b/analyzer/windows/modules/packages/eml.py
@@ -15,5 +15,5 @@ class EML(Package):
     ]
 
     def start(self, path):
-        outlook = self.get_path_glob("Microsoft Office Outlook")
+        outlook = self.get_path_glob("OUTLOOK.EXE")
         return self.execute(outlook, f'/eml "{path}"', path)

--- a/analyzer/windows/modules/packages/msg.py
+++ b/analyzer/windows/modules/packages/msg.py
@@ -15,5 +15,5 @@ class MSG(Package):
     ]
 
     def start(self, path):
-        outlook = self.get_path_glob("Microsoft Office Outlook")
+        outlook = self.get_path_glob("OUTLOOK.EXE")
         return self.execute(outlook, f'/f "{path}"', path)

--- a/analyzer/windows/modules/packages/one.py
+++ b/analyzer/windows/modules/packages/one.py
@@ -30,7 +30,7 @@ class ONE(Package):
     ]
 
     def start(self, path):
-        onenote = self.get_path_glob("Microsoft Office OneNote")
+        onenote = self.get_path_glob("ONENOTE.EXE")
         if "." not in os.path.basename(path):
             new_path = f"{path}.one"
             os.rename(path, new_path)

--- a/analyzer/windows/modules/packages/pdf.py
+++ b/analyzer/windows/modules/packages/pdf.py
@@ -3,6 +3,7 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 from lib.common.abstracts import Package
+from lib.common.exceptions import CuckooPackageError
 
 
 class PDF(Package):
@@ -22,5 +23,10 @@ class PDF(Package):
         self.options["pdf"] = "1"
 
     def start(self, path):
-        reader = self.get_path_glob("Adobe Reader")
+        # Try getting AcroRd32 or Acrobat as a backup
+        try:
+            reader = self.get_path_glob("AcroRd32.exe")
+        except CuckooPackageError:
+            reader = self.get_path_glob("Acrobat.exe")
+
         return self.execute(reader, f'"{path}"', path)

--- a/analyzer/windows/modules/packages/ppt.py
+++ b/analyzer/windows/modules/packages/ppt.py
@@ -21,5 +21,5 @@ class PPT(Package):
     ]
 
     def start(self, path):
-        powerpoint = self.get_path_glob("Microsoft Office PowerPoint")
+        powerpoint = self.get_path_glob("POWERPNT.EXE")
         return self.execute(powerpoint, f'/s "{path}"', path)

--- a/analyzer/windows/modules/packages/ppt2016.py
+++ b/analyzer/windows/modules/packages/ppt2016.py
@@ -19,5 +19,5 @@ class PPT2007(Package):
     ]
 
     def start(self, path):
-        powerpoint = self.get_path_glob("Microsoft Office PowerPoint")
+        powerpoint = self.get_path_glob("POWERPNT.EXE")
         return self.execute(powerpoint, f'/s "{path}"', path)

--- a/analyzer/windows/modules/packages/pub.py
+++ b/analyzer/windows/modules/packages/pub.py
@@ -52,6 +52,6 @@ class PUB(Package):
 
     def start(self, path):
         self.set_keys()
-        publisher = self.get_path_glob("Microsoft Office Publisher")
+        publisher = self.get_path_glob("MSPUB.EXE")
         path = check_file_extension(path, ".pub")
         return self.execute(publisher, f'"{path}"', path)

--- a/analyzer/windows/modules/packages/pub2016.py
+++ b/analyzer/windows/modules/packages/pub2016.py
@@ -48,6 +48,6 @@ class PUB2007(Package):
 
     def start(self, path):
         self.set_keys()
-        publisher = self.get_path_glob("Microsoft Office Publisher")
+        publisher = self.get_path_glob("MSPUB.EXE")
         path = check_file_extension(path, ".pub")
         return self.execute(publisher, f'"{path}"', path)

--- a/analyzer/windows/modules/packages/python.py
+++ b/analyzer/windows/modules/packages/python.py
@@ -3,6 +3,7 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 from lib.common.abstracts import Package
+from lib.common.exceptions import CuckooPackageError
 
 
 class Python(Package):
@@ -11,6 +12,11 @@ class Python(Package):
     PATHS = [("HomeDrive", "Python*", "python.exe"), ("SystemRoot", "py.exe")]
 
     def start(self, path):
-        python = self.get_path_glob("Python")
+        # Try getting python or py as a backup
+        try:
+            python = self.get_path_glob("python.exe")
+        except CuckooPackageError:
+            python = self.get_path_glob("py.exe")
+
         arguments = self.options.get("arguments", "")
         return self.execute(python, f"{path} {arguments}", path)

--- a/analyzer/windows/modules/packages/xls.py
+++ b/analyzer/windows/modules/packages/xls.py
@@ -24,5 +24,5 @@ class XLS(Package):
     def start(self, path):
         if not path.endswith((".xls", ".xlsx")):
             path = check_file_extension(path, ".xls")
-        excel = self.get_path_glob("Microsoft Office Excel")
+        excel = self.get_path_glob("EXCEL.EXE")
         return self.execute(excel, f'"{path}" /dde', path)

--- a/analyzer/windows/modules/packages/xls2016.py
+++ b/analyzer/windows/modules/packages/xls2016.py
@@ -19,5 +19,5 @@ class XLS2207(Package):
 
     def start(self, path):
         path = check_file_extension(path, ".xls")
-        excel = self.get_path_glob("Microsoft Office Excel")
+        excel = self.get_path_glob("EXCEL.EXE")
         return self.execute(excel, f'"{path}" /dde', path)

--- a/analyzer/windows/modules/packages/zip.py
+++ b/analyzer/windows/modules/packages/zip.py
@@ -28,6 +28,10 @@ class Zip(Package):
         ("SystemRoot", "system32", "rundll32.exe"),
         ("SystemRoot", "sysnative", "WindowsPowerShell", "v1.0", "powershell.exe"),
         ("SystemRoot", "system32", "xpsrchvw.exe"),
+        ("ProgramFiles", "Microsoft Office", "WINWORD.EXE"),
+        ("ProgramFiles", "Microsoft Office", "Office*", "WINWORD.EXE"),
+        ("ProgramFiles", "Microsoft Office*", "root", "Office*", "WINWORD.EXE"),
+        ("ProgramFiles", "Microsoft Office", "WORDVIEW.EXE"),
     ]
 
     def extract_zip(self, zip_path, extract_path, password=b"infected", recursion_depth=1):
@@ -168,6 +172,14 @@ class Zip(Package):
             powershell = self.get_path_app_in_path("powershell.exe")
             args = f'-NoProfile -ExecutionPolicy bypass -File "{path}"'
             return self.execute(powershell, args, file_path)
+        elif file_name.lower().endswith(".doc"):
+            # Try getting winword or wordview as a backup
+            try:
+                word = self.get_path_glob("WINWORD.EXE")
+            except CuckooPackageError:
+                word = self.get_path_glob("WORDVIEW.EXE")
+
+            return self.execute(word, f'"{file_path}" /q', file_path)
         else:
             path = check_file_extension(path, ".exe")
             return self.execute(file_path, self.options.get("arguments"), file_path)


### PR DESCRIPTION
WARNING: This PR could break analysis. I'm creating it since it is a definite bug fix in `get_path_glob`. Previously, all of the analysis packages that use this method would not check for the application in the path, but rather the first of the `PATHS` that existed. With this patch at least the method will do what it is supposed to do, but could break multiple analysis packages.

I currently don't have time to test this, but wanted to bring it everyone's attention :)

Update: I have tested the doc_antivm, ppt, excel, zip, pdf, and archive packages with the `get_path_glob` and it works correctly.

Update: I have released this PR to my production environments, so it could go to staging