### PR TITLE
A few things

### DIFF
--- a/conf/az.conf
+++ b/conf/az.conf
@@ -119,5 +119,5 @@ arch = x64
 # virtual machines in this scale set will have this tag
 pool_tag = <tag>
 
-# Initial virtual machine pool size for scale set
+# Initial virtual machine pool size for scale set. This should be a positive integer.
 initial_pool_size = 1

--- a/conf/az.conf
+++ b/conf/az.conf
@@ -119,5 +119,5 @@ arch = x64
 # virtual machines in this scale set will have this tag
 pool_tag = <tag>
 
-# Initial virtual machine pool size for scale set. This should be a positive integer.
+# Initial virtual machine pool size for scale set
 initial_pool_size = 1

--- a/conf/az.conf.default
+++ b/conf/az.conf.default
@@ -123,5 +123,5 @@ arch = x64
 # virtual machines in this scale set will have this tag
 pool_tag = <tag>
 
-# Initial virtual machine pool size for scale set
+# Initial virtual machine pool size for scale set. This should be a positive integer.
 initial_pool_size = 1

--- a/conf/routing.conf.default
+++ b/conf/routing.conf.default
@@ -61,6 +61,9 @@ drop = no
 # Should check if the inteface is up
 verify_interface = yes
 
+# Should check if rt_table exists before initializing
+verify_rt_table = yes
+
 [inetsim]
 # Inetsim quick deploy, chose your vm manager if is not kvm
 # wget https://googledrive.com/host/0B6fULLT_NpxMQ1Rrb1drdW42SkE/remnux-6.0-ova-public.ova

--- a/docs/book/src/installation/host/routing.rst
+++ b/docs/book/src/installation/host/routing.rst
@@ -115,7 +115,7 @@ default.
 
 Do this by writing a file at
 ``/etc/cloud/cloud.cfg.d/99-disable-network-config.cfg``, with the
-content ``{config: disabled}``, then delete
+content ``network: {config: disabled}``, then delete
 ``/etc/netplan/50-cloud-init.yaml``.
 
 If you are using a desktop version of Ubuntu instead,
@@ -141,12 +141,12 @@ CAPE web UI, SSH and other administrative services. In this configuration the
 dirty line is used as the default gateway for all internet traffic on the host.
 This helps prevent network leaks, firewall IDS/IPS issues, and keeps
 administrative traffic separate, where it could be placed in its own subnet
-for additional security. 
+for additional security.
 
 You will need to replace the interface names and IP addresses to reflect your
 own system.
 
-Each interface configuration needs a ``routes`` section that describes the 
+Each interface configuration needs a ``routes`` section that describes the
 routes that can be accessed via that interface. In order for the configuration
 to work with CAPE's per-analysis routing, each ``routes`` section must have an
 arbitrary but unique ``table`` integer value.
@@ -180,8 +180,8 @@ arbitrary but unique ``table`` integer value.
                    - to: 10.23.6.0/24
                      via: 10.23.6.1
                      table: 102
-               :
-                  routing-policy - from: 10.23.6.0/24
+                routing-policy:
+                   - from: 10.23.6.0/24
                      table: 102
 
 Run ``sudo netplan apply`` to apply the new ``netplan`` configuration.

--- a/lib/cuckoo/core/startup.py
+++ b/lib/cuckoo/core/startup.py
@@ -359,15 +359,10 @@ def init_routing():
                 raise CuckooStartupError(f"Could not find VPN configuration for {name}")
 
             entry = routing.get(name)
-            # add = 1
-            # if not rooter("nic_available", entry.interface):
-            # raise CuckooStartupError(
-            #   f"The network interface that has been configured for VPN {entry.name} is not available"
-            # )
-            #    add = 0
-            is_rt_available = rooter("rt_available", entry.rt_table)["output"]
-            if not is_rt_available:
-                raise CuckooStartupError(f"The routing table that has been configured for VPN {entry.name} is not available")
+            if routing.routing.verify_rt_table:
+                is_rt_available = rooter("rt_available", entry.rt_table)["output"]
+                if not is_rt_available:
+                    raise CuckooStartupError(f"The routing table that has been configured for VPN {entry.name} is not available")
             vpns[entry.name] = entry
 
             # Disable & enable NAT on this network interface. Disable it just
@@ -402,9 +397,10 @@ def init_routing():
         if not is_nic_available:
             raise CuckooStartupError("The network interface that has been configured as dirty line is not available")
 
-        is_rt_available = rooter("rt_available", routing.routing.rt_table)["output"]
-        if not is_rt_available:
-            raise CuckooStartupError("The routing table that has been configured for dirty line interface is not available")
+        if routing.routing.verify_rt_table:
+            is_rt_available = rooter("rt_available", routing.routing.rt_table)["output"]
+            if not is_rt_available:
+                raise CuckooStartupError("The routing table that has been configured for dirty line interface is not available")
 
         # Disable & enable NAT on this network interface. Disable it just
         # in case we still had the same rule from a previous run.

--- a/modules/machinery/az.py
+++ b/modules/machinery/az.py
@@ -361,28 +361,6 @@ class Azure(Machinery):
                 f"Subnet '{self.options.az.subnet}' does not exist in Virtual Network '{self.options.az.vnet}'"
             )
 
-        # Create required VMSSs that don't exist yet
-        vmss_creation_threads = []
-        vmss_reimage_threads = []
-        for vmss, vals in self.required_vmsss.items():
-            if vals["exists"] and not self.options.az.just_start:
-                # Reimage VMSS!
-                thr = threading.Thread(
-                    target=self._thr_reimage_vmss,
-                    args=(vmss,),
-                )
-                vmss_reimage_threads.append(thr)
-                thr.start()
-            else:
-                # Create VMSS!
-                thr = threading.Thread(target=self._thr_create_vmss, args=(vmss, vals["image"], vals["platform"]))
-                vmss_creation_threads.append(thr)
-                thr.start()
-
-        # Wait for everything to complete!
-        for thr in vmss_reimage_threads + vmss_creation_threads:
-            thr.join()
-
         # Initialize the platform scaling state monitor
         is_platform_scaling = {Azure.WINDOWS_PLATFORM: False, Azure.LINUX_PLATFORM: False}
 
@@ -412,6 +390,31 @@ class Azure(Machinery):
         # Do not programmatically determine the number of cores for the sku
         else:
             self.instance_type_cpus = self.options.az.instance_type_cores
+
+        # Create required VMSSs that don't exist yet
+        vmss_creation_threads = []
+        vmss_reimage_threads = []
+        for vmss, vals in self.required_vmsss.items():
+            if vals["exists"] and not self.options.az.just_start:
+                if machine_pools[vmss]["size"] == 0:
+                    self._thr_scale_machine_pool(self.options.az.scale_sets[vmss].pool_tag, True if vals["platform"] else False),
+                else:
+                    # Reimage VMSS!
+                    thr = threading.Thread(
+                        target=self._thr_reimage_vmss,
+                        args=(vmss,),
+                    )
+                    vmss_reimage_threads.append(thr)
+                    thr.start()
+            else:
+                # Create VMSS!
+                thr = threading.Thread(target=self._thr_create_vmss, args=(vmss, vals["image"], vals["platform"]))
+                vmss_creation_threads.append(thr)
+                thr.start()
+
+        # Wait for everything to complete!
+        for thr in vmss_reimage_threads + vmss_creation_threads:
+            thr.join()
 
         # Initialize the batch reimage threads. We want at most 4 batch reimaging threads
         # so that if no VMSS scaling or batch deleting is taking place (aka we are receiving constant throughput of


### PR DESCRIPTION
- `az.py`: Scale VMSS up on start if # of VMs is 0
- `routing.rst`: Correcting the routing docs
- Adding `verify_rt_table` option in `routing.conf` which affects how CAPE starts up in `startup.py`