### PR TITLE
Bug fix to scheduler.py

### DIFF
--- a/lib/cuckoo/core/scheduler.py
+++ b/lib/cuckoo/core/scheduler.py
@@ -377,6 +377,8 @@ class AnalysisManager(threading.Thread):
             log.error("Task #%s: Cannot acquire machine: %s", self.task.id, e, exc_info=True)
             return False
 
+        aux = RunAuxiliary(task=self.task, machine=self.machine)
+
         try:
             unlocked = False
 
@@ -398,8 +400,6 @@ class AnalysisManager(threading.Thread):
                 machinery.release(self.machine.label)
                 log.exception(e, exc_info=True)
                 self.errors.put(e)
-
-            aux = RunAuxiliary(task=self.task, machine=self.machine)
 
             # Enable network routing.
             self.route_network()


### PR DESCRIPTION
An intended error occurs when there is an exception thrown on `machinery.start(self.machine.label)`. This is because it is trying to start a virtual machine that has not been turned off.
https://github.com/kevoreilly/CAPEv2/blob/23f92b58338679d1db8a60b66aee1f5da2acb3ed/lib/cuckoo/core/scheduler.py#L383-#L385

However, this causes the try-except-finally block in this section to stop auxiliary modules before they are being initialized. 
https://github.com/kevoreilly/CAPEv2/blob/23f92b58338679d1db8a60b66aee1f5da2acb3ed/lib/cuckoo/core/scheduler.py#L436-#L438

This throws an unintended exception:
```
Oct 11 15:51:43 bobby python3[7291]: 2023-10-11 15:51:43,406 [lib.cuckoo.core.scheduler] ERROR: Task #396: Failure in AnalysisManager.run: local variable 'aux' referenced before assignment
Oct 11 15:51:43 bobby python3[7291]: Traceback (most recent call last):
Oct 11 15:51:43 bobby python3[7291]:   File "/opt/CAPEv2/lib/cuckoo/core/scheduler.py", line 520, in run
Oct 11 15:51:43 bobby python3[7291]:     success = self.launch_analysis()
Oct 11 15:51:43 bobby python3[7291]:   File "/opt/CAPEv2/lib/cuckoo/core/scheduler.py", line 446, in launch_analysis
Oct 11 15:51:43 bobby python3[7291]:     aux.stop()
Oct 11 15:51:43 bobby python3[7291]: UnboundLocalError: local variable 'aux' referenced before assignment
Oct 11 15:51:43 bobby python[7291]: 2023-10-11 15:51:43,406 [lib.cuckoo.core.scheduler] ERROR: Task #396: Failure in AnalysisManager.run: local variable 'aux' referenced before assignment
                                    Traceback (most recent call last):
                                      File "/opt/CAPEv2/lib/cuckoo/core/scheduler.py", line 520, in run
                                        success = self.launch_analysis()
                                      File "/opt/CAPEv2/lib/cuckoo/core/scheduler.py", line 446, in launch_analysis
                                        aux.stop()
                                    UnboundLocalError: local variable 'aux' referenced before assignment
```
This unintended exception would be fixed if we shift `aux` initialization before the try-except block.