### PR TITLE
Wrong File Package

### DIFF
--- a/analyzer/windows/analyzer.py
+++ b/analyzer/windows/analyzer.py
@@ -331,25 +331,22 @@ class Analyzer:
         log.debug("Python path: %s", os.path.dirname(sys.executable))
 
         # If no analysis package was specified at submission, we try to select one automatically.
-        if not self.config.package:
-            log.debug("No analysis package specified, trying to detect it automagically")
+        log.debug("No analysis package specified, trying to detect it automagically")
 
-            # If the analysis target is a file, we choose the package according to the file format.
-            if self.config.category == "file":
-                package = choose_package(self.config.file_type, self.config.file_name, self.config.exports, self.target)
-            # If it's an URL, we'll just use the default Internet Explorer package.
-            else:
-                package = "ie"
-
-            # If we weren't able to automatically determine the proper package, we need to abort the analysis.
-            if not package:
-                raise CuckooError(f"No valid package available for file type: {self.config.file_type}")
-
-            log.info('Automatically selected analysis package "%s"', package)
-        # Otherwise just select the specified package.
+        # If the analysis target is a file, we choose the package according to the file format.
+        if self.config.category == "file":
+            package = choose_package(self.config.file_type, self.config.file_name, self.config.exports, self.target)
+        # If it's an URL, we'll just use the default Internet Explorer package.
         else:
-            package = self.config.package
-            log.info('Analysis package "%s" has been specified', package)
+            package = "ie"
+
+        # If we weren't able to automatically determine the proper package, we need to abort the analysis.
+        if not package:
+            raise CuckooError(f"No valid package available for file type: {self.config.file_type}")
+
+        log.info('Automatically selected analysis package "%s"', package)
+        # Otherwise just select the specified package.
+
         # Generate the package path.
         package_name = f"modules.packages.{package}"
         # Try to import the analysis package.

--- a/analyzer/windows/lib/core/packages.py
+++ b/analyzer/windows/lib/core/packages.py
@@ -59,7 +59,7 @@ def choose_package(file_type, file_name, exports, target):
         (".ppt", ".ppa", ".pot", ".pps", ".pptx", ".pptm", ".potx", ".potm", ".ppam", ".ppsx", ".ppsm", ".sldx", ".sldm")
     ):
         return "ppt"
-    elif "Java Jar" in file_type or "Java archive" in file_type or file_name.endswith(".jar"):
+    elif b'MANIFEST' in file_content or "Java Jar" in file_type or "Java archive" in file_type or file_name.endswith(".jar"):
         return "jar"
     elif "Zip" in file_type:
         return "zip"


### PR DESCRIPTION
# Main Issue:
CAPE typically identifies the file type using its `CONTENT-TYPE` MIME **(as I understand)**, with assistance from the CAPE agent, and then proceeds to determine the appropriate package for executing the file. If the file type is not detected correctly, it will be identified based on its magic bytes.

Unfortunately, JAR files without their extension are treated as ZIP files. To solve this, I have modified the file type detection logic to be more specific, selecting based on the magic bytes **_ONLY_**.

filehash: 7f4e1b678de5191288c8e74a64c82d60
https://www.virustotal.com/gui/file/c55ba1aa7a57b772f0108cd8f90a36787468ef0e2a53ef9fc2bcf689d109a95c/