### PR TITLE
Update kvm-qemu.sh to address #1618

### DIFF
--- a/installer/kvm-qemu.sh
+++ b/installer/kvm-qemu.sh
@@ -776,7 +776,7 @@ function replace_seabios_clues_public() {
 
     FILES=(
         src/hw/blockcmd.c
-        src/fw/paravirt.c
+        #src/fw/paravirt.c
     )
     for file in "${FILES[@]}"; do
         _sed_aux 's/"QEMU/"<WOOT>/g' "$file" "QEMU was not replaced in $file"


### PR DESCRIPTION
Exclude `paravirt.c` from patching to work around the issue described in #1618. I'm not sure if there is a better fix, but this will at least prevent VMs from crashing due to insufficient memory.