### PR TITLE
Improvements to NGINX and guacd configuration

### DIFF
--- a/docs/book/src/usage/interactive_desktop.rst
+++ b/docs/book/src/usage/interactive_desktop.rst
@@ -27,52 +27,72 @@ Enable and configure ``guacamole`` in ``conf/web.conf`` and restart ``cape-web.s
 
     $ systemctl restart cape-web guacd.service
 
-In case you using ``NGINX``, you need to configure it, to be able to use interactive mode, Example config.
+In case you using are ``NGINX``, you need to configure it to be able to use interactive mode.  Here's an example config.
 
-.. code-block:: python
+Replace `www.capesandbox.com` with your own hostname.
 
-    map $http_upgrade $connection_upgrade {
-        default upgrade;
-        ''      close;
-    }
-    upstream nodeserver1 {
-        # CAPE
-        server 127.0.0.1:8000;
-    }
-    upstream nodeserver2 {
-        # guac-session
-        server 127.0.0.1:8008;
-    }
-    server {
-        listen <YOUR_DESIRED_IP>;
-        client_max_body_size 101M;
-        location / {
-            proxy_pass http://nodeserver1;
-            proxy_set_header Host $host;
-            proxy_set_header X-Remote-User $remote_user;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+.. code-block:: nginx
+
+        server {
+            listen 80;
+            listen [::]:80;
+            server_name www.capesandbox.com;
+            client_max_body_size 101M;
+
+            location / {
+                proxy_pass http://127.0.0.1:8000;
+                proxy_set_header Host $host;
+                proxy_set_header X-Remote-User $remote_user;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            }
+
+            location /static/ {
+                alias /opt/CAPEv2/web/static/;
+            }
+
+            location /static/admin/ {
+                proxy_pass http://127.0.0.1:8000;
+                proxy_set_header Host $host;
+                proxy_set_header X-Remote-User $remote_user;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            }
+
+            location /guac {
+                proxy_pass http://127.0.0.1:8008;
+                proxy_set_header X-Forwarded-Proto $scheme;
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_buffering off;
+                proxy_http_version 1.1;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header Upgrade $http_upgrade;
+                proxy_set_header Connection $http_connection;
+            }
+
+            location /recordings/playback/recfile {
+                alias /opt/CAPEv2/storage/guacrecordings/;
+                autoindex off;
+            }
         }
-        location /static/ {
-            alias /opt/CAPEv2/web/static/;
-        }
-        location /guac {
-            proxy_pass http://nodeserver2;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_buffering off;
-            proxy_http_version 1.1;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection $http_connection;
-        }
-        location /guac/playback/recfile {
-            alias /var/www/guacrecordings/;
-            autoindex on;
-            autoindex_exact_size off;
-            autoindex_localtime on;
-        }
+
+If you want to block users from changing their own email addresses, add the following `location` directive inside of the `server` directive:
+
+.. code-block:: nginx
+
+    location /accounts/email/ {
+        return 403;
     }
+
+If you want to block users from changing their own passwords, add the following `location` directive inside of the `server` directive:
+
+.. code-block:: nginx
+
+    location /accounts/email/ {
+        return 403;
+    }
+        
 
 Virtual machine configuration
 =============================

--- a/systemd/guacd.service
+++ b/systemd/guacd.service
@@ -24,7 +24,7 @@ After=network.target
 ExecStart=/usr/local/sbin/guacd -f
 Restart=on-abnormal
 User=cape
-Group=cape
+Group=www-data
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
- Improvements to the example NGINX config file
  - Make the `/recordings/playback/recfile` URI point to the correct file path
  - Turn off auto indexing of the `/recordings/playback/recfile` URI for added privacy
  - Support serving static files for the Django admin application
  - Simplify the configuration by removing the `map` and `upstream` directives and moving the settings into the `location` directives
  - Provide examples on how to prevent users from changing their own passwords and/or email addresses
- `guacd` service improvements
  -  Set `guacd.service` `group` to `www-data` so NGINX can read the recording files 