### PR TITLE
Add more descriptive error messages with possible fixes for some beginner errors

### DIFF
--- a/lib/cuckoo/core/resultserver.py
+++ b/lib/cuckoo/core/resultserver.py
@@ -434,7 +434,12 @@ class ResultServer(metaclass=Singleton):
             sock.bind((ip, port))
         except (OSError, socket.error) as e:
             if e.errno == errno.EADDRINUSE:
-                raise CuckooCriticalError(f"Cannot bind ResultServer on port {port} because it was in use, bailing")
+                raise CuckooCriticalError(
+                    f"Cannot bind ResultServer on port {port} because it was in use, bailing"
+                    "This might happen because CAPE is already running in the background as cape.service"
+                    "sudo systemctl stop cape.service"
+                    "to stop the background service. You can also run the just use the background service without starting it again here in the terminal."
+                    )
             elif e.errno == errno.EADDRNOTAVAIL:
                 raise CuckooCriticalError(
                     f"Unable to bind ResultServer on {ip}:{port} {e}. This "

--- a/lib/cuckoo/core/resultserver.py
+++ b/lib/cuckoo/core/resultserver.py
@@ -448,6 +448,8 @@ class ResultServer(metaclass=Singleton):
                     "the ResultServer IP address. Please refer to "
                     "https://cuckoo.sh/docs/faq/#troubles-problem "
                     "for more information"
+                    "One more reason this might happen is if you don't correctly set the IP of the resultserver in cuckoo.conf."
+                    "Make sure the resultserver IP is set to the host IP"
                 )
             else:
                 raise CuckooCriticalError(f"Unable to bind ResultServer on {ip}:{port} {e}")


### PR DESCRIPTION
As suggested, I have added more context to the error messages in resultserver.py for some errors that beginners might encounter. This is in addition to my previous PR #1789 which documented these errors.