### PR TITLE
Fix issue in architecture determination when linux support is enabled.

### DIFF
--- a/lib/cuckoo/core/database.py
+++ b/lib/cuckoo/core/database.py
@@ -1360,7 +1360,7 @@ class Database(object, metaclass=Singleton):
                         else:
                             tags = "x64"
                     else:
-                        if LINUX_ENABLED:
+                        if LINUX_ENABLED and platform == "linux":
                             linux_arch = _get_linux_vm_tag(file_type)
                             if linux_arch:
                                 if tags:


### PR DESCRIPTION
Previously, if LINUX_ENABLED is True, then 32-bit PE samples would still get tagged with x64 and thus only run on x64 VM's, because _get_linux_vm_tag would get called and always return x64. This makes it so that we only call that function if the platform is actually linux in order that x86 might still get applied to the 32-bit PE.