### PR TITLE
Fix issue with pre-commit hook.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
       - id: black
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort (python)


### PR DESCRIPTION
newer versions of poetry detect an issue with the pyproject.toml in older versions of isort. See https://github.com/PyCQA/isort/issues/2077.