### PR TITLE
Don't store an entire text file in "strings".

### DIFF
--- a/lib/cuckoo/common/integrations/file_extra_info.py
+++ b/lib/cuckoo/common/integrations/file_extra_info.py
@@ -218,10 +218,18 @@ def static_file_info(
             if floss_strings:
                 data_dictionary["floss"] = floss_strings
 
-        if HAVE_STRINGS:
+        if data_dictionary["data"]:
+            # Don't store "strings" for text files, but don't let the web frontend
+            # think that we want to look them up on-demand (i.e. display the
+            # "strings" button linking to an on_demand URL).
+            data_dictionary["strings"] = []
+        elif HAVE_STRINGS:
             strings = extract_strings(file_path, dedup=True)
-            if strings:
-                data_dictionary["strings"] = strings
+            data_dictionary["strings"] = strings
+        else:
+            # Don't store anything in data_dictionary["strings"] so that the frontend
+            # will display the "strings" button and allow them to be fetched on-demand.
+            pass
 
         # ToDo we need url support
         if HAVE_VIRUSTOTAL and processing_conf.virustotal.enabled:

--- a/web/templates/analysis/generic/_file_info.html
+++ b/web/templates/analysis/generic/_file_info.html
@@ -265,9 +265,9 @@
                     {% endif %}
                 {% endif %}
                 {% if config.strings %}
-                    {% if not file.strings %}
+                    {% if "strings" not in file %}
                         <a class="btn btn-secondary btn-sm" href="{% url "on_demand" "strings" id tab_name file.sha256 %}" role="button" data-bs-toggle="tooltip" title="Generate strings"><span class="fas fa-cogs"></span> Strings</a>
-                    {% else %}
+                    {% elif file.strings %}
                         <a class="btn btn-secondary btn-sm" data-toggle="collapse" href="#strings_{{file.sha256}}" role="button" aria-expanded="false" aria-controls="strings_{{file.sha256}}"  data-bs-toggle="tooltip" title="Display strings"><span class="fas fa-envelope-open-text"></span> Strings</a>
                     {% endif %}
                 {% endif %}

--- a/web/templates/analysis/generic/_subfile_info.html
+++ b/web/templates/analysis/generic/_subfile_info.html
@@ -261,9 +261,9 @@
                     {% endif %}
                 {% endif %}
                 {% if config.strings %}
-                    {% if not sub_file.strings %}
+                    {% if "strings" not in sub_file %}
                         <a class="btn btn-secondary btn-sm" href="{% url "on_demand" "strings" id "static" sub_file.sha256 %}" role="button" data-bs-toggle="tooltip" title="Generate strings"><span class="fas fa-cogs"></span> Strings</a>
-                    {% else %}
+                    {% elif sub_file.strings %}
                         <a class="btn btn-secondary btn-sm" data-toggle="collapse" href="#strings_{{sub_file.sha256}}" role="button" aria-expanded="false" aria-controls="strings_{{sub_file.sha256}}"  data-bs-toggle="tooltip" title="Display strings"><span class="fas fa-envelope-open-text"></span> Strings</a>
                     {% endif %}
                 {% endif %}


### PR DESCRIPTION
For text files, the first X bytes (as defined in
processing.conf:CAPE->buffer) are stored in the "data" key of the data dictionary. We don't need to also store that data in "strings". In fact, for large text files, previously we could be storing the entire file in "strings". This could result in the document to be inserted in to MongoDB being >16MB, which MongoDB doesn't allow. Don't display the "strings" button in the UI in this case.