### PR TITLE
match all subdomains of windowsupdate

### DIFF
--- a/data/safelist/domains.py
+++ b/data/safelist/domains.py
@@ -2,9 +2,8 @@ domain_passlist_re = [
     # Certificate Trust Update domains
     r"^ocsp\.usertrust\.com$",
     r"\.windows\.com$",
+    r"\.windowsupdate\.com$",
     r"^ocsp\.comodoca\.com$",
-    r"^ctldl\.windowsupdate\.com$",
-    r"^www\.download\.windowsupdate\.com$",
     r"^crl\.microsoft\.com$",
     r"^urs\.microsoft\.com$",
     r"\.microsoft\.com$",


### PR DESCRIPTION
For example: https://www.virustotal.com/gui/ip-address/209.197.3.8/relations

There are many subdomains of windows update
```
1b.au.download.windowsupdate.com
aupl.ds.download.windowsupdate.com
opsmsedgeextensions.f.tlu.dl.delivery.mp.microsoft.com
mp.aupn.ds.download.windowsupdate.com
mp.aupl.ds.download.windowsupdate.com
9.b1.download.windowsupdate.com
```