### PR TITLE
Fix AgentTesla yara rule

### DIFF
--- a/data/yara/CAPE/AgentTesla.yar
+++ b/data/yara/CAPE/AgentTesla.yar
@@ -109,15 +109,3 @@ rule AgentTeslaV3 {
     condition:
         (uint16(0) == 0x5a4d and (8 of ($s*) or (6 of ($s*) and all of ($g*)))) or (2 of ($m*))
 }
-
-rule AgentTeslaV4 {
-    meta:
-        author = "Rony (r0ny_123)"
-        cape_type = "AgentTesla payload"
-    strings:
-        $decode = { 06 91 06 61 20 [4] 61 d2 9c 06 17 58 0a }
-    condition:
-        uint16be(0) == 0x4d5a
-        and uint32(uint32(0x3C)) == 0x00004550
-        and any of them
-}

--- a/data/yara/CAPE/AgentTesla.yar
+++ b/data/yara/CAPE/AgentTesla.yar
@@ -115,8 +115,7 @@ rule AgentTeslaV4 {
         author = "Rony (r0ny_123)"
         cape_type = "AgentTesla payload"
     strings:
-        $decode_1 = { 06 91 06 61 20 [4] 61 d2 9c 06 17 58 0a } // seen in other AgentTesla samples
-        $decode_2 = { 91 06 1a 58 4a 61 d2 61 d2 52 } // seen in XorStringsNET obfuscated AgentTesla
+        $decode = { 06 91 06 61 20 [4] 61 d2 9c 06 17 58 0a }
     condition:
         uint16be(0) == 0x4d5a
         and uint32(uint32(0x3C)) == 0x00004550


### PR DESCRIPTION
It turned out that decoding routing is unique to XorStringsNET obfuscation.