### PR TITLE
Reimaging time of analysis machine

### DIFF
--- a/lib/cuckoo/core/scheduler.py
+++ b/lib/cuckoo/core/scheduler.py
@@ -10,8 +10,9 @@ import signal
 import threading
 import time
 from collections import defaultdict
-import ping3
+import requests
 
+from lib.cuckoo.common.constants import CUCKOO_GUEST_PORT
 from lib.cuckoo.common.config import Config
 from lib.cuckoo.common.constants import CUCKOO_ROOT
 from lib.cuckoo.common.exceptions import (
@@ -196,10 +197,14 @@ class AnalysisManager(threading.Thread):
                 machine_id=self.task.machine, platform=self.task.platform, tags=task_tags, arch=task_archs, os_version=os_version
             )
 
-            # Check if machine is up or not to submit new task
-            response_time = ping3.ping(machine.ip)
-            if response_time is None:
-                continue  # Machine is down. Maybe it's being reimaged
+            # Check if machine is up before acquiring the new task
+            url = f"http://{machine.ip}:{CUCKOO_GUEST_PORT}"
+
+            try:
+                r = requests.get(f"{url}/status")
+                log.debug(r.text)
+            except:
+                continue
 
             # If no machine is available at this moment, wait for one second and try again.
             if not machine:

--- a/lib/cuckoo/core/scheduler.py
+++ b/lib/cuckoo/core/scheduler.py
@@ -10,6 +10,7 @@ import signal
 import threading
 import time
 from collections import defaultdict
+import ping3
 
 from lib.cuckoo.common.config import Config
 from lib.cuckoo.common.constants import CUCKOO_ROOT
@@ -194,6 +195,11 @@ class AnalysisManager(threading.Thread):
             machine = machinery.acquire(
                 machine_id=self.task.machine, platform=self.task.platform, tags=task_tags, arch=task_archs, os_version=os_version
             )
+
+            # Check if machine is up or not to submit new task
+            response_time = ping3.ping(machine.ip)
+            if response_time is None:
+                continue  # Machine is down. Maybe it's being reimaged
 
             # If no machine is available at this moment, wait for one second and try again.
             if not machine:

--- a/modules/machinery/physical.py
+++ b/modules/machinery/physical.py
@@ -8,7 +8,7 @@ import logging
 import socket
 import struct
 import sys
-from time import sleep
+#from time import sleep
 
 import requests
 

--- a/modules/machinery/physical.py
+++ b/modules/machinery/physical.py
@@ -133,36 +133,17 @@ class Physical(Machinery):
 
                     requests.post(f"http://{self.options.fog.hostname}/fog/host/{hostID}/task", headers=headers, data=payload)
 
-                    try:
-                        if managerType == "pure":
-                            requests.post(
-                                f"http://{machine.ip}:{CUCKOO_GUEST_PORT}/execute",
-                                data={"command": "shutdown -r -f -t 0"},
-                            )
-                        elif managerType == "proxmox":
-                            proxmox_shutdown_vm(machine.name)
-                    except Exception:
-                        # The reboot will start immediately which may kill our socket so we just ignore this exception
-                        log.debug("Socket killed from analysis machine due to reboot")
+                    
+                    if managerType == "pure":
+                        requests.post(
+                            f"http://{machine.ip}:{CUCKOO_GUEST_PORT}/execute",
+                            data={"command": "shutdown -r -f -t 0"},
+                        )
+                    elif managerType == "proxmox":
+                        proxmox_shutdown_vm(machine.name)
 
-        # We are waiting until we are able to connect to the agent again since we dont know how long it will take to restore the machine
-        while not self.isTaskigDone(hostID):
-            log.debug("Restore operation for %s still running", machine.name)
-            sleep(10)
-
-        # After the restore operation is done we are waiting until it is up again and we can connect to the agent
-        url = f"http://{machine.ip}:{CUCKOO_GUEST_PORT}"
-
-        connection_succesful = False
-
-        while not connection_succesful:
-            try:
-                r = requests.get(f"{url}/status")
-                print(r.text)
-                connection_succesful = True
-            except Exception:
-                log.debug("Machine not reachable yet after reset")
-                sleep(3)
+                        # Start processing collected results even if machine is not started
+                        return
 
     def _list(self):
         """List physical machines installed.


### PR DESCRIPTION
# Main Issue:
After the analysis reaches its timeout, CAPE initiates a request to the FOG server, triggering the reimaging process of the VM. It then proceeds to process the collected results to activate run signatures and release the final report.

However, a challenge arises due to the time required to reimage the VM back to its clean state. This process typically takes between 1.5 to 3 minutes or even longer if multiple reimaging tasks are running concurrently.

To address this issue, an initial solution involves proceeding to the next phase even if the VM has not yet started. However, a problem arises when submitting another task to CAPE, as it assumes the VM is already running and attempts to submit the task to it. CAPE manages this situation by utilizing the following mechanism:
```
[modules.machinery.physical] DEBUG: Getting status for machine: win7_1
[lib.cuckoo.common.abstracts] DEBUG: Waiting 0 cuckooseconds for machine 1_win7_1 to switch to status ['running']
[modules.machinery.physical] DEBUG: Getting status for machine: win7_1
[lib.cuckoo.common.abstracts] DEBUG: Waiting 1 cuckooseconds for machine 1_win7_1 to switch to status ['running']
```
~I made a temporary solution by pinging the acquired machine first using `ping3` library, if it's pingable, submit the new task to it.~

I used the traditional way to get machine status before acquiring new task to it.