### PR TITLE
When getting the number of dropped files, payloads, etc. make sure to count files that have been stored in the 'files' collection.

### DIFF
--- a/web/analysis/views.py
+++ b/web/analysis/views.py
@@ -1412,7 +1412,16 @@ def report(request, task_id):
                         "analysis",
                         [
                             {"$match": {"info.id": int(task_id)}},
-                            {"$project": {"_id": 0, f"{value}_size": {"$size": {"$ifNull": [f"${key}.sha256", []]}}}},
+                            {
+                                "$project": {
+                                    "_id": 0,
+                                    f"{value}_size": {
+                                        "$add": [
+                                            {"$size": {"$ifNull": [f"${key}.{subkey}", []]}} for subkey in ("sha256", "file_ref")
+                                        ]
+                                    },
+                                },
+                            },
                         ],
                     )
                 )[0][f"{value}_size"]


### PR DESCRIPTION
Without this, new samples would not display the 'dropped' or 'payloads' tabs in the UI because it was returning 0 for the count of that type of file since the sha256 key is not stored in the "analysis" collection any more.