### PR TITLE
small cape.sh installer fixes

### DIFF
--- a/extra/yara_installer.sh
+++ b/extra/yara_installer.sh
@@ -12,3 +12,6 @@ python setup.py build --enable-cuckoo --enable-magic --enable-profiling
 cd ..
 # for root
 pip install ./yara-python
+if [ -d yara-python ]; then
+    rm -r yara-python
+fi

--- a/extra/yara_installer.sh
+++ b/extra/yara_installer.sh
@@ -12,4 +12,3 @@ python setup.py build --enable-cuckoo --enable-magic --enable-profiling
 cd ..
 # for root
 pip install ./yara-python
-rm -r yara-python

--- a/installer/cape2.sh
+++ b/installer/cape2.sh
@@ -658,10 +658,10 @@ function install_suricata() {
         crontab -l | { cat; echo "15 * * * * /usr/bin/suricata-update --suricata /usr/bin/suricata --suricata-conf /etc/suricata/suricata.yaml -o /etc/suricata/rules/ && /usr/bin/suricatasc -c reload-rules /tmp/suricata-command.socket &>/dev/null"; } | crontab -
     fi
     if [ -d /usr/share/suricata/rules/ ]; then
-        cp "/usr/share/suricata/rules/*" "/etc/suricata/rules/"
+        cp "/usr/share/suricata/rules/"* "/etc/suricata/rules/"
     fi
     if [ -d /var/lib/suricata/rules/ ]; then
-        cp "/var/lib/suricata/rules/*" "/etc/suricata/rules/"
+        cp "/var/lib/suricata/rules/"* "/etc/suricata/rules/"
     fi
 
     # ToDo this is not the best solution but i don't have time now to investigate proper one
@@ -1176,7 +1176,10 @@ function install_CAPE() {
     pip3 install poetry crudini
     CRYPTOGRAPHY_DONT_BUILD_RUST=1 sudo -u ${USER} bash -c 'export PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring; poetry install'
     sudo -u ${USER} bash -c 'export PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring; poetry run extra/libvirt_installer.sh'
+    #packages are needed for build options in extra/yara_installer.sh
+    apt install libjansson-dev libmagic1 libmagic-dev -y
     sudo -u ${USER} bash -c 'poetry run extra/yara_installer.sh'
+    sudo rm -r yara-python
 
     sudo usermod -aG kvm ${USER}
     sudo usermod -aG libvirt ${USER}


### PR DESCRIPTION
Following errors appeared, followed up by my suggestions:

install_suricata:
 cp: cannot stat '/usr/share/suricata/rules/*': No such file or directory
-> if source directory is set in quotes, * should be outside the quotes.

install_CAPE (yara_installer.sh)
yara/libyara/modules/cuckoo/cuckoo.c:31:10: fatal error: jansson.h: No such file or directory
-> apt install libjansson-dev -y
yara/libyara/modules/magic/magic.c:36:10: fatal error: magic.h: No such file or directory
-> apt install libmagic1 libmagic-dev -y
rm: remove write-protected regular file 'yara-python/.git/objects/pack/pack-6854d0fa261e050a13eaa61497e1ad74b3535e89.pack'? 
-> move rm -r /tmp/yara-python to cape.sh to fix permission

Greetings

Claudio