### PR TITLE
give mongo_find limit capabilities and use them

### DIFF
--- a/lib/cuckoo/common/web_utils.py
+++ b/lib/cuckoo/common/web_utils.py
@@ -1181,7 +1181,7 @@ def perform_search(term, value, search_limit=False, user_id=False, privs=False, 
         if "target.file.sha256" in projection:
             projection = dict(**projection)
             projection[f"target.file.{FILE_REF_KEY}"] = 1
-        retval = list(mongo_find("analysis", mongo_search_query, projection).sort([["_id", -1]]).limit(search_limit))
+        retval = list(mongo_find("analysis", mongo_search_query, projection, limit=search_limit))
         for doc in retval:
             target_file = doc.get("target", {}).get("file", {})
             if FILE_REF_KEY in target_file and "sha256" not in target_file:

--- a/utils/cleaners.py
+++ b/utils/cleaners.py
@@ -290,9 +290,8 @@ def cuckoo_clean_failed_url_tasks():
         return
 
     if repconf.mongodb.enabled:
-        rtmp = mongo_find(
-            "analysis", {"info.category": "url", "network.http.0": {"$exists": False}}, {"info.id": 1}, sort=[("_id", -1)]
-        ).limit(100)
+        query = {"info.category": "url", "network.http.0": {"$exists": False}}
+        rtmp = mongo_find("analysis", query, projection={"info.id": 1}, sort=[("_id", -1)], limit=100)
     elif repconf.elasticsearchdb.enabled:
         rtmp = [
             d["_source"]
@@ -444,9 +443,8 @@ def cuckoo_clean_sorted_pcap_dump():
 
     while not done:
         if repconf.mongodb.enabled:
-            rtmp = mongo_find("analysis", {"network.sorted_pcap_id": {"$exists": True}}, {"info.id": 1}, sort=[("_id", -1)]).limit(
-                100
-            )
+            query = {"network.sorted_pcap_id": {"$exists": True}}
+            rtmp = mongo_find("analysis", query, projection={"info.id": 1}, sort=[("_id", -1)], limit=100)
         elif repconf.elasticsearchdb.enabled:
             rtmp = [
                 d["_source"]


### PR DESCRIPTION
Fixes web_utils and cleaners calls to [sort() and limit()](https://github.com/kevoreilly/CAPEv2/blob/d1acb2ab1e9b881d5d118f887f7030589c659308/lib/cuckoo/common/web_utils.py#L1184) by adding them to the find query if provided as kwargs.