### PR TITLE
Add option to filter networks using cidr

### DIFF
--- a/conf/processing.conf.default
+++ b/conf/processing.conf.default
@@ -102,6 +102,8 @@ dnswhitelist = yes
 dnswhitelist_file = extra/whitelist_domains.txt
 ipwhitelist = yes
 ipwhitelist_file = extra/whitelist_ips.txt
+network_passlist = no
+network_passlist_file = extra/whitelist_network.txt
 
 # Requires geoip2 and maxmind database
 country_lookup = no


### PR DESCRIPTION
Add an option to put CIDR in `whitelist_network.txt` file in order to whitelist all the ip addresses in that CIDR range