### PR TITLE
Add feature toggle for checking path safety

### DIFF
--- a/conf/web.conf.default
+++ b/conf/web.conf.default
@@ -194,3 +194,7 @@ guest_rdp_port = 3389
 # Some samples will only detonate on specific versions of Windows (see web.conf packages for more info)
 # Example: MSIX - Windows >= 10
 msix = win10,win11
+
+[security]
+# When using mounted folder you might want to set to no
+check_path_safe = yes


### PR DESCRIPTION
We encountered an issue that since we store our `analyses` folder in a separate mount and create a symlink to `/opt/CAPEv2/storage`, we couldn't serve content on cape web UI since we would fail the `path_safe` function.

We added an option to toggle off this feature (default is that the feature is **enabled**)