### PR TITLE
Update IP and domain whitelists

### DIFF
--- a/extra/whitelist_domains.txt
+++ b/extra/whitelist_domains.txt
@@ -37,6 +37,7 @@ crl\.microsoft\.com
 \.res\.office365\.com$
 \.licdn\.com$
 \.xboxlive\.com$
+\.onestore\.ms$
 
 # Google
 update\.googleapis\.com$

--- a/extra/whitelist_domains.txt
+++ b/extra/whitelist_domains.txt
@@ -31,6 +31,12 @@ crl\.microsoft\.com
 \.windows\.com\.akadns\.net$
 \.microsoft\.com\.nsatc\.net$
 
+-microsoft-com\.akamaized\.net$
+\.s-microsoft\.com$
+\.msedge\.net$
+\.res\.office365\.com$
+\.licdn\.com$
+
 # Google
 update\.googleapis\.com$
 

--- a/extra/whitelist_domains.txt
+++ b/extra/whitelist_domains.txt
@@ -36,6 +36,7 @@ crl\.microsoft\.com
 \.msedge\.net$
 \.res\.office365\.com$
 \.licdn\.com$
+\.xboxlive\.com$
 
 # Google
 update\.googleapis\.com$

--- a/extra/whitelist_ips.txt
+++ b/extra/whitelist_ips.txt
@@ -1,4 +1,6 @@
 # CloudFlare's DNS server
 1.1.1.1
+1.0.0.1
 # Google's DNS server
 8.8.8.8
+4.4.4.4


### PR DESCRIPTION
Add alternate DNS resolver IP addresses

- Cloudflare - `1.0.0.1`
- Google - `8.8.8.8`

Add more Microsoft domains

`-microsoft-com\.akamaized\.net$` - Akamai CDN for Microsoft that device information is sent to for driver lookups
`\.s-microsoft\.com$` - gets queried when opening Settings and some other built-in Windows 10 apps
`\.msedge\.net$` - Microsoft Edge background things
`\.res\.office365\.com$` - Office 365/ Office 2016+ updates
`\.licdn\.com$` - LinkedIn CDN that gets queried by modern versions of Office (Microsoft owns LinkedIn) 
