### PR TITLE
Bug fix to during_script.py

### DIFF
--- a/analyzer/windows/modules/auxiliary/during_script.py
+++ b/analyzer/windows/modules/auxiliary/during_script.py
@@ -33,7 +33,7 @@ class During_script(Thread, Auxiliary):
             self.file_ext = os.path.splitext(self.file_path)[-1]
             self.do_run = True
             if self.file_ext == ".py":
-                self.executable = ["python.exe"]
+                self.executable = ["python.exe", "-u"]
             elif self.file_ext == ".ps1":
                 self.executable = ["powershell.exe", "-NoProfile", "-ExecutionPolicy", "bypass", "-File"]
             else:
@@ -63,7 +63,7 @@ class During_script(Thread, Auxiliary):
             else:
                 self.executable.append(self.during_script_args_list)
             log.info("During_script command: %s", " ".join(self.executable))
-            popen = subprocess.Popen(self.executable, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
+            popen = subprocess.Popen(self.executable, bufsize=0, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
             self.popen = popen
             self.nf = nf
@@ -77,13 +77,21 @@ class During_script(Thread, Auxiliary):
 
         popen = self.popen
         nf = self.nf
-
-        for stdout_line in iter(popen.stdout.readline, ""):
-            nf.sock.send(stdout_line.encode())
-        popen.stdout.close()
-        nf.close()
-        return_code = popen.wait()
-        log.info("Running during_script, saved output to logs/during_script.logs")
-        if return_code:
-            log.error("Process stderr: %s", popen.stderr)
-            raise subprocess.CalledProcessError(return_code, str(self.executable))
+        log.info("Stopping during_script")
+        try:
+            return_code = popen.poll()
+            if return_code is None:
+                popen.terminate()
+            
+            stdout_data, stderr_data = popen.communicate()
+            nf.sock.send(stdout_data)
+            if stderr_data:
+                nf.sock.send(b"Process stderr\n")
+                nf.sock.send(b"--------------\n")
+                nf.sock.send(stderr_data)
+                raise subprocess.CalledProcessError(return_code, str(self.executable))
+            nf.close()
+        except Exception as e:
+            log.error("Error running during_script due to error: %s", e)
+            return False
+        return True


### PR DESCRIPTION
Currently there's a bug where the sandbox will wait for the During-Execution Script to complete instead of running it concurrently with the uploaded file.

This is because of this line in the `start()` method which blocks the execution of the uploaded file until the During-Execution Script terminates

https://github.com/kevoreilly/CAPEv2/blob/1b9fd7f7a95a509c22d2ce86d7030d2a812409cc/analyzer/windows/modules/auxiliary/during_script.py#L72

The auxiliary module will work as intended if we shift the waiting and processing code to the `stop()` method