### PR TITLE
proxy/vpn selection feature

### DIFF
--- a/lib/cuckoo/common/web_utils.py
+++ b/lib/cuckoo/common/web_utils.py
@@ -561,10 +561,10 @@ def download_file(**kwargs):
         vpn_random = ""
 
         if routing_conf.socks5.random_socks5 and socks5s:
-            socks5s_random = choice(socks5s.values()).get("name", False)
+            socks5s_random = choice(list(socks5s.keys()))
 
-        if routing_conf.vpn.random_vpn:
-            vpn_random = choice(list(vpns.values())).get("name", False)
+        if routing_conf.vpn.random_vpn and vpns:
+            vpn_random = choice(list(vpns.keys()))
 
         if vpn_random and socks5s_random:
             route = choice((vpn_random, socks5s_random))

--- a/lib/cuckoo/core/rooter.py
+++ b/lib/cuckoo/core/rooter.py
@@ -12,9 +12,8 @@ cfg = Config()
 router_cfg = Config("routing")
 log = logging.getLogger(__name__)
 
-vpns = {}
-socks5s = {}
-
+vpns = dict()
+socks5s = dict()
 
 def _load_socks5_operational():
 
@@ -42,6 +41,14 @@ def _load_socks5_operational():
                 continue
 
             socks5s[name] = socks5.to_dict()
+
+            # decode utf-8 socks5man database data
+            for k, v in socks5s[name].items():
+                if isinstance(v, (bytes, bytearray)):
+                    try:
+                        socks5s[name][k] = v.decode()
+                    except (UnicodeDecodeError, AttributeError):
+                        pass
     except Socks5manDatabaseError as e:
         print(e, "you migth have an outdated database at $HOME/.socks5man")
 

--- a/utils/rooter.py
+++ b/utils/rooter.py
@@ -479,8 +479,8 @@ def socks5_enable(ipaddr, resultserver_port, dns_port, proxy_port):
         "--to-ports",
         proxy_port,
     )
-    run_iptables("-I", "1", "OUTPUT", "-m", "conntrack", "--ctstate", "INVALID", "-j", "DROP")
-    run_iptables("-I", "2", "OUTPUT", "-m", "state", "--state", "INVALID", "-j", "DROP")
+    run_iptables("-I", "OUTPUT", "1", "-m", "conntrack", "--ctstate", "INVALID", "-j", "DROP")
+    run_iptables("-I", "OUTPUT", "2", "-m", "state", "--state", "INVALID", "-j", "DROP")
     run_iptables(
         "-t", "nat", "-A", "PREROUTING", "-p", "tcp", "--dport", "53", "--source", ipaddr, "-j", "REDIRECT", "--to-ports", dns_port
     )

--- a/utils/submit.py
+++ b/utils/submit.py
@@ -43,6 +43,8 @@ def main():
     )
     parser.add_argument("--user", type=str, action="store", default=None, help="Username for Basic Auth", required=False)
     parser.add_argument("--password", type=str, action="store", default=None, help="Password for Basic Auth", required=False)
+    parser.add_argument("--token", type=str, action="store", default=None, help="Token for Token Auth", required=False)
+    parser.add_argument("--route", type=str, action="store", default=None, help="Specify an analysis route", required=False)
     parser.add_argument("--sslnoverify", action="store_true", default=False, help="Do not validate SSL cert", required=False)
     parser.add_argument("--ssl", action="store_true", default=False, help="Use SSL/TLS for remote", required=False)
     parser.add_argument("--url", action="store_true", default=False, help="Specify whether the target is an URL", required=False)
@@ -148,9 +150,9 @@ def main():
                 return False
 
             if args.ssl:
-                url = "https://{0}/tasks/create/url".format(args.remote)
+                url = "https://{0}/apiv2/tasks/create/url/".format(args.remote)
             else:
-                url = "http://{0}/tasks/create/url".format(args.remote)
+                url = "http://{0}/apiv2/tasks/create/url/".format(args.remote)
 
             data = dict(
                 url=target,
@@ -164,6 +166,7 @@ def main():
                 enforce_timeout=args.enforce_timeout,
                 custom=args.custom,
                 tags=args.tags,
+                route=args.route,
             )
 
             try:
@@ -176,6 +179,16 @@ def main():
                         response = requests.post(url, auth=(args.user, args.password), data=data, verify=verify)
                     else:
                         response = requests.post(url, auth=(args.user, args.password), data=data)
+                elif args.token:
+                    if args.ssl:
+                        if args.sslnoverify:
+                            verify = False
+                        else:
+                            verify = True
+                        response = requests.post(url, headers={"Authorization": f"Token {args.token}"}, data=data,
+                                                 verify=verify)
+                    else:
+                        response = requests.post(url, headers={"Authorization": f"Token {args.token}"}, data=data)
                 else:
                     if args.ssl:
                         if args.sslnoverify:
@@ -206,6 +219,7 @@ def main():
                 enforce_timeout=args.enforce_timeout,
                 clock=args.clock,
                 tags=args.tags,
+                route=args.route,
             )
 
         if task_id:
@@ -259,9 +273,9 @@ def main():
                     print((bold(red("Error")) + ": you need to install python-requests (`pip3 install requests`)"))
                     return False
                 if args.ssl:
-                    url = "https://{0}/tasks/create/file".format(args.remote)
+                    url = "https://{0}/apiv2/tasks/create/file/".format(args.remote)
                 else:
-                    url = "http://{0}/tasks/create/file".format(args.remote)
+                    url = "http://{0}/apiv2/tasks/create/file/".format(args.remote)
 
                 files = dict(file=open(file_path, "rb"), filename=os.path.basename(file_path))
 
@@ -276,6 +290,7 @@ def main():
                     enforce_timeout=args.enforce_timeout,
                     custom=args.custom,
                     tags=args.tags,
+                    route=args.route,
                 )
 
                 try:
@@ -288,6 +303,17 @@ def main():
                             response = requests.post(url, auth=(args.user, args.password), files=files, data=data, verify=verify)
                         else:
                             response = requests.post(url, auth=(args.user, args.password), files=files, data=data)
+                    elif args.token:
+                        if args.ssl:
+                            if args.sslnoverify:
+                                verify = False
+                            else:
+                                verify = True
+                            response = requests.post(url, headers={"Authorization": f"Token {args.token}"}, files=files,
+                                                     data=data, verify=verify)
+                        else:
+                            response = requests.post(url, headers={"Authorization": f"Token {args.token}"}, files=files,
+                                                     data=data)
                     else:
                         if args.ssl:
                             if args.sslnoverify:
@@ -303,7 +329,7 @@ def main():
                     return False
 
                 json = response.json()
-                task_ids = [json.get("task_ids")]
+                task_ids = json["data"].get("task_ids")
 
             else:
                 if args.unique and db.check_file_uniq(File(file_path).get_sha256()):
@@ -327,6 +353,7 @@ def main():
                         enforce_timeout=args.enforce_timeout,
                         clock=args.clock,
                         tags=args.tags,
+                        route=args.route,
                     )
                 except CuckooDemuxError as e:
                     task_ids = []

--- a/web/submission/views.py
+++ b/web/submission/views.py
@@ -34,7 +34,7 @@ from lib.cuckoo.common.web_utils import (
     process_new_task_files,
 )
 from lib.cuckoo.core.database import Database
-from lib.cuckoo.core.rooter import _load_socks5_operational
+from lib.cuckoo.core.rooter import _load_socks5_operational, vpns
 
 # this required for hash searches
 cfg = Config("cuckoo")
@@ -550,7 +550,6 @@ def index(request, task_id=None, resubmit_hash=None):
         if routing.socks5.random_socks5 and socks5s:
             socks5s_random = socks5s[random.choice(list(socks5s.keys()))]
 
-        from lib.cuckoo.core.rooter import vpns
         if routing.vpn.random_vpn and vpns:
             vpn_random = vpns[random.choice(list(vpns.keys()))]
 
@@ -578,7 +577,7 @@ def index(request, task_id=None, resubmit_hash=None):
                     "port": random_route["port"],
                     "type": "SOCKS5"
                 }
-        socks5s = [
+        socks5s_data = [
             {
                 "name": v["description"],
                 "host": v["host"],
@@ -587,7 +586,7 @@ def index(request, task_id=None, resubmit_hash=None):
             }
             for k, v in socks5s.items()
         ]
-        vpns = [
+        vpns_data = [
             {
                 "name": v["name"],
                 "description": v["description"],
@@ -611,9 +610,9 @@ def index(request, task_id=None, resubmit_hash=None):
             {
                 "packages": sorted(packages),
                 "machines": machines,
-                "vpns": vpns,
+                "vpns": vpns_data,
                 "random_route": random_route,
-                "socks5s": socks5s,
+                "socks5s": socks5s_data,
                 "route": routing.routing.route,
                 "internet": routing.routing.internet,
                 "inetsim": routing.inetsim.enabled,

--- a/web/templates/submission/index.html
+++ b/web/templates/submission/index.html
@@ -228,7 +228,11 @@ $(document).ready( function() {
                                             <option value="internet"{% if route == "internet" %} selected{% endif %}>Internet (dirty line, {{ internet }})</option>
                                         {% endif %}}
                                         {% if random_route %}
-                                            <option value="{{random_route}}" selected>{{random_route}}</option>
+                                            {% if random_route.type == "SOCKS5" %}
+                                            <option value="{{ random_route.name }}" selected hidden>[RANDOM] {{ random_route.name }} - {{ random_route.host }}:{{ random_route.port }} ({{ random_route.type }})</option>
+                                            {% else %}
+                                            <option value="{{ vpn.name }}" selected hidden>[RANDOM] {{ vpn.description }} ({{ vpn.interface }}, {{ vpn.type }})</option>
+                                            {% endif %}
                                         {% endif %}
                                         {% if inetsim %}
                                             <option value="inetsim">inetsim/fakenet-ng</option>
@@ -237,11 +241,11 @@ $(document).ready( function() {
                                             <option value="tor">tor</option>
                                         {% endif %}
                                         {% for vpn in vpns %}
-                                            <option value="{{ vpn.name }}">{{ vpn.description }} (VPN, {{ vpn.interface }})</option>
+                                            <option value="{{ vpn.name }}">{{ vpn.description }} ({{ vpn.interface }}, {{ vpn.type }})</option>
                                         {% endfor %}
 
-                                        {% for socks5 in socks5s|dictsort:"0.lower" %}
-                                            <option value="{{ socks5.name }}">{{ socks5.description }} (socks5)</option>
+                                        {% for socks5 in socks5s %}
+                                            <option value="{{ socks5.name }}">{{ socks5.name }} - {{ socks5.host }}:{{ socks5.port }} ({{ socks5.type }})</option>
                                         {% endfor %}
                                         {% if all_exitnodes %}
                                             {% for route_name in all_exitnodes %}


### PR DESCRIPTION
Hi, in my use case it is convenient for me to be able to select which route to submit to the analysis and therefore I have added this feature. I hope it can be useful for others too :)

I also have a question: which socks5 transparent proxy do you use? I tried several socks5 transparent proxies (redsocks, redsocks2, gost, danted...) but your `iptables` double REDIRECT target for UDP and TCP traffic only works with: https://github.com/n1nj4sec/pr0cks.

NOTES: I also modified the `utils/submit.py` file because I couldn't submit the analysis correctly, if I touched something wrong, tell me and I'll change it back :+1: