### PR TITLE
Keep IPv6 enabled on the loopback interface

### DIFF
--- a/installer/cape2.sh
+++ b/installer/cape2.sh
@@ -985,7 +985,7 @@ EOF
         echo "net.ipv6.conf.default.disable_ipv6 = 1" >> /etc/sysctl.conf
     fi
     if ! grep -q -E '^net.ipv6.conf.lo.disable_ipv6' /etc/sysctl.conf; then
-        echo "net.ipv6.conf.lo.disable_ipv6 = 1" >> /etc/sysctl.conf
+        echo "net.ipv6.conf.lo.disable_ipv6 = 0" >> /etc/sysctl.conf
     fi
     if ! grep -q -E '^net.bridge.bridge-nf-call-ip6tables' /etc/sysctl.conf; then
         echo "net.bridge.bridge-nf-call-ip6tables = 0" >> /etc/sysctl.conf


### PR DESCRIPTION
This change fixes compatibility with xrdp on the host system. xrdp's session manager, `xrdp-sesman` exclusively binds to a `tcp6` socket on the loopback interface, so disabling IPv6 on the loopback interface prevents xrdp from connecting to its session manager.

This change does not break per-analysis routing or cause leaks because it only applies to the loopback interface of the host system.