### PR TITLE
az: rscrc_skus.list: remove invalid parameter

### DIFF
--- a/modules/machinery/az.py
+++ b/modules/machinery/az.py
@@ -390,7 +390,6 @@ class Azure(Machinery):
         # If we want to programmatically determine the number of cores for the sku
         if self.options.az.find_number_of_cores_for_sku or self.options.az.instance_type_cores == 0:
             resource_skus = Azure._azure_api_call(
-                self.options.az.region_name,
                 filter=f"location={self.options.az.region_name}",
                 operation=self.compute_client.resource_skus.list,
             )


### PR DESCRIPTION
This change removes the additional parameter which shouldn't be present in the code, as its presence leads to the error:
```log
2023-07-14 11:36:45,147 [modules.machinery.az] DEBUG: Trying <bound method ResourceSkusOperations.list of <azure.mgmt.compute.v2021_07_01.operations._operations.ResourceSkusOperations object at 0x7fbe127d35b0>>(('WestEurope',))
2023-07-14 11:36:45,147 [modules.machinery.az] WARNING: Failed to <bound method ResourceSkusOperations.list of <azure.mgmt.compute.v2021_07_01.operations._operations.ResourceSkusOperations object at 0x7fbe127d35b0>>(('WestEurope',)) due to the Azure error 'ResourceSkusOperations.list() takes 1 positional argument but 2 were given': 'TypeError('ResourceSkusOperations.list() takes 1 positional argument but 2 were given')'.
2023-07-14 11:36:45,148 [root] CRITICAL: CuckooCriticalError: Error initializing machines: ResourceSkusOperations.list() takes 1 positional argument but 2 were given:TypeError('ResourceSkusOperations.list() takes 1 positional argument but 2 were given')
```

As you may see in the [docs](https://learn.microsoft.com/en-us/python/api/azure-mgmt-compute/azure.mgmt.compute.v2021_07_01.operations.resourceskusoperations?view=azure-python#azure-mgmt-compute-v2021-07-01-operations-resourceskusoperations-list) `list` function expects only `kwargs`, but in this case the unnecessary parameter were passed using `args`