### PR TITLE
Don't lose data when multiple configs for the same family are found.

### DIFF
--- a/modules/processing/CAPE.py
+++ b/modules/processing/CAPE.py
@@ -381,9 +381,8 @@ class CAPE(Processing):
 
         # look for an existing config matching this cape_name; merge them if found
         for existing_config in self.cape["configs"]:
-            if cape_name in existing_config:
-                log.warning("CAPE: data loss may occur, existing config found for: %s", cape_name)
-                existing_config[cape_name].update(config[cape_name])
+            if cape_name in existing_config and existing_config[cape_name] == config:
+                log.info("CAPE: Found identical %s config", cape_name)
                 config = existing_config
                 break
         else:


### PR DESCRIPTION
Keep them separate and maintain the file_obj hashes associated with each one.