### PR TITLE
Add package exclusion for web form

### DIFF
--- a/conf/web.conf
+++ b/conf/web.conf
@@ -184,3 +184,9 @@ guest_rdp_port = 3389
 # Some samples will only detonate on specific versions of Windows (see web.conf packages for more info)
 # Example: MSIX - Windows >= 10
 msix = win10,win11
+
+[security]
+# When using mounted folder you might want to set to no
+check_path_safe = yes
+# Can be multiple domains. Ex: domain.com,domain.net,domain.org
+csrf_trusted_origins =

--- a/conf/web.conf
+++ b/conf/web.conf
@@ -184,14 +184,3 @@ guest_rdp_port = 3389
 # Some samples will only detonate on specific versions of Windows (see web.conf packages for more info)
 # Example: MSIX - Windows >= 10
 msix = win10,win11
-
-[security]
-# When using mounted folder you might want to set to no
-check_path_safe = yes
-# Can be multiple domains. Ex: domain.com,domain.net,domain.org
-csrf_trusted_origins =
-
-[package_exclusion]
-# Remove packages from submission page. Useful when the package application is not available
-# Example: packages = chrome,chromium,firefox
-packages =

--- a/conf/web.conf
+++ b/conf/web.conf
@@ -190,3 +190,8 @@ msix = win10,win11
 check_path_safe = yes
 # Can be multiple domains. Ex: domain.com,domain.net,domain.org
 csrf_trusted_origins =
+
+[package_exclusion]
+# Remove packages from submission page. Useful when the package application is not available
+# Example: packages = chrome,chromium,firefox
+packages =

--- a/conf/web.conf.default
+++ b/conf/web.conf.default
@@ -202,3 +202,8 @@ msix = win10,win11
 check_path_safe = yes
 # Can be multiple domains. Ex: domain.com,domain.net,domain.org
 csrf_trusted_origins =
+
+[package_exclusion]
+# Remove packages from submission page. Useful when the package application is not availabe
+# Example: chrome,chromium,firefox
+packages =

--- a/conf/web.conf.default
+++ b/conf/web.conf.default
@@ -204,6 +204,6 @@ check_path_safe = yes
 csrf_trusted_origins =
 
 [package_exclusion]
-# Remove packages from submission page. Useful when the package application is not availabe
-# Example: chrome,chromium,firefox
+# Remove packages from submission page. Useful when the package application is not available
+# Example: packages = chrome,chromium,firefox
 packages =

--- a/web/submission/views.py
+++ b/web/submission/views.py
@@ -64,7 +64,8 @@ def get_form_data(platform):
         name = os.path.splitext(name)[0]
         if name == "__init__":
             continue
-        packages.append(name)
+        if name not in web_conf.package_exclusion.packages:
+            packages.append(name)
 
     # Prepare a list of VM names, description label based on tags.
     machines = []


### PR DESCRIPTION
# Remove packages from submission page. Useful when the package application is not available
# Example: packages = chrome,chromium,firefox