### PR TITLE
Don't assume sudo exists.

### DIFF
--- a/modules/auxiliary/sniffer.py
+++ b/modules/auxiliary/sniffer.py
@@ -61,7 +61,7 @@ class Sniffer(Auxiliary):
 
             try:
                 subprocess.check_call([self.sudo_path, "--list", "--non-interactive", tcpdump])
-            except subprocess.CalledProcessError:
+            except (FileNotFoundError, subprocess.CalledProcessError):
                 # https://github.com/cuckoosandbox/cuckoo/pull/2842/files
                 mode = os.stat(tcpdump).st_mode
                 if mode & S_ISUID:


### PR DESCRIPTION
If sudo doesn't exist, then a FileNotFoundError is raised, not CalledProcessError.

This is in response to https://github.com/kevoreilly/CAPEv2/pull/1610#issuecomment-1614820122