### PR TITLE
Volatility configuration issue fix

### DIFF
--- a/modules/processing/memory.py
+++ b/modules/processing/memory.py
@@ -16,6 +16,7 @@ from lib.cuckoo.common.abstracts import Processing
 from lib.cuckoo.common.constants import CUCKOO_ROOT
 from lib.cuckoo.common.exceptions import CuckooProcessingError
 from lib.cuckoo.common.path_utils import path_delete, path_exists
+from lib.cuckoo.common.config import Config
 
 try:
     import re2 as re
@@ -184,6 +185,7 @@ class VolatilityManager:
         self.mask_pid = []
         self.taint_pid = set()
         self.memfile = memfile
+        self.options = Config("memory")
 
         conf_path = os.path.join(CUCKOO_ROOT, "conf", "memory.conf")
         if not path_exists(conf_path):


### PR DESCRIPTION
ERROR: Generic error executing volatility
Traceback (most recent call last):
  File "/opt/CAPEv2/utils/../modules/processing/memory.py", line 339, in run
    vol = VolatilityManager(self.memory_path)
  File "/opt/CAPEv2/utils/../modules/processing/memory.py", line 196, in __init__
    if isinstance(self.options.mask.pid_generic, int):
AttributeError: 'VolatilityManager' object has no attribute 'options'


It seems like the config for volatility is never fetched, adding the following lines resolves the issue. 