### PR TITLE
Fix CAPA output in HTML summary report - Closes #1523

### DIFF
--- a/modules/reporting/reporthtml.py
+++ b/modules/reporting/reporthtml.py
@@ -69,7 +69,7 @@ class ReportHTML(Report):
                 "dict2list": dict2list,
                 "parentfixup": parentfixup,
                 "malware_config": malware_config,
-                "flare_capa_capabilities": flare_capa_capabilities,
+                "flare_capa_capability": flare_capa_capabilities,
                 "flare_capa_attck": flare_capa_attck,
                 "flare_capa_mbc": flare_capa_mbc,
                 "datefmt": datefmt,

--- a/modules/reporting/reporthtmlsummary.py
+++ b/modules/reporting/reporthtmlsummary.py
@@ -82,7 +82,7 @@ class ReportHTMLSummary(Report):
                 "dict2list": dict2list,
                 "parentfixup": parentfixup,
                 "malware_config": malware_config,
-                "flare_capa_capabilities": flare_capa_capabilities,
+                "flare_capa_capability": flare_capa_capabilities,
                 "flare_capa_attck": flare_capa_attck,
                 "flare_capa_mbc": flare_capa_mbc,
                 "datefmt": datefmt,


### PR DESCRIPTION
Updates the `filters` environment variable in `reporthtml.py` and `reporthtmlsummary.py` to reflect the actual name of the filter for CAPA. The filter name for the function `flare_capa_capabilities` is `flare_capa_capability`, not `flare_capa_capabilities`. See https://github.com/kevoreilly/CAPEv2/blob/705ea08c24b069fa2bb609b5f9f643fd9479bc4e/web/analysis/templatetags/analysis_tags.py#L113