### PR TITLE
Update whitelist_domains.txt

### DIFF
--- a/extra/whitelist_domains.txt
+++ b/extra/whitelist_domains.txt
@@ -44,6 +44,8 @@ msn-com\.akamaized\.net$
 \.virtualearth\.net$
 devtools\.azureedge\.net$
 
+\.local$
+
 # Google
 update\.googleapis\.com$
 _googlecast\._tcp\.local$

--- a/extra/whitelist_domains.txt
+++ b/extra/whitelist_domains.txt
@@ -35,6 +35,7 @@ crl\.microsoft\.com$
 -microsoft-com\.akamaized\.net$
 msn-com\.akamaized\.net$
 \.s-microsoft\.com$
+\.microsoft.net$
 \.msedge\.net$
 \.licdn\.com$
 \.xboxlive\.com$

--- a/extra/whitelist_domains.txt
+++ b/extra/whitelist_domains.txt
@@ -11,6 +11,7 @@ client-office365-tas\.msedge\.net$
 api\.onedrive\.com$
 \.live\.com$
 \.bing.com$
+\.res\.office365\.com$
 
 # Microsoft
 watson\.telemetry\.microsoft\.com$
@@ -26,21 +27,25 @@ download\.windowsupdate\.com$
 \.windows\.com$
 \.edgesuite\.net$
 \.blob\.core\.windows\.net$
-crl\.microsoft\.com
+crl\.microsoft\.com$
 
 \.windows\.com\.akadns\.net$
 \.microsoft\.com\.nsatc\.net$
 
 -microsoft-com\.akamaized\.net$
+msn-com\.akamaized\.net$
 \.s-microsoft\.com$
 \.msedge\.net$
-\.res\.office365\.com$
 \.licdn\.com$
 \.xboxlive\.com$
 \.onestore\.ms$
 
+\.virtualearth\.net$
+devtools\.azureedge\.net$
+
 # Google
 update\.googleapis\.com$
+_googlecast\._tcp\.local$
 
 # https://github.com/threatstop/crl-ocsp-whitelist
 aces\.ocsp\.identrust\.com


### PR DESCRIPTION
- Move `\.res\.office365\.com$` to the Office 365 domains list
- Add `$` to the end of `crl\.microsoft\.com`
- Add `msn-com\.akamaized\.net$` to the list of Microsoft domains
- Add `\.microsoft.net$` to the list of Microsoft domains
- Add `\.virtualearth\.net$` to the list of Microsoft domains
- Add `devtools\.azureedge\.net$` to the list of Microsoft domains (queried when the Developer Tools are opened in Microsoft Edge)
- Add `_googlecast\._tcp\.local$` to the list of Google domains (Queried when programs like Chrome and related browsers like Edge are searching for Google Cast devices on the local network)
- Add `\.local$` to the list of Microsoft domains. It is a reserved TLD, so no external domains can use it. For some reason Edge (and possibly Chrome query three random non-existent `.local` domain names when the developer tools are opened.