### PR TITLE
Remove the protocol from the hostname value in web.conf

### DIFF
--- a/conf/web.conf.default
+++ b/conf/web.conf.default
@@ -40,8 +40,8 @@ anon_viewable = no
 existent_tasks = no
 top_detections = yes
 # hostname of the cape instance
-hostname = https://127.0.0.1/
-;hostname = https://www.capesandbox.com/
+hostname = 127.0.0.1
+;hostname = www.capesandbox.com
 # Check if config exists or try to extract before accept task as static
 check_config_exists = no
 # Assign architecture to task to fetch correct VM type


### PR DESCRIPTION
`CSRF_TRUSTED_ORIGINS` in `web/web/settings.py` expects the `hostname` value in `conf/web.conf` to be the hostname, not the full URL.

https://github.com/kevoreilly/CAPEv2/blob/master/web/web/settings.py#L40