### PR TITLE
Added CITATION.cff file to make it easier to cite CAPE

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,25 @@
+cff-version: 1.2.0
+title: CAPEv2
+message: Malware Configuration And Payload Extraction
+type: software
+authors:
+  - given-names: O'Reilly
+    family-names: Kevin
+  - given-names: Andriy
+    family-names: Brukhovetskyy
+identifiers:
+  - type: url
+    value: 'https://github.com/kevoreilly/CAPEv2'
+    description: CAPE v2
+repository-code: 'https://github.com/kevoreilly/CAPEv2'
+url: 'https://capev2.readthedocs.io/en/latest/#'
+abstract: >
+  CAPEv2: Malware Configuration And Payload Extraction is a
+  malware sandbox.
+keywords:
+  - malware
+  - sandbox
+  - cape
+  - capev2
+  - analysis
+license: GPL-3.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,18 +1,16 @@
 cff-version: 1.2.0
-title: CAPEv2
-message: Malware Configuration And Payload Extraction
+title: "CAPE: Malware Configuration And Payload Extraction"
+message: "If you use this software, please cite it as below."
 type: software
 authors:
-  - given-names: O'Reilly
-    family-names: Kevin
+  - given-names: Kevin
+    family-names: O'Reilly
   - given-names: Andriy
     family-names: Brukhovetskyy
-identifiers:
-  - type: url
-    value: 'https://github.com/kevoreilly/CAPEv2'
-    description: CAPE v2
-repository-code: 'https://github.com/kevoreilly/CAPEv2'
-url: 'https://capev2.readthedocs.io/en/latest/#'
+url: "https://github.com/kevoreilly/CAPEv2"
+repository-code: "https://github.com/kevoreilly/CAPEv2"
+url: "https://capev2.readthedocs.io/en/latest/#"
+version: 2
 abstract: >
   CAPEv2: Malware Configuration And Payload Extraction is a
   malware sandbox.

--- a/README.md
+++ b/README.md
@@ -149,6 +149,9 @@ git merge kevoreilly/master
 git push
 ```
 
+### How to cite this work
+If you use CAPEv2 in your work, please cite it as specified in the [CITATION](./CITATION.cff) file.
+
 ### Special note about 3rd part dependencies:
 * They becoming a headache, specially those that using `pefile` as each pins version that they want.
     * Our suggestion is clone/fork them, remove `pefile` dependency as you already have it installed. Volia no more pain.

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ git push
 ```
 
 ### How to cite this work
-If you use CAPEv2 in your work, please cite it as specified in the [CITATION](./CITATION.cff) file.
+If you use CAPEv2 in your work, please cite it as specified in the "Cite this repository" GitHub menu.
 
 ### Special note about 3rd part dependencies:
 * They becoming a headache, specially those that using `pefile` as each pins version that they want.
@@ -158,3 +158,5 @@ If you use CAPEv2 in your work, please cite it as specified in the [CITATION](./
 
 ### Docs
 * [ReadTheDocs](https://capev2.readthedocs.io/en/latest/#)
+
+


### PR DESCRIPTION
GitHub automatically parses the file and transforms it in both APA and BibTeX formats:
![image](https://github.com/kevoreilly/CAPEv2/assets/41084837/e4267666-b24e-42f2-9e92-be94e5b16bc1)
