### PR TITLE
Address conflict with QEMU package, bump QEMU to 8.0.2, and bump libvirt to 9.4.0

### DIFF
--- a/extra/poetry_libvirt_installer.sh
+++ b/extra/poetry_libvirt_installer.sh
@@ -3,7 +3,7 @@
 # run this via...
 # cd /opt/CAPEv2/ ; sudo -u cape poetry run extra/poetry_libvirt_installer.sh
 
-LIB_VERSION=9.0.0
+LIB_VERSION=9.4.0
 cd /tmp || return
 
 if [ ! -f v${LIB_VERSION}.zip ]; then

--- a/installer/kvm-qemu.sh
+++ b/installer/kvm-qemu.sh
@@ -51,10 +51,10 @@ QTARGETS="--target-list=i386-softmmu,x86_64-softmmu,i386-linux-user,x86_64-linux
 
 
 #https://www.qemu.org/download/#source or https://download.qemu.org/
-qemu_version=7.2.0
+qemu_version=8.0.2
 # libvirt - https://libvirt.org/sources/
 # changelog - https://libvirt.org/news.html
-libvirt_version=9.0.0
+libvirt_version=9.4.0
 # virt-manager - https://github.com/virt-manager/virt-manager/releases
 # autofilled
 OS=""
@@ -836,7 +836,7 @@ function install_qemu() {
         aptitude install -f software-properties-common -y
         add-apt-repository universe -y
         apt update 2>/dev/null
-        aptitude install -f python3-pip openbios-sparc openbios-ppc libssh2-1-dev vde2 liblzo2-dev libghc-gtk3-dev libsnappy-dev libbz2-dev libxml2-dev google-perftools libgoogle-perftools-dev libvde-dev python3-sphinx-rtd-theme -y
+        aptitude install -f python3-pip  libssh2-1-dev vde2 liblzo2-dev libghc-gtk3-dev libsnappy-dev libbz2-dev libxml2-dev google-perftools libgoogle-perftools-dev libvde-dev python3-sphinx-rtd-theme -y
         aptitude install -f debhelper libusb-1.0-0-dev libxen-dev uuid-dev xfslibs-dev libjpeg-dev libusbredirparser-dev device-tree-compiler texinfo libbluetooth-dev libbrlapi-dev libcap-ng-dev libcurl4-gnutls-dev libfdt-dev gnutls-dev libiscsi-dev libncurses5-dev libnuma-dev libcacard-dev librados-dev librbd-dev libsasl2-dev libseccomp-dev libspice-server-dev libaio-dev libcap-dev libattr1-dev libpixman-1-dev libgtk2.0-bin  libxml2-utils systemtap-sdt-dev uml-utilities libcapstone-dev -y
         # qemu docs required
         PERL_MM_USE_DEFAULT=1 perl -MCPAN -e install "Perl/perl-podlators"
@@ -858,7 +858,7 @@ function install_qemu() {
             cd qemu-$qemu_version || return
             # add in future --enable-netmap https://sgros-students.blogspot.com/2016/05/installing-and-testing-netmap.html
             # remove --target-list=i386-softmmu,x86_64-softmmu,i386-linux-user,x86_64-linux-user  if you want all targets
-                ./configure $QTARGETS --prefix=/usr --libexecdir=/usr/lib/qemu --localstatedir=/var --bindir=/usr/bin/ --enable-gnutls --enable-docs --enable-gtk --enable-vnc --enable-vnc-sasl --enable-curl --enable-kvm  --enable-linux-aio --enable-cap-ng --enable-vhost-net --enable-vhost-crypto --enable-spice --enable-usb-redir --enable-lzo --enable-snappy --enable-bzip2 --enable-coroutine-pool --enable-jemalloc --enable-replication --enable-tools
+                ./configure $QTARGETS --prefix=/usr --libexecdir=/usr/lib/qemu --localstatedir=/var --bindir=/usr/bin/ --enable-gnutls --enable-docs --enable-gtk --enable-vnc --enable-vnc-sasl --enable-curl --enable-kvm  --enable-linux-aio --enable-cap-ng --enable-vhost-net --enable-vhost-crypto --enable-spice --enable-usb-redir --enable-lzo --enable-snappy --enable-bzip2 --enable-coroutine-pool --enable-malloc=jemalloc --enable-replication --enable-tools
                 #  --enable-capstone
             if  [ $? -eq 0 ]; then
                 echo '[+] Starting Install it'


### PR DESCRIPTION
- Remove `openbios-sparc` `openbios-ppc` APT packages as build dependencies for `QEMU`
  - These are metapackages for `qemu-system-data`, which conflicts with the content of the bundled `qemu` package that will be built by `kvm-qemu.sh` (This applies `QEMU` 7 and 8)
  - Bump `libvirt` version from `9.0.0` to `9.4.0` in `installer/kvm-qemu.sh` and `extras/poetry_libvirt_installer.sh`
    - See https://www.libvirt.org/news.html for changes
  - Bump `QEMU` version from `7.0.0` to `8.0.2`
    - See https://wiki.qemu.org/ChangeLog/8.0 for changes
    - Addresses `CVE-2023-0330` (Could also just upgrade `QEMU` to `7.2.3` instead)
    - Accommodate changes in the `QEMU` 8 `configure` script by replacing the `--enable-jemalloc` option with `--enable-malloc=jemalloc`
