### PR TITLE
If free=yes, a pid in pids returned from analysis package can be None

### DIFF
--- a/analyzer/windows/analyzer.py
+++ b/analyzer/windows/analyzer.py
@@ -845,7 +845,8 @@ class ProcessList:
         """Add one or more process identifiers to the process list."""
         if isinstance(pids, (tuple, list)):
             for pid in pids:
-                self.add_pid(pid)
+                if pid is not None:
+                    self.add_pid(pid)
         else:
             self.add_pid(pids)
 


### PR DESCRIPTION
This was causing the analyzer to crash and not perform analysis cleanup.