### PR TITLE
Changing pool size to be per VMSS

### DIFF
--- a/conf/az.conf
+++ b/conf/az.conf
@@ -27,7 +27,7 @@ interface = eth1
 # Virtual Network containing Cuckoo host and guests
 vnet = <vnet>
 
-# Subnet within virtual network for Cuckoo containing the guests and the interface of the 
+# Subnet within virtual network for Cuckoo containing the guests and the interface of the
 # host where the resultserver is listening
 subnet = <subnet>
 
@@ -69,9 +69,6 @@ gallery_name = <gallery_name>
 # Specify the storage account type for the OS disk (for example, Standard_LRS)
 storage_account_type = <storage_account_type>
 
-# Initial virtual machine pool size for each scale set
-initial_pool_size = 1
-
 # Reset pool size to initial_pool_size on CAPE restart
 reset_pool_size = true
 
@@ -84,7 +81,7 @@ scale_sets = cuckoo1
 # A percentage to be used for overprovisioning a scale set. To disable overprovisiong, set to 0
 overprovision = 0
 
-# This time, in seconds, is used to build up a queue of machines that need to be reimaged, 
+# This time, in seconds, is used to build up a queue of machines that need to be reimaged,
 # such that we can perform bulk reimaging.
 wait_time_to_reimage = 15
 
@@ -118,6 +115,9 @@ platform = windows
 # x64 or x86
 arch = x64
 
-# A tag used to specify on which guest scale set a sample should be run. All 
+# A tag used to specify on which guest scale set a sample should be run. All
 # virtual machines in this scale set will have this tag
 pool_tag = <tag>
+
+# Initial virtual machine pool size for scale set
+initial_pool_size = 1

--- a/conf/az.conf.default
+++ b/conf/az.conf.default
@@ -27,7 +27,7 @@ interface = eth1
 # Virtual Network containing Cuckoo host and guests
 vnet = <vnet>
 
-# Subnet within virtual network for Cuckoo containing the guests and the interface of the 
+# Subnet within virtual network for Cuckoo containing the guests and the interface of the
 # host where the resultserver is listening
 subnet = <subnet>
 
@@ -69,9 +69,6 @@ gallery_name = <gallery_name>
 # Specify the storage account type for the OS disk (for example, Standard_LRS)
 storage_account_type = <storage_account_type>
 
-# Initial virtual machine pool size for each scale set
-initial_pool_size = 1
-
 # Reset pool size to initial_pool_size on CAPE restart
 reset_pool_size = true
 
@@ -84,7 +81,7 @@ scale_sets = cuckoo1
 # A percentage to be used for overprovisioning a scale set. To disable overprovisiong, set to 0
 overprovision = 0
 
-# This time, in seconds, is used to build up a queue of machines that need to be reimaged, 
+# This time, in seconds, is used to build up a queue of machines that need to be reimaged,
 # such that we can perform bulk reimaging.
 wait_time_to_reimage = 15
 
@@ -118,6 +115,9 @@ platform = windows
 # x64 or x86
 arch = x64
 
-# A tag used to specify on which guest scale set a sample should be run. All 
+# A tag used to specify on which guest scale set a sample should be run. All
 # virtual machines in this scale set will have this tag
 pool_tag = <tag>
+
+# Initial virtual machine pool size for scale set
+initial_pool_size = 1


### PR DESCRIPTION
Rather than having a general initial pool size for all scale sets, we want a customized one per scale set