### PR TITLE
Fix exception handling for missing sudo

### DIFF
--- a/lib/cuckoo/core/startup.py
+++ b/lib/cuckoo/core/startup.py
@@ -537,7 +537,7 @@ def check_tcpdump_permissions():
     if user:
         try:
             subprocess.check_call(["/usr/bin/sudo", "--list", "--non-interactive", tcpdump])
-        except subprocess.CalledProcessError:
+        except (FileNotFoundError, subprocess.CalledProcessError):
             try:
                 if user not in grp.getgrnam("pcap").gr_mem:
                     pcap_permissions_error = True


### PR DESCRIPTION
subprocess throws FileNotFoundError when the binary does not exist.