### PR TITLE
Use sudo to invoke tcpdump, if possible.

### DIFF
--- a/installer/cape2.sh
+++ b/installer/cape2.sh
@@ -924,10 +924,8 @@ function dependencies() {
         useradd --system -g ${USER} -d /home/${USER}/ -m ${USER} --shell /bin/bash
     fi
 
-    groupadd pcap
-    usermod -a -G pcap ${USER}
-    chgrp pcap ${TCPDUMP_PATH}
-    setcap cap_net_raw,cap_net_admin=eip ${TCPDUMP_PATH}
+    echo "${USER} ALL=NOPASSWD: ${TCPDUMP_PATH}" > /etc/sudoers.d/tcpdump
+    chmod 440 /etc/sudoers.d/tcpdump
 
     usermod -a -G systemd-journal ${USER}
 


### PR DESCRIPTION
Rather than having to worry about the capabilities set on tcpdump and maintaining it whenever tcpdump gets upgraded, just use sudo to invoke it. This retains backwards compatibility, so it will fall back to check if tcpdump is suid if it can't be run via sudo.
Update the installer script to add a file to /etc/sudoers.d to configure it.