### PR TITLE
bugfix: azure - don't set spot_restore_policy unless using Spot

### DIFF
--- a/modules/machinery/az.py
+++ b/modules/machinery/az.py
@@ -773,7 +773,11 @@ class Azure(Machinery):
             # When true this limits the scale set to a single placement group, of max size 100 virtual machines.
             single_placement_group=False,
             scale_in_policy=models.ScaleInPolicy(rules=[models.VirtualMachineScaleSetScaleInRules.newest_vm]),
-            spot_restore_policy=models.SpotRestorePolicy(enabled=True, restore_timeout="PT30M"),
+            spot_restore_policy=(
+                models.SpotRestorePolicy(enabled=True, restore_timeout="PT30M")
+                if self.options.az.spot_instances
+                else None
+            ),
         )
         if not self.options.az.just_start:
             async_vmss_creation = Azure._azure_api_call(


### PR DESCRIPTION
Azure machinery is setting the spot_restore_policy setting even when az.spot_instances option is set to false. This causes Azure to return an error and the VM scale set to not be created.

Update az.py to set spot_restore_policy to None if not using spot instances.