### PR TITLE
improve x86 Python requirements docs; #1680

### DIFF
--- a/agent/agent.py
+++ b/agent/agent.py
@@ -30,6 +30,9 @@ if sys.version_info[:2] < (3, 6):
     sys.exit("You are running an incompatible version of Python, please use >= 3.6")
 
 # You must run x86 version not x64
+# The analysis process interacts with low-level Windows libraries that need a
+# x86 Python to be running.
+# (see https://github.com/kevoreilly/CAPEv2/issues/1680)
 if sys.maxsize > 2**32 and sys.platform == "win32":
     sys.exit("You should install python3 x86! not x64")
 

--- a/docs/book/src/installation/guest/requirements.rst
+++ b/docs/book/src/installation/guest/requirements.rst
@@ -12,7 +12,10 @@ Python is a strict requirement for the CAPE guest component (*analyzer*) to run 
     .. note::
 
         Please note that only 32-bit (x86) versions of Python3 are
-        supported at this time for Windows. For other it can be 64-bit(x64).
+        supported at this time for Windows, due to the way the analyzer
+        interacts with low-level Windows libraries. Using a 64-bit version
+        of Python will crash the analyzer in Windows. For other platforms the
+        version of Python can be 64-bit (x64).
 
 You can download the proper `Windows`_ / `Linux`_ installer from the `official website`_.
 Python versions > 3.6 are preferred.


### PR DESCRIPTION
The x86 Python requirement in Windows VMs isn't documented very well. Improve that a bit and reference #1680.