### PR TITLE
vbs analysis package

### DIFF
--- a/analyzer/windows/lib/core/packages.py
+++ b/analyzer/windows/lib/core/packages.py
@@ -125,7 +125,7 @@ def choose_package(file_type, file_name, exports, target):
         return "pdf"
     elif re.search(b'<script\\s+language="(J|VB|Perl)Script"', file_content, re.I):
         return "wsf"
-    elif file_name.endswith((".vbs", ".vbe")) or re.findall(rb"\s?Dim\s", file_content, re.I) or re.findall(r'\bDim\b', file_content.decode('utf-16le'), re.IGNORECASE):
+    elif file_name.endswith((".vbs", ".vbe")) or re.findall(rb"\s?Dim\s", file_content, re.I) or re.findall(b"\s?\x00D\x00i\x00m\x00\s", file_content, re.I):
         return "vbs"
     elif b"Set-StrictMode" in file_content[:100]:
         return "ps1"

--- a/analyzer/windows/lib/core/packages.py
+++ b/analyzer/windows/lib/core/packages.py
@@ -125,7 +125,7 @@ def choose_package(file_type, file_name, exports, target):
         return "pdf"
     elif re.search(b'<script\\s+language="(J|VB|Perl)Script"', file_content, re.I):
         return "wsf"
-    elif file_name.endswith((".vbs", ".vbe")) or re.findall(rb"\s?Dim\s", file_content, re.I):
+    elif file_name.endswith((".vbs", ".vbe")) or re.findall(rb"\s?Dim\s", file_content, re.I) or re.findall(r'\bDim\b', file_content.decode('utf-16le'), re.IGNORECASE):
         return "vbs"
     elif b"Set-StrictMode" in file_content[:100]:
         return "ps1"


### PR DESCRIPTION
# Main Issue:
CAPE determines whether the submitted is a `vbs` or not either by examining the file's extension or by searching for the presence of the `Dim` keyword within the script's content.

However, a significant issue arises when the contents of the file are encoded in Unicode. In such cases, CAPE incorrectly categorizes the package as `generic`.

![qwers](https://github.com/kevoreilly/CAPEv2/assets/62453654/01ad2e3f-fd05-4289-9a59-fb514b476832)