### PR TITLE
Prevent exceptions in guac-web app

### DIFF
--- a/web/web/guac_settings.py
+++ b/web/web/guac_settings.py
@@ -77,7 +77,7 @@ TEMPLATES = [
 ]
 
 # Database settings. We don't need it.
-DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3", "NAME": "siteauth.sqlite"}
+DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3", "NAME": "siteauth.sqlite"}}
 
 ASGI_APPLICATION = "web.asgi.application"
 

--- a/web/web/guac_settings.py
+++ b/web/web/guac_settings.py
@@ -49,6 +49,7 @@ INSTALLED_APPS = [
     "django.contrib.contenttypes",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "django.contrib.sessions",
     "django_extensions",
 ]
 
@@ -74,6 +75,9 @@ TEMPLATES = [
         },
     },
 ]
+
+# Database settings. We don't need it.
+DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3", "NAME": "siteauth.sqlite"}
 
 ASGI_APPLICATION = "web.asgi.application"
 


### PR DESCRIPTION
After authentication is enabled in the main Django app, the `guac-web` app will raise exceptions when trying to load a Guacamole console page. This PR updates `guac_settings.py` to avoid these issues.

Exceptions addressed.

> Model class django.contrib.sessions.models.Session doesn't declare an explicit app_label and isn't in an application in INSTALLED_APPS

> django.core.exceptions.ImproperlyConfigured: settings.DATABASES is improperly configured. Please supply the ENGINE value. Check settings documentation.