### PR TITLE
Fix searching by file hashes.

### DIFF
--- a/lib/cuckoo/common/web_utils.py
+++ b/lib/cuckoo/common/web_utils.py
@@ -15,6 +15,7 @@ import magic
 import requests
 from django.http import HttpResponse
 
+from dev_utils.mongo_hooks import FILE_REF_KEY, FILES_COLL, NORMALIZED_FILE_FIELDS
 from lib.cuckoo.common.config import Config
 from lib.cuckoo.common.integrations.parse_pe import HAVE_PEFILE, IsPEImage, pefile
 from lib.cuckoo.common.objects import File
@@ -100,13 +101,6 @@ if repconf.elasticsearchdb.enabled:
         es_as_db = True
 
     es = elastic_handler
-
-hash_len = {
-    32: "md5",
-    40: "sha1",
-    64: "sha256",
-    128: "sha512",
-}
 
 hashes = {
     32: hashlib.md5,
@@ -960,6 +954,16 @@ perform_search_filters = {
     "_id": 0,
 }
 
+hash_searches = {
+    "ssdeep": "ssdeep",
+    "crc32": "crc32",
+    "md5": "md5",
+    "sha1": "sha1",
+    "sha3": "sha3_384",
+    "sha256": "sha256",
+    "sha512": "sha512",
+}
+
 search_term_map = {
     "id": "info.id",
     "ids": "info.id",
@@ -967,10 +971,8 @@ search_term_map = {
     "package": "info.package",
     "ttp": "ttps.ttp",
     "malscore": "malscore",
-    "user_tasks": True,
     "name": "target.file.name",
     "type": "target.file.type",
-    "string": "strings",
     "file": "behavior.summary.files",
     "command": "behavior.summary.executed_commands",
     "configs": "CAPE.configs",
@@ -1007,11 +1009,10 @@ search_term_map = {
     "shrikesid": "info.shrike_sid",
     "custom": "info.custom",
     # initial binary
-    "target_sha256": "target.file.sha256",
+    "target_sha256": ("target.file.sha256", f"target.file.{FILE_REF_KEY}"),
     "tlp": "info.tlp",
     "ja3_hash": "suricata.tls.ja3.hash",
     "ja3_string": "suricata.tls.ja3.string",
-    "payloads": "CAPE.payloads.",
     "dhash": "static.pe.icon_dhash",
     "dport": ("network.tcp.dport", "network.udp.dport", "network.smtp_ex.dport"),
     "sport": ("network.tcp.dport", "network.udp.dport", "network.smtp_ex.dport"),
@@ -1044,24 +1045,13 @@ search_term_map_repetetive_blocks = {
     "sha256": "sha256",
     "sha3": "sha3_384",
     "sha512": "sha512",
+    "crc32": "crc32",
     "die": "die",
     "trid": "trid",
     "imphash": "imphash",
 }
 
-search_term_map_base_naming = (
-    "info.parent_sample",
-    "target.file",
-    "dropped",
-    "procdump",
-    "CAPE.payloads"
-    # file_extra_info
-    "info.parent_sample.extracted_files_tool",
-    "target.file.extracted_files_tool",
-    "dropped.extracted_files_tool",
-    "procdump.extracted_files_tool",
-    "CAPE.payloads.extracted_files_tool",
-)
+search_term_map_base_naming = ("info.parent_sample",) + NORMALIZED_FILE_FIELDS
 
 for key, value in search_term_map_repetetive_blocks.items():
     search_term_map.update({key: [f"{path}.{value}" for path in search_term_map_base_naming]})
@@ -1090,7 +1080,7 @@ normalized_int_terms = (
 )
 
 
-def perform_search(term, value, search_limit=False, user_id=False, privs=False, web=True, projection={}):
+def perform_search(term, value, search_limit=False, user_id=False, privs=False, web=True, projection=None):
     if repconf.mongodb.enabled and repconf.elasticsearchdb.enabled and essearch and not term:
         multi_match_search = {"query": {"multi_match": {"query": value, "fields": ["*"]}}}
         numhits = es.search(index=get_analysis_index(), body=multi_match_search, size=0)["hits"]["total"]
@@ -1155,9 +1145,6 @@ def perform_search(term, value, search_limit=False, user_id=False, privs=False, 
     if not search_limit:
         search_limit = web_cfg.general.get("search_limit", 50)
 
-    if term == "payloads" and len(value) in (32, 40, 64, 128):
-        search_term_map[term] = f"CAPE.payloads.{hash_len.get(len(value))}"
-
     elif term == "configs":
         # check if family name is string only maybe?
         search_term_map[term] = f"CAPE.configs.{value}"
@@ -1167,12 +1154,40 @@ def perform_search(term, value, search_limit=False, user_id=False, privs=False, 
         if isinstance(search_term_map[term], str):
             mongo_search_query = {search_term_map[term]: query_val}
         else:
-            mongo_search_query = {"$or": [{search_term: query_val} for search_term in search_term_map[term]]}
+            search_terms = [{search_term: query_val} for search_term in search_term_map[term]]
+            if term in hash_searches:
+                # For analyses where files have been stored in the "files" collection, search
+                # there for the _id (i.e. sha256) of documents matching the given hash. As a
+                # special case, we don't need to do that query if the requested hash type is
+                # "sha256" since that's what's stored in the "file_refs" key.
+                # We do all this in addition to search the old keys for backwards-compatibility
+                # with documents that do not use this mechanism for storing file data.
+                if term == "sha256":
+                    file_refs = [query_val]
+                else:
+                    file_docs = mongo_find(FILES_COLL, {hash_searches[term]: query_val}, {"_id": 1})
+                    file_refs = [doc["_id"] for doc in file_docs]
+                if file_refs:
+                    if len(file_refs) > 1:
+                        query = {"$in": file_refs}
+                    else:
+                        query = file_refs[0]
+                    search_terms.extend([{f"{pfx}.{FILE_REF_KEY}": query} for pfx in NORMALIZED_FILE_FIELDS])
+            mongo_search_query = {"$or": search_terms}
 
         # Allow to overwrite perform_search_filters for custom results
         if not projection:
             projection = perform_search_filters
-        return mongo_find("analysis", mongo_search_query, projection).sort([["_id", -1]]).limit(search_limit)
+        if "target.file.sha256" in projection:
+            projection = dict(**projection)
+            projection[f"target.file.{FILE_REF_KEY}"] = 1
+        retval = list(mongo_find("analysis", mongo_search_query, projection).sort([["_id", -1]]).limit(search_limit))
+        for doc in retval:
+            target_file = doc.get("target", {}).get("file", {})
+            if FILE_REF_KEY in target_file and "sha256" not in target_file:
+                target_file["sha256"] = target_file.pop(FILE_REF_KEY)
+        return retval
+
     if es_as_db:
         _source_fields = list(perform_search_filters.keys())[:-1]
         if isinstance(search_term_map[term], str):
@@ -1413,7 +1428,6 @@ def submit_task(
     filename: str = "",
     server_url: str = "",
 ):
-
     """
     ToDo add url support in future
     """

--- a/web/analysis/views.py
+++ b/web/analysis/views.py
@@ -2001,10 +2001,13 @@ def full_memory_dump_strings(request, analysis_number):
 @ratelimit(key="ip", rate=my_rate_seconds, block=rateblock)
 @ratelimit(key="ip", rate=my_rate_minutes, block=rateblock)
 def search(request, searched=""):
-    if "search" in request.POST or searched:
+    if "search" in request.POST or "search" in request.GET or searched:
         term = ""
-        if not searched and request.POST.get("search"):
-            searched = str(request.POST["search"])
+        if not searched:
+            if request.POST.get("search"):
+                searched = str(request.POST["search"])
+            elif request.GET.get("search"):
+                searched = str(request.GET["search"])
 
         if ":" in searched:
             term, value = searched.strip().split(":", 1)

--- a/web/templates/analysis/search.html
+++ b/web/templates/analysis/search.html
@@ -2,7 +2,7 @@
 {% block content %}
 <div class="row">
     <div class="col-md-0 mx-auto">
-        <form class="form-inline" role="form" action="{% url "search" %}" enctype="multipart/form-data" method="post">{% csrf_token %}
+        <form class="form-inline" role="form" action="{% url "search" %}" method="get">
             <div class="form-group">
                 <label class="sr-only" for="form_search">Search term</label>
                 <input type="text" class="form-control" id="form_search" name="search" size=50 placeholder="Search term as regex" />
@@ -57,10 +57,6 @@
                     <tr>
                         <td><code>type:</code></td>
                         <td>File type/format</td>
-                    </tr>
-                    <tr>
-                        <td><code>string:</code></td>
-                        <td>String contained in the binary</td>
                     </tr>
                     <tr>
                         <td><code>ssdeep:</code></td>
@@ -253,10 +249,6 @@
                     <tr>
                         <td><code>ttp:</code></td>
                         <td>TTP id, ex: T1053</td>
-                    </tr>
-                    <tr>
-                        <td><code>payloads: to be depricated soon due to global search</code></td>
-                        <td>md5/sha1/sha3/sha256/sha512</td>
                     </tr>
                     <tr>
                         <td><code>dhash:</code></td>

--- a/web/templates/header.html
+++ b/web/templates/header.html
@@ -45,7 +45,7 @@
             <li class="nav-item"><a class="nav-link" href="https://capev2.readthedocs.io/en/latest/"><span class="fas fa-info"></span> Docs</a></li>
             <li class="nav-item"><a class="nav-link" href="https://github.com/kevoreilly/CAPEv2/blob/master/changelog.md"><span class="far fa-newspaper"></span> Changelog</a></li>
           </ul>
-          <form class="form-inline" style="margin:0px;" action="{% url "search" %}" enctype="multipart/form-data" method="post">{% csrf_token %}
+          <form class="form-inline" style="margin:0px;" action="{% url "search" %}" method="get">
             <input class="form-control" type="text" id="form_search" name="search" placeholder="Search term as regex">
             <button class="btn btn-secondary" type="submit">Search</button>
           </form>


### PR DESCRIPTION
- For documents whose file information has been normalized to the "files"
collection, we need to search there to find the sha256 of those files
and then do our normal search using that.
- Add back searching by crc32. I think it was mistakenly taken out.
- Remove "string" from search page documentation since it was never
correctly implemented. There is no top-level "strings" field.
- Don't apply the hash suffixes to "extracted_files_tool" keys. The
corresponding value is just the name of the tool. It does not have
sub-keys for the hash types.
- Submit searches using HTTP GET so that they're easy to share. Continue
to accept POST requests, though.