### PR TITLE
Set route to empty string when not specified

### DIFF
--- a/lib/cuckoo/common/web_utils.py
+++ b/lib/cuckoo/common/web_utils.py
@@ -1238,7 +1238,7 @@ def parse_request_arguments(request, keyword="POST"):
     unique = force_bool(getattr(request, keyword).get("unique", False))
     tlp = getattr(request, keyword).get("tlp")
     lin_options = getattr(request, keyword).get("lin_options", "")
-    route = getattr(request, keyword).get("route")
+    route = getattr(request, keyword).get("route", "")
     cape = getattr(request, keyword).get("cape", "")
 
     if referrer:


### PR DESCRIPTION
When a route is not specified in an API request to create an analysis, the route would be set to None, eventually resulting in the string 'false', which would then result in no route to be specified, instead of the default specified in the configuration settings:

https://github.com/kevoreilly/CAPEv2/blob/a0769ed88c6a92b1cb4d8422b05c2138dfe7dfe7/lib/cuckoo/core/scheduler.py#L505-L510

Setting it to an empty string if not specified resolves this issue. Setting to the string 'none' is still possible to explicitly disable routing.