### PR TITLE
Add CSS to create readable PDF reports when using reportpdf module

### DIFF
--- a/data/html/css/style.css
+++ b/data/html/css/style.css
@@ -7,6 +7,14 @@ body {
     padding-top: 60px;
     background: #1c1c1c repeat-x;
 }
+@media print {
+    html {
+        -webkit-print-color-adjust: exact;
+    }
+    .table{
+        color: #000!important;
+    }
+}
 
 @page {
     size: A3;


### PR DESCRIPTION
# Issue: Improper PDF generation
As reported in issue #1210 and #1543, PDF generated with the ``reportpdf`` reporting modules are not readable because
of white-on-white text.

This PR contains a quick CSS fix that make the PDF readable and that should only affect the PDF generation.

As @kevoreilly said in #1210, the PDF reports might be missing Cape-specific information as it hasn't been maintained.
If this is effectively the case, this is an issue that I might try to resolve later on.

## PDF before changes
![PDF-before](https://github.com/kevoreilly/CAPEv2/assets/67320645/3761b13c-9bad-4ec0-93ca-88fc31e3db42)
## PDF after changes
![PDF-after](https://github.com/kevoreilly/CAPEv2/assets/67320645/20c1034a-d235-4424-8cc2-5f29200206ae)
