### PR TITLE
Yara Detections

### DIFF
--- a/conf/processing.conf
+++ b/conf/processing.conf
@@ -208,6 +208,9 @@ max_file_size = 90
 userdb_signature = no
 # https://capev2.readthedocs.io/en/latest/usage/patterns_replacement.html
 replace_patterns = no
+# If enabled, the detections section will depend on YARA hits only if the rule contains an identifier named "cape_type" and contains "config", "payload", or "loader"
+# otherwise, it will be triggered whatever YARA hits are found
+yara_detections = no
 
 # Deduplicate screenshots
 # You need to install dependency ImageHash>=4.2.1

--- a/conf/processing.conf
+++ b/conf/processing.conf
@@ -208,9 +208,6 @@ max_file_size = 90
 userdb_signature = no
 # https://capev2.readthedocs.io/en/latest/usage/patterns_replacement.html
 replace_patterns = no
-# If enabled, the detections section will depend on YARA hits only if the rule contains an identifier named "cape_type" and contains "config", "payload", or "loader"
-# otherwise, it will be triggered whatever YARA hits are found
-yara_detections = no
 
 # Deduplicate screenshots
 # You need to install dependency ImageHash>=4.2.1

--- a/conf/processing.conf.default
+++ b/conf/processing.conf.default
@@ -214,7 +214,7 @@ userdb_signature = no
 # https://capev2.readthedocs.io/en/latest/usage/patterns_replacement.html
 replace_patterns = no
 # If enabled, the detections section will depend on YARA hits only if the rule contains an identifier named "cape_type" and contains "config", "payload", or "loader"
-# otherwise, it will be triggered whatever YARA hits are found
+# otherwise, it will be triggered whatever YARA hits are found (related to "data/yara/CAPE" ONLY)
 yara_detections = no
 
 # Deduplicate screenshots

--- a/conf/processing.conf.default
+++ b/conf/processing.conf.default
@@ -213,6 +213,9 @@ max_file_size = 90
 userdb_signature = no
 # https://capev2.readthedocs.io/en/latest/usage/patterns_replacement.html
 replace_patterns = no
+# If enabled, the detections section will depend on YARA hits only if the rule contains an identifier named "cape_type" and contains "config", "payload", or "loader"
+# otherwise, it will be triggered whatever YARA hits are found
+yara_detections = no
 
 # Deduplicate screenshots
 # You need to install dependency ImageHash>=4.2.1

--- a/modules/processing/CAPE.py
+++ b/modules/processing/CAPE.py
@@ -280,9 +280,8 @@ class CAPE(Processing):
             # Check for a payload or config hit
             cape_name = None
             try:
-                if File.yara_hit_provides_detection(hit):
-                    file_info["cape_type"] = hit["meta"]["cape_type"]
-                    cape_name = File.get_cape_name_from_yara_hit(hit)
+               if yara['name']:
+                    cape_name=yara['name']
                     cape_names.add(cape_name)
             except Exception as e:
                 log.error("Cape type error: %s", str(e))

--- a/modules/processing/CAPE.py
+++ b/modules/processing/CAPE.py
@@ -280,9 +280,15 @@ class CAPE(Processing):
             # Check for a payload or config hit
             cape_name = None
             try:
-               if yara['name']:
-                    cape_name=yara['name']
-                    cape_names.add(cape_name)
+                if processing_conf.CAPE.yara_detections:
+                    if File.yara_hit_provides_detection(hit):
+                        file_info["cape_type"] = hit["meta"]["cape_type"]
+                        cape_name = File.get_cape_name_from_yara_hit(hit)
+                        cape_names.add(cape_name)
+                else:
+                    if yara['name']:
+                        cape_name=yara['name']
+                        cape_names.add(cape_name)
             except Exception as e:
                 log.error("Cape type error: %s", str(e))
             type_strings = file_info["type"].split()


### PR DESCRIPTION
# Main Issue: CAPE Check
CAPE performs a check by searching for an identifier called `cape_type` within the meta section of the **YARA** rule. If this variable contains specific words such as `payload`, `loader`, or `config`, CAPE adds the `"Detections"` section, which includes the name of the malware family.

![image12](https://github.com/kevoreilly/CAPEv2/assets/62453654/694eabe1-a617-4bc0-b898-902f29e67d8b)


What if we want to download additional rules from multiple sources, it doesn't make any sense to add this identifier to all of them. To overcome this limitation, I modified this condition in the code to include the "Detections" section whenever a **YARA** hit is found.

![image14](https://github.com/kevoreilly/CAPEv2/assets/62453654/b4d46db4-a92d-486e-ab7d-e206acffc8e5)
