### PR TITLE
Updated docs to reflect pyw preference and some troubleshooting with poetry upgrade

### DIFF
--- a/docs/book/src/installation/guest/agent.rst
+++ b/docs/book/src/installation/guest/agent.rst
@@ -18,6 +18,12 @@ spawned, with a title similar to ``C:\Windows\py.exe``. If you want to hide this
 *agent.py* to **agent.pyw** which will prevent the window from
 spawning upon launching the script. 
 
+   .. warning::
+      It is **encouraged** to use the agent in its window-less version (``.pyw`` extension) 
+      given that opening a ``cmd`` window will definitely interfere with `human.py <https://github.com/kevoreilly/CAPEv2/blob/master/analyzer/windows/modules/auxiliary/human.py>`_, causing 
+      several problems like blocking the `agent.py <https://github.com/kevoreilly/CAPEv2/blob/master/agent/agent.py>`_. communication with the host or 
+      producing no **behavioral analysis** output, just to mention some.
+
 Don't forget to test the agent before saving the snapshot. You can do it both navigating to ``VM_IP:8000`` with a browser from your Host or be executing: ``curl VM_IP:8000``. You should see an output similar to the following:
 
    .. image:: ../../_images/screenshots/running_agentpy_within_guest_0.png

--- a/docs/book/src/installation/upgrade.rst
+++ b/docs/book/src/installation/upgrade.rst
@@ -86,3 +86,35 @@ PIP3:
 PIP3+git:
    $ poetry run pip install -U git+<repo_url>
    $ poetry run pip install -U git+https://github.com/doomedraven/sflock
+
+Troubleshooting:
+================
+When trying to update your local CAPE installation with poetry with either of the following commands::
+
+   $ sudo -u cape poetry install
+   $ sudo -u cape poetry update
+
+you may encounter the following error::
+
+   CalledProcessError
+      Command '['git', '--git-dir', '/tmp/pypoetry-git-web3.pyocemorcf/.git', '--work-tree', '/tmp/pypoetry-git-web3.pyocemorcf', 'checkout', 'master']' returned non-zero exit status 1.
+
+
+Or maybe when trying to update ``poetry`` itself with::
+
+   $ sudo -u cape poetry self update
+
+you may face the following error::
+
+   RuntimeError
+      Poetry was not installed with the recommended installer. Cannot update automatically.
+
+That is becuase you probably installed poetry with pip.
+
+In order to solve it you must first upgrade your local ``poetry`` installation with::
+
+   $ sudo pip3 install poetry --upgrade
+
+and then run the update command again::
+
+   $ sudo -u cape poetry update


### PR DESCRIPTION
I think it is important to warn the used that the **standard, preferred** agent.py version is the cmd-windows-less *.pyw one.
Added some indications that may come handy when upgrading with poetry.