### PR TITLE
Small fix for office parsing

### DIFF
--- a/lib/cuckoo/common/integrations/parse_office.py
+++ b/lib/cuckoo/common/integrations/parse_office.py
@@ -101,8 +101,11 @@ class Office:
         metares = {"SummaryInformation": {}, "DocumentSummaryInformation": {}}
 
         for elem in core._get_documentElement().childNodes:
-            n = elem._get_tagName()
             try:
+                if isinstance(elem, xml.dom.minidom.Text):
+                    continue
+
+                n = elem._get_tagName()
                 data = core.getElementsByTagName(n)
                 if not data:
                     continue


### PR DESCRIPTION
Handle a case where the child object is `xml.dom.minidom.Text` and does not have `_get_tagName` function