### PR TITLE
Hancitor update

### DIFF
--- a/modules/processing/parsers/CAPE/Hancitor.py
+++ b/modules/processing/parsers/CAPE/Hancitor.py
@@ -3,6 +3,8 @@
 """
 import hashlib
 import logging
+import re
+import struct
 
 import pefile
 from Cryptodome.Cipher import ARC4
@@ -12,22 +14,39 @@ AUTHOR = "threathive"
 
 log = logging.getLogger(__name__)
 
+def getHashKey(key_data):
+    # source: https://github.com/OALabs/Lab-Notes/blob/main/Hancitor/hancitor.ipynb
+    m = hashlib.sha1()
+    m.update(key_data)
+    key = m.digest()[:5]
+    return key
+
+
+def get_key_config_data(filebuf, pe):
+    # source: https://github.com/OALabs/Lab-Notes/blob/main/Hancitor/hancitor.ipynb
+    RE_KEY = rb'\x6a(.)\x68(....)\x68\x00\x20\x00\x00'
+    m = re.search(RE_KEY, filebuf)
+    key_len = struct.unpack('b', m.group(1))[0]
+    key_address = struct.unpack('<I', m.group(2))[0]
+    key_rva = key_address - pe.OPTIONAL_HEADER.ImageBase
+    key_offset = pe.get_offset_from_rva(key_rva)
+    key_data = filebuf[key_offset:key_offset + key_len]
+    key = getHashKey(key_data)
+    config_data = filebuf[key_offset + key_len:key_offset + key_len+0x2000]
+    return key, config_data
+
 
 def extract_config(filebuf):
     cfg = {}
     try:
         pe = pefile.PE(data=filebuf, fast_load=False)
-        for i in pe.sections:
-            if b".data" in i.Name:
-                DATA_SECTION = i.get_data()
-                key = hashlib.sha1(DATA_SECTION[16:24]).digest()[:5]
-                ENCRYPT_DATA = DATA_SECTION[24:2000]
-                DECRYPTED_DATA = ARC4.new(key).decrypt(ENCRYPT_DATA)
-                build_id, controllers = list(filter(None, DECRYPTED_DATA.split(b"\x00")))
-                cfg.setdefault("Build ID", build_id.decode())
-                controllers = list(filter(None, controllers.split(b"|")))
-                if controllers:
-                    cfg.setdefault("address", [url.decode() for url in controllers])
+        key, ENCRYPT_DATA = get_key_config_data(filebuf, pe)
+        DECRYPTED_DATA = ARC4.new(key).decrypt(ENCRYPT_DATA)
+        build_id, controllers = list(filter(None, DECRYPTED_DATA.split(b"\x00")))
+        cfg.setdefault("Build ID", build_id.decode())
+        controllers = list(filter(None, controllers.split(b"|")))
+        if controllers:
+            cfg.setdefault("address", [url.decode() for url in controllers])
     except Exception as e:
         log.warning(e)
 


### PR DESCRIPTION
Implemented code from OALabs (source: https://github.com/OALabs/Lab-Notes/blob/main/Hancitor/hancitor.ipynb) to use regex to find the encryption key instead of hard coded offset from the  .data section.

A few samples have the key in the .text section causing the extractor to fail: 137ae44ea6f625a3dae762a668b68c96b10f953e5b407d3f5600da096a014f46 1a495667c6a44520eaa6f284a254973e0ea0cf222e37ab4bb06a9b5cf930d89c