### PR TITLE
Fix poetry_libvirt_installer.sh renaming

### DIFF
--- a/docs/book/src/usage/start.rst
+++ b/docs/book/src/usage/start.rst
@@ -48,9 +48,9 @@ If you used poetry to install dependencies, you should launch cape with the foll
 
         $ sudo -u cape poetry run python3 cuckoo.py
 
-If you get any dependency-related error, make sure you execute the **extra/poetry_libvirt_installer.sh** script.::
+If you get any dependency-related error, make sure you execute the **extra/libvirt_installer.sh** script.::
 
-        $ sudo -u cape poetry run extra/poetry_libvirt_installer.sh
+        $ sudo -u cape poetry run extra/libvirt_installer.sh
 
 Troubleshooting
 ===============

--- a/installer/kvm-qemu.sh
+++ b/installer/kvm-qemu.sh
@@ -567,7 +567,7 @@ EOH
     pip3 install .
     cd ..
     # Remove the $libvirt_version directory to permission errors when runing
-    # cd /opt/CAPEv2/ ; sudo -u cape poetry run extra/poetry_libvirt_installer.sh later
+    # cd /opt/CAPEv2/ ; sudo -u cape poetry run extra/libvirt_installer.sh later
     rm -r libvirt-python-$libvirt_version
     if [ "$OS" = "Linux" ]; then
         # https://github.com/libvirt/libvirt/commit/e94979e901517af9fdde358d7b7c92cc055dd50c

--- a/web/guac/views.py
+++ b/web/guac/views.py
@@ -6,7 +6,7 @@ from django.shortcuts import render
 try:
     import libvirt
 except ImportError:
-    print("Missed python-libvirt. Use extra/poetry_libvirt_installer.sh")
+    print("Missed python-libvirt. Use extra/libvirt_installer.sh")
 
 
 def index(request, task_id, session_data):


### PR DESCRIPTION
Fix poetry_libvirt_installer.sh renaming in this commit:  
https://github.com/kevoreilly/CAPEv2/commit/5c9cdc5d1f018f27c4241b0ddda80e4d7949c6ed  