### PR TITLE
Fix guacamole version and poetry path for guac-web.service

### DIFF
--- a/installer/cape2.sh
+++ b/installer/cape2.sh
@@ -1263,6 +1263,11 @@ function install_guacamole() {
         cp /opt/CAPEv2/systemd/guac-web.service /lib/systemd/system/guac-web.service
     fi
 
+    poetry_path=$(which poetry)
+    if ! grep -q $poetry_path /lib/systemd/system/guac-web.service ; then
+        sed -i "s|/usr/bin/poetry|$poetry_path|g" /lib/systemd/system/guac-web.service
+    fi
+
     if [ ! -d "/var/www/guacrecordings" ] ; then
         sudo mkdir -p /var/www/guacrecordings && chown ${USER}:${USER} /var/www/guacrecordings
     fi

--- a/installer/cape2.sh
+++ b/installer/cape2.sh
@@ -22,7 +22,7 @@ nginx_version=1.19.6
 prometheus_version=2.20.1
 grafana_version=7.1.5
 node_exporter_version=1.0.1
-guacamole_version=1.4.0
+guacamole_version=1.5.0
 # if set to 1, enables snmpd and other various bits to support
 # monitoring via LibreNMS
 librenms_enable=0


### PR DESCRIPTION
Current version 1.4.0 is not available on the remote server anymore, throwing a 404 error and effectively not installing guacamole.
Additionally add a check for poetry path, since the guac-web.service will not work out of the box