### PR TITLE
Make sure that we don't process the same plugin multiple times.

### DIFF
--- a/lib/cuckoo/core/plugins.py
+++ b/lib/cuckoo/core/plugins.py
@@ -94,10 +94,11 @@ def load_plugins(module):
                 register_plugin("feeds", value)
 
 
-def register_plugin(group, name):
+def register_plugin(group, cls):
     global _modules
     group = _modules.setdefault(group, [])
-    group.append(name)
+    if cls not in group:
+        group.append(cls)
 
 
 def list_plugins(group=None):


### PR DESCRIPTION
In the case where one plugin module imports another one, it's possible that the same class could be inserted in to the plugin list multiple times. This prevents that from happening.