### PR TITLE
Fix Additional Filter in Behavioral Analysis

### DIFF
--- a/docs/book/src/development/current_module_improvement.rst
+++ b/docs/book/src/development/current_module_improvement.rst
@@ -20,6 +20,6 @@ Suricata name detection
     CUCKOO_ROOT = os.path.join(os.path.abspath(os.path.dirname(__file__)), "..")
     sys.path.append(CUCKOO_ROOT)
 
-    from lib.cuckoo.core.plugins import get_suricata_family
+    from lib.cuckoo.common.suricata_detection import get_suricata_family
     # Signature example: "ET MALWARE Sharik/Smoke CnC Beacon 11"
     print(get_suricata_family(signature_string))

--- a/utils/community.py
+++ b/utils/community.py
@@ -208,7 +208,18 @@ def main():
     enabled = []
 
     if args.all:
-        enabled = ["feeds", "processing", "signatures", "reporting", "machinery", "analyzer", "data", "integrations", "mitre", "common"]
+        enabled = [
+            "feeds",
+            "processing",
+            "signatures",
+            "reporting",
+            "machinery",
+            "analyzer",
+            "data",
+            "integrations",
+            "mitre",
+            "common",
+        ]
         flare_capa()
     else:
         if args.feeds:
@@ -224,7 +235,7 @@ def main():
         if args.analyzer:
             enabled.append("analyzer")
         if args.common:
-             enabled.append("common")
+            enabled.append("common")
         # Data contains yara
         if args.data:
             enabled.append("data")

--- a/utils/community.py
+++ b/utils/community.py
@@ -102,6 +102,7 @@ def install(enabled, force, rewrite, filepath: str = False, access_token=None, p
         "machinery": "modules/machinery",
         "analyzer": "analyzer",
         "data": "data",
+        "common": "lib/cuckoo/common",
         "integrations": "lib/cuckoo/common/integrations",
         "mitre": "data/mitre",
         "yara": "data/yara",
@@ -140,7 +141,7 @@ def install(enabled, force, rewrite, filepath: str = False, access_token=None, p
             dest_file = os.path.basename(filepath)
 
             if filepath in blocklist.get(category, []):
-                print(f'You have blacklisted file: {dest_file}. {colors.yellow("skipped")}')
+                print(f'You have blocklisted file: {dest_file}. {colors.yellow("skipped")}')
                 continue
 
             if not force:
@@ -166,6 +167,7 @@ def main():
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-a", "--all", help="Download everything", action="store_true", required=False)
+    parser.add_argument("-cm", "--common", help="Download CAPE common modules", action="store_true", required=False)
     parser.add_argument("-e", "--feeds", help="Download CAPE feed modules", action="store_true", required=False)
     parser.add_argument("-s", "--signatures", help="Download CAPE signatures", action="store_true", required=False)
     parser.add_argument("-p", "--processing", help="Download processing modules", action="store_true", required=False)
@@ -206,7 +208,7 @@ def main():
     enabled = []
 
     if args.all:
-        enabled = ["feeds", "processing", "signatures", "reporting", "machinery", "analyzer", "data", "integrations", "mitre"]
+        enabled = ["feeds", "processing", "signatures", "reporting", "machinery", "analyzer", "data", "integrations", "mitre", "common"]
         flare_capa()
     else:
         if args.feeds:
@@ -221,6 +223,8 @@ def main():
             enabled.append("machinery")
         if args.analyzer:
             enabled.append("analyzer")
+        if args.common:
+             enabled.append("common")
         # Data contains yara
         if args.data:
             enabled.append("data")

--- a/web/analysis/views.py
+++ b/web/analysis/views.py
@@ -850,8 +850,6 @@ def filtered_chunk(request, task_id, pid, category, apilist, caller, tid):
         apis = apilist.split(",")
         apis[:] = [s.strip().lower() for s in apis if len(s.strip())]
 
-        tid = int(tid)
-
         # Populate dict, fetching data from all calls and selecting only appropriate category/APIs.
         for call in process["calls"]:
             if enabledconf["mongodb"]:
@@ -860,8 +858,8 @@ def filtered_chunk(request, task_id, pid, category, apilist, caller, tid):
                 chunk = es.search(index=get_calls_index(), body={"query": {"match": {"_id": call}}})["hits"]["hits"][0]["_source"]
             for call in chunk["calls"]:
                 # filter by call or tid
-                if caller != "null" or tid != 0:
-                    if call["caller"] == caller and call["thread_id"] == tid:
+                if caller != "null" or tid != "0":
+                    if (caller == "null" or call["caller"] == caller) and (tid == "0" or call["thread_id"] == tid):
                         filtered_process["calls"].append(call)
                 elif category in ("all", call["category"]):
                     if len(apis) > 0:

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -272,7 +272,7 @@ pre {
     /*background-color: white;*/
     color: #5bc0de;
 }
-#filter-toggle {
+.filter-toggle {
     display: inline-block;
     cursor: pointer;
 }

--- a/web/templates/analysis/behavior/_processes.html
+++ b/web/templates/analysis/behavior/_processes.html
@@ -163,7 +163,7 @@
                     </div>
                 </div>
 
-                <a id="filter-toggle">
+                <a class="filter-toggle" id="filter_toggle_{{process.process_id}}">
                     <h4>Additional Filters</h4>
                 </a>
                 <div class="filter-box">
@@ -176,7 +176,7 @@
                         <label class="sr-only" for="form_search">API Filter2</label>
                         <input type="text" class="form-control" id="tidfilter_{{process.process_id}}" name="tidfilter" size=25 placeholder="TID" />
                     </div>
-                    <button id="submit-filter" type="submit" class="btn btn-secondary">Filter</button>
+                    <button id="submit_filter_{{process.process_id}}" type="submit" class="btn btn-secondary">Filter</button>
                 </div>
             </div>
 
@@ -203,11 +203,11 @@
                     event.preventDefault();
                 });
                 // toggles additional filtering
-                $("#filter-toggle").click(function(){
+                $("#filter_toggle_{{process.process_id}}").click(function(){
                     $(".filter-box").toggle()
                 })
                 // submits filters to backend
-                $("#submit-filter").click(function(){
+                $("#submit_filter_{{process.process_id}}").click(function(){
                     var pid = {{process.process_id}};
                     var caller = ($("#callerfilter_"+pid).val() == "") ? "null" : $("#callerfilter_"+pid).val();
                     var tid = ($("#tidfilter_"+pid).val() == "") ? 0 : $("#tidfilter_"+pid).val();


### PR DESCRIPTION
This MR:
* Fixes using the Additional Filter in process tabs (it only worked in the first tab due to non-unique IDs).
* Fixes a bug where tid was casted to `int` but `call["thread_id"]` is always `str`.
* Removes requirement to specify both, caller and tid, allowing you to filter for just one of the two.