### PR TITLE
Two small bug fixes

### DIFF
--- a/lib/cuckoo/core/database.py
+++ b/lib/cuckoo/core/database.py
@@ -1588,7 +1588,7 @@ class Database(object, metaclass=Singleton):
 
         if tmp_package and tmp_package in sandbox_packages:
             # This probably should be way much bigger list of formats
-            if tmp_package == ("iso", "udf", "vhd"):
+            if tmp_package in ("iso", "udf", "vhd"):
                 package = "archive"
             elif tmp_package in ("zip", "rar"):
                 package = ""

--- a/utils/process.py
+++ b/utils/process.py
@@ -248,7 +248,7 @@ def autoprocess(
     maxcount = cfg.cuckoo.max_analysis_count
     count = 0
     # pool = multiprocessing.Pool(parallel, init_worker)
-    pool = None
+    pool = False
     try:
         memory_limit()
         log.info("Processing analysis data")
@@ -321,7 +321,7 @@ def autoprocess(
 
         traceback.print_exc()
     finally:
-        if pool is not None:
+        if pool:
             pool.close()
             pool.join()
 

--- a/utils/process.py
+++ b/utils/process.py
@@ -248,6 +248,7 @@ def autoprocess(
     maxcount = cfg.cuckoo.max_analysis_count
     count = 0
     # pool = multiprocessing.Pool(parallel, init_worker)
+    pool = None
     try:
         memory_limit()
         log.info("Processing analysis data")
@@ -320,8 +321,9 @@ def autoprocess(
 
         traceback.print_exc()
     finally:
-        pool.close()
-        pool.join()
+        if pool is not None:
+            pool.close()
+            pool.join()
 
 
 def _load_report(task_id: int, return_one: bool = False):


### PR DESCRIPTION
Bug 1:

The variable pool is referenced outside of its scope in the finally section of the function autoprocess. An unhandled exception from pebble.ProcessPool of type OSError can be thrown, which happens before pool is declared originally. This causes the finally clause to be executed, only pool does not exist yet.

Here is an example of a crash that I had caused by low memory resources:
```
Jun 05 00:05:19 CAPEv2-Server python3[6180]: Traceback (most recent call last):
Jun 05 00:05:19 CAPEv2-Server python3[6180]:   File "/opt/CAPEv2/utils/process.py", line 254, in autoprocess
Jun 05 00:05:19 CAPEv2-Server python3[6180]:     with pebble.ProcessPool(max_workers=parallel, max_tasks=maxtasksperchild, initializer=init_worker) as pool:
Jun 05 00:05:19 CAPEv2-Server python3[6180]:   File "/home/cape/.cache/pypoetry/virtualenvs/capev2-t2x27zRb-py3.10/lib/python3.10/site-packages/pebble/pool/process.py", line 61, in __init__
Jun 05 00:05:19 CAPEv2-Server python3[6180]:     self._pool_manager = PoolManager(self._context, mp_context)
Jun 05 00:05:19 CAPEv2-Server python3[6180]:   File "/home/cape/.cache/pypoetry/virtualenvs/capev2-t2x27zRb-py3.10/lib/python3.10/site-packages/pebble/pool/process.py", line 200, in __init__
Jun 05 00:05:19 CAPEv2-Server python3[6180]:     self.worker_manager = WorkerManager(context.workers,
Jun 05 00:05:19 CAPEv2-Server python3[6180]:   File "/home/cape/.cache/pypoetry/virtualenvs/capev2-t2x27zRb-py3.10/lib/python3.10/site-packages/pebble/pool/process.py", line 342, in __init__
Jun 05 00:05:19 CAPEv2-Server python3[6180]:     self.pool_channel, self.workers_channel = channels(mp_context)
Jun 05 00:05:19 CAPEv2-Server python3[6180]:   File "/home/cape/.cache/pypoetry/virtualenvs/capev2-t2x27zRb-py3.10/lib/python3.10/site-packages/pebble/pool/channel.py", line 34, in channels
Jun 05 00:05:19 CAPEv2-Server python3[6180]:     WorkerChannel(read0, write1, (read1, write0), mp_context))
Jun 05 00:05:19 CAPEv2-Server python3[6180]:   File "/home/cape/.cache/pypoetry/virtualenvs/capev2-t2x27zRb-py3.10/lib/python3.10/site-packages/pebble/pool/channel.py", line 86, in __init__
Jun 05 00:05:19 CAPEv2-Server python3[6180]:     self.mutex = ChannelMutex(mp_context)
Jun 05 00:05:19 CAPEv2-Server python3[6180]:   File "/home/cape/.cache/pypoetry/virtualenvs/capev2-t2x27zRb-py3.10/lib/python3.10/site-packages/pebble/pool/channel.py", line 132, in __init__
Jun 05 00:05:19 CAPEv2-Server python3[6180]:     self.reader_mutex = mp_context.RLock()
Jun 05 00:05:19 CAPEv2-Server python3[6180]:   File "/usr/lib/python3.10/multiprocessing/context.py", line 73, in RLock
Jun 05 00:05:19 CAPEv2-Server python3[6180]:     return RLock(ctx=self.get_context())
Jun 05 00:05:19 CAPEv2-Server python3[6180]:   File "/usr/lib/python3.10/multiprocessing/synchronize.py", line 187, in __init__
Jun 05 00:05:19 CAPEv2-Server python3[6180]:     SemLock.__init__(self, RECURSIVE_MUTEX, 1, 1, ctx=ctx)
Jun 05 00:05:19 CAPEv2-Server python3[6180]:   File "/usr/lib/python3.10/multiprocessing/synchronize.py", line 57, in __init__
Jun 05 00:05:19 CAPEv2-Server python3[6180]:     sl = self._semlock = _multiprocessing.SemLock(
Jun 05 00:05:19 CAPEv2-Server python3[6180]: OSError: [Errno 12] Cannot allocate memory

...

Jun 05 00:05:19 CAPEv2-Server python3[6180]: Traceback (most recent call last):
Jun 05 00:05:19 CAPEv2-Server python3[6180]:   File "/opt/CAPEv2/utils/process.py", line 504, in <module>
Jun 05 00:05:19 CAPEv2-Server python3[6180]:     main()
Jun 05 00:05:19 CAPEv2-Server python3[6180]:   File "/opt/CAPEv2/utils/process.py", line 447, in main
Jun 05 00:05:19 CAPEv2-Server python3[6180]:     autoprocess(
Jun 05 00:05:19 CAPEv2-Server python3[6180]:   File "/opt/CAPEv2/utils/process.py", line 323, in autoprocess
Jun 05 00:05:19 CAPEv2-Server python3[6180]:     pool.close()
Jun 05 00:05:19 CAPEv2-Server python3[6180]: UnboundLocalError: local variable 'pool' referenced before assignment
Jun 05 00:05:19 CAPEv2-Server systemd[1]: cape-processor.service: Main process exited, code=exited, status=1/FAILURE
Jun 05 00:05:19 CAPEv2-Server systemd[1]: cape-processor.service: Failed with result 'exit-code'.
```

Bug 2:
When an ISO is submitted without an extension in the file name, CAPE tries to process it with a package called "iso", but there is no such package. This seems to be caused by a bug in the function checking for archive types which compares the type to a tuple instead of checking if the type is in the tuple. 

You can see an example in this submission:
https://capesandbox.com/analysis/397799/