### PR TITLE
Make PowerShell Core optional.

### DIFF
--- a/analyzer/windows/lib/common/abstracts.py
+++ b/analyzer/windows/lib/common/abstracts.py
@@ -43,9 +43,13 @@ class Package:
         """Check."""
         return True
 
+    def get_paths(self):
+        """Get the default list of paths."""
+        return self.PATHS
+
     def enum_paths(self):
         """Enumerate available paths."""
-        for path in self.PATHS:
+        for path in self.get_paths():
             basedir = path[0]
             sys32 = len(path) > 1 and path[1].lower() == "system32"
             if basedir == "SystemRoot":

--- a/analyzer/windows/modules/packages/ps1.py
+++ b/analyzer/windows/modules/packages/ps1.py
@@ -9,13 +9,25 @@ from lib.common.common import check_file_extension
 class PS1(Package):
     """PowerShell analysis package."""
 
-    PATHS = [
-        # PS v7
+    POWERSHELL_CORE = [
+        # PS v7 (Powershell Core) optional.
         ("ProgramFiles", "PowerShell", "*", "pwsh.exe"),
+    ]
+    PATHS = [
         # PS <= 5
         ("SystemRoot", "sysnative", "WindowsPowerShell", "v*.0", "powershell.exe"),
         ("SystemRoot", "system32", "WindowsPowerShell", "v*.0", "powershell.exe"),
     ]
+
+    def get_paths(self):
+        """Return list of paths to search for the PowerShell executable.
+
+        If the user selected the option, insert PowerShell Core path at the start of
+        the list.
+        """
+        if self.options.get("pwsh"):
+            return self.POWERSHELL_CORE + self.PATHS
+        return self.PATHS
 
     def start(self, path):
         powershell = self.get_path_glob("PowerShell")

--- a/analyzer/windows/tests/modules/packages/test_ps1.py
+++ b/analyzer/windows/tests/modules/packages/test_ps1.py
@@ -1,0 +1,22 @@
+import unittest
+from modules.packages.ps1 import PS1
+
+
+class TestPS1(unittest.TestCase):
+
+    def test_get_paths(self):
+        """By default, the first path should be powershell.exe"""
+        ps1_module = PS1()
+        paths = ps1_module.get_paths()
+        assert paths[0][-1] == "powershell.exe"
+        all_paths = set([path[-1] for path in paths])
+        assert "pwsh.exe" not in all_paths
+
+    def test_get_paths_powershell_core(self):
+        """When option pwsh selected, the first path should be pwsh.exe"""
+        options = {"pwsh": True}
+        ps1_module = PS1(options=options)
+        paths = ps1_module.get_paths()
+        assert paths[0][-1] == "pwsh.exe"
+        all_paths = set([path[-1] for path in paths])
+        assert "powershell.exe" in all_paths

--- a/docs/book/src/usage/submit.rst
+++ b/docs/book/src/usage/submit.rst
@@ -164,6 +164,7 @@ some options (in this case a command line argument for the malware)::
 - ``pre_script_args``: Command line arguments for pre_script. Example: pre_script_args=file1 file2 file3
 - ``pre_script_timeout``: pre_script_timeout will default to 60 seconds. Script will stop after timeout Example: pre_script_timeout=30
 - ``during_script_args``: Command line arguments for during_script. Example: during_script_args=file1 file2 file3
+- ``pwsh``: - for ps1 package: prefer PowerShell Core, if available in the vm
 
 .. _webpy:
 

--- a/web/templates/submission/index.html
+++ b/web/templates/submission/index.html
@@ -510,6 +510,10 @@ $(document).ready( function() {
                                                     <td>Allow ignore file size, must be enabled in conf/web.conf</td>
                                                 </tr>
                                                 <tr>
+                                                    <td><code>pwsh</code></td>
+                                                    <td>When using the ps1 package, prefer PowerShell Core (pwsh.exe) if available (defaults to powershell.exe)</td>
+                                                </tr>
+                                                <tr>
                                                     <td><code>unpacker</code></td>
                                                     <td>Ex: unpacker=2 - Add description here</td>
                                                 </tr>


### PR DESCRIPTION
Previously it would default to PowerShell Core (pwsh.exe) if available. With this change, powershell.exe is the default. Submitters can use the option 'pwsh' to select PowerShell Core.