### PR TITLE
Update how sample hashes are associated with extracted configs and display them in the UI.

### DIFF
--- a/lib/cuckoo/common/objects.py
+++ b/lib/cuckoo/common/objects.py
@@ -548,7 +548,7 @@ class File:
         filetype = self.get_content_type()
         return any([ftype in filetype for ftype in type_list])
 
-    def get_all_hashe(self):
+    def get_all_hashes(self):
         return {
             "crc32": self.get_crc32(),
             "md5": self.get_md5(),

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -155,6 +155,9 @@ img.opaque:hover {
     margin: 0 auto !important;
     float: none !important;
 }
+.table-bordered tfoot th, .table-bordered tfoot td {
+    border-top: 4px solid #444;
+}
 a.tag-label {
     color: white;
 }

--- a/web/templates/analysis/overview/index.html
+++ b/web/templates/analysis/overview/index.html
@@ -4,27 +4,71 @@
 {% if analysis.malware_conf %}
     {% for config_block in analysis.malware_conf %}
         {% for family, config in config_block.items %}
-            {% if family not in "associated_config_hashes,associated_analysis_hashes" %}
-            <div class="card-header">
-                <a class="accordion-toggle" data-toggle="collapse" aria-expanded="true" href="#{{family}}_config"><i class="fas fa-tasks"></i><span> {{family}} Config</span></a>
-                {% if analysis.info.has_cents_rules %}
-                    <a class="btn btn-secondary btn-sm" href="{% url "filereport" analysis.info.id "cents" %}"><span class="fas fa-download"></span> CENTS ruleset</a>
-                {% endif %}
-            </div>
-            <div id="{{family}}_config" class="collapse show">
-                <table class="table table-striped table-bordered" style="table-layout: fixed;">
-                    <tr>
-                        <th style="border-top: 0; width: 15%;">Type</th>
-                        <td style="border-top: 0; word-wrap: break-word;"><b>{{family}} Config</b></td>
-                    </tr>
-                    {% for key, value in config.items %}
-                    <tr>
-                        <th style="border-top: 0; width: 15%;"><b>{{key}}</b></th>
-                        <td style="border-top: 0; word-wrap: break-word;">{% malware_config value %}</td>
-                    </tr>
-                    {% endfor %}
-                </table>
-            </div>
+            {% if family|slice:":1" != "_" %}
+                <div class="card-header">
+                    <a class="accordion-toggle" data-toggle="collapse" aria-expanded="true" href="#{{family}}_config"><i class="fas fa-tasks"></i><span> {{family}} Config</span></a>
+                    {% if analysis.info.has_cents_rules %}
+                        <a class="btn btn-secondary btn-sm" href="{% url "filereport" analysis.info.id "cents" %}"><span class="fas fa-download"></span> CENTS ruleset</a>
+                    {% endif %}
+                </div>
+                <div id="{{family}}_config" class="collapse show">
+                    <table class="table table-striped table-bordered" style="table-layout: fixed;">
+                        <thead>
+                            <tr>
+                                <th style="border-top: 0; width: 15%;">Type</th>
+                                <th style="border-top: 0; word-wrap: break-word;">{{family}} Config</th>
+                            </tr>
+                        </thead>
+                        {% if config_block|get_item:"_associated_config_hashes" %}
+                            <tfoot>
+                                <tr>
+                                    <th>Extracted From</th>
+                                    <td>
+                                        {% for hashes in config_block|get_item:"_associated_config_hashes" %}
+                                            <div class="card" style="margin-bottom: 4px">
+                                                    {% with short_sha256=hashes.sha256|slice:":8" %}
+                                                    {% with hashes_id=family|add:"-"|add:short_sha256 %}
+                                                    {% with hashes_header_id=hashes_id|add:"-header" %}
+                                                    <div class="card-header" id="{{ hashes_header_id }}" style="padding: 0px">
+                                                        <h3 class="mb-0">
+                                                            <a class="btn btn-block text-left" role="button" data-toggle="collapse" href="#{{ hashes_id }}" aria-expanded="false" aria-controls="{{ hashes_id }}">
+                                                                <b>sha256:</b> {{ hashes.sha256 }}
+                                                            </a>
+                                                        </h3>
+                                                    </div>
+                                                    <div id="{{ hashes_id }}" class="collapse" aria-labelledby="{{ hashes_header_id }}">
+                                                        <div class="card-body">
+                                                            <dl class="row" style="margin-bottom: 0px">
+                                                                {% with sorted_hashes=hashes|sort %}
+                                                                    {% for algo, value in sorted_hashes.items %}
+                                                                        {% if algo != "sha256" %}
+                                                                            <dt class="col-sm-1">{{ algo }}</dt>
+                                                                            <dd class="col-sm-11">{{ value }}</dd>
+                                                                        {% endif %}
+                                                                    {% endfor %}
+                                                                {% endwith %}
+                                                            </dl>
+                                                        </div>
+                                                    </div>
+                                                {% endwith %}
+                                                {% endwith %}
+                                                {% endwith %}
+                                            </div>
+                                        {% endfor %}
+                                    </td>
+                                </tr>
+                            </tfoot>
+                        {% endif %}
+                        <tbody>
+                            {% for key, value in config.items %}
+                                <tr>
+                                    <th style="border-top: 0; width: 15%;"><b>{{key}}</b></th>
+                                    <td style="border-top: 0; word-wrap: break-word;">{% malware_config value %}</td>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
             {% endif %}
         {% endfor %}
     {% endfor %}


### PR DESCRIPTION
If more than one artifact from a detonation has the same config extracted from it, associated the hashes for each of them with the config. This requires the _associated_config_hashes to be stored as a list of dicts instead of a single dict.

Rename associated_config_hashes and associated_analysis_hashes to each have a leading underscore. This makes it easier to identify what is a malware family (no leading underscore) from something that is more like meta data. The alternative would've been to include the hashes inside the family's config dict, but I think it's better to keep that to only the actual config pieces that were extracted.

UI: For each extracted config, display the sha256 of each artifact it was extracted from. Clicking on it will expand to show the other hashes for the artifact.

Here's what the UI looks like with the hashes collapsed:
<img width="815" alt="collapsed" src="https://user-images.githubusercontent.com/4206917/226948028-747f6a0b-b56b-4714-b4e8-b249901dbb24.png">
Note that there could be more than one sha256 listed.

Clicking on the sha256 expands it out like this:
<img width="1201" alt="expanded" src="https://user-images.githubusercontent.com/4206917/226948037-8e16b5b2-7ed0-49da-91f7-05da21c8739f.png">
