### PR TITLE
Update NGINX instructions

### DIFF
--- a/docs/book/src/usage/interactive_desktop.rst
+++ b/docs/book/src/usage/interactive_desktop.rst
@@ -29,7 +29,7 @@ Enable and configure ``guacamole`` in ``conf/web.conf`` and restart ``cape-web.s
 
 In case you using are ``NGINX``, you need to configure it to be able to use interactive mode.  Here's an example config.
 
-Replace `www.capesandbox.com` with your own hostname.
+Replace ``www.capesandbox.com`` with your own hostname.
 
 .. code-block:: nginx
 
@@ -92,12 +92,63 @@ If you want to block users from changing their own passwords, add the following 
     location /accounts/email/ {
         return 403;
     }
-        
+
+The recording files written by ``guacd`` are only readable by the ``cape`` user and other members of the ``cape`` group, so in order for NGINX to read and serve the recordings the ``www-data`` user must be added to the ``cape`` group.
+
+.. code-block:: bash
+
+    sudo usermod www-data -G cape
+
+Then restart NGINX
+
+.. code-block:: bash
+
+    sudo service nginx restart
+
+.. warning::
+
+    The CAPE Guacamole Django web application is currently separate from the main CAPE Django web application, and does not support any authentication. Anyone who can connect to the web server access can Guacamole consoles and recordings, if they know the CAPE analysis ID and Guacamole session GUID.
+    
+    NGINX can be configured to require HTTP basic authentication for all CAPE web applications, as an alternative to the Django authentication system.
+
+    Install the ``apache2-utils`` package, which contains the ``htpasswd`` utility.
+ 
+    .. code-block:: bash
+
+        sudo apt install apache2-utils
+
+    Use the ``htpasswd`` file to create a new password file and add a first user, such as ``cape``.
+
+    .. code-block:: bash
+
+        sudo htpasswd -c /opt/CAPEv2/web/.htpasswd cape
+
+    Use the same command without the `-c` option to add another user to an existing password file.
+
+    Set the proper file permissions.
+
+    .. code-block:: bash
+
+        sudo chown root:www-data /opt/CAPEv2/web/.htpasswd
+        sudo chmod u=rw,g=r,o= /opt/CAPEv2/web/.htpasswd
+
+    Add the following lines to the NGINX configuration, just below the ``client_max_body_size`` line.
+
+    .. code-block :: nginx
+
+        auth_basic           "Authentication required";
+        auth_basic_user_file /opt/CAPEv2/web/.htpasswd;
+
+    Then restart NGINX
+
+    .. code-block:: bash
+
+        sudo service nginx restart
 
 Virtual machine configuration
 =============================
 * At the moment we support only KVM and we don't have plans to support any other hypervisor.
-* To enable support for remote session you need to configure your VM to use ``VNC`` display, otherwise it won't work.
+* To enable support for remote session you need to add a ``VNC`` display to your VM, otherwise it won't work.
 
 
 Having troubles?

--- a/systemd/guacd.service
+++ b/systemd/guacd.service
@@ -24,7 +24,7 @@ After=network.target
 ExecStart=/usr/local/sbin/guacd -f
 Restart=on-abnormal
 User=cape
-Group=www-data
+Group=cape
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
- Add `www-data` to `cape` group so NGINX can read recording files created by `guacd`
- Add warning about the lack of authentication on the CAPE `guac-web` service and recording files
-  Add optional NGINX HTTP basic authentication instructions
- Set `guacd.service` group back to cape
  - Revert change from https://github.com/kevoreilly/CAPEv2/commit/d722d7367ebed8ce72546fb1ffbff53d539ea8f0 because `guacd` will write files owned by the same group as the user either way

I understand that even without authentication, the risk of unauthorized access to Guacamole console and records are low, because the CAPE session ID and the Guacamole session GUID must be known to build the URL. That said, the ideal situation would be to build the functionality of the `guac-web` Django application into the main Django application, so the same authentication mechanism could be used for everything, and the recording files could be served behind that instead of being served directly by NGINX as static files.

I don't know enough about Django right now to do that myself but thought I should call out the (small) risk, and hope that maybe someone will take up the task of combining the web apps before I can, because I don't think I'll be able to get to it anytime soon.