### PR TITLE
Fix: Zipped files defaults to windows platform

### DIFF
--- a/lib/cuckoo/common/demux.py
+++ b/lib/cuckoo/common/demux.py
@@ -294,4 +294,4 @@ def demux_sample(filename: bytes, package: str, options: str, use_sflock: bool =
                         retlist.append(trimmed_path(filename))
                 retlist.remove(filename)
 
-    return retlist[:10]
+    return retlist[:10], platform

--- a/lib/cuckoo/common/demux.py
+++ b/lib/cuckoo/common/demux.py
@@ -207,7 +207,7 @@ def demux_sflock(filename: bytes, options: str) -> List[bytes]:
     return list(filter(None, retlist))
 
 
-def demux_sample(filename: bytes, package: str, options: str, use_sflock: bool = True) -> List[bytes]:
+def demux_sample(filename: bytes, package: str, options: str, use_sflock: bool = True) -> tuple[List[bytes], str]:
     """
     If file is a ZIP, extract its included files and return their file paths
     If file is an email, extracts its attachments and return their file paths (later we'll also extract URLs)

--- a/lib/cuckoo/core/database.py
+++ b/lib/cuckoo/core/database.py
@@ -1644,7 +1644,7 @@ class Database(object, metaclass=Singleton):
             package, _ = self._identify_aux_func(file_path, package)
 
         # extract files from the (potential) archive
-        extracted_files = demux_sample(file_path, package, options)
+        extracted_files, platform = demux_sample(file_path, package, options)
         # check if len is 1 and the same file, if diff register file, and set parent
         if extracted_files and file_path not in extracted_files:
             sample_parent_id = self.register_sample(File(file_path), source_url=source_url)
@@ -1813,7 +1813,7 @@ class Database(object, metaclass=Singleton):
         user_id=0,
         username=False,
     ):
-        extracted_files = demux_sample(file_path, package, options)
+        extracted_files, platform = demux_sample(file_path, package, options)
         sample_parent_id = None
         # check if len is 1 and the same file, if diff register file, and set parent
         if not isinstance(file_path, bytes):


### PR DESCRIPTION
When submitting a zipped elf file, it goes to the windows platform. This fix will return the platform accordingly