### PR TITLE
quiet down screenshot capture debug logs

### DIFF
--- a/lib/cuckoo/common/abstracts.py
+++ b/lib/cuckoo/common/abstracts.py
@@ -500,15 +500,14 @@ class LibVirtMachinery(Machinery):
         @param label: machine name
         @param path: where to store the screenshot
         """
-        log.debug("getting screenshot for %s", label)
         conn = self._connect()
         try:
             vm = conn.lookupByName(label)
         except libvirt.libvirtError as e:
             raise CuckooMachineError(f"Error screenshotting virtual machine {label}: {e}") from e
         stream0, screen = conn.newStream(), 0
-        mime = vm.screenshot(stream0, screen)
-        log.debug("got screenshot of type %s", mime)
+        # ignore the mime type returned by the call to screenshot()
+        _ = vm.screenshot(stream0, screen)
 
         buffer = io.BytesIO()
 
@@ -517,7 +516,6 @@ class LibVirtMachinery(Machinery):
 
         stream0.recvAll(stream_handler, buffer)
         stream0.finish()
-        log.debug("took screenshot, got %d bytes of %s", buffer.tell(), mime)
         streamed_img = PIL.Image.open(buffer)
         streamed_img.convert(mode="RGB").save(path)
 

--- a/lib/cuckoo/core/guest.py
+++ b/lib/cuckoo/core/guest.py
@@ -350,7 +350,11 @@ class GuestManager:
         start = timeit.default_timer()
 
         while db.guest_get_status(self.task_id) == "running" and self.do_run:
-            self.analysis_manager.screenshot_machine()
+            if cfg.cuckoo.machinery_screenshots:
+                if count == 0:
+                    # indicate screenshot captures have started
+                    log.info("Task #%s: Started capturing screenshots for %s", self.task_id, self.vmid)
+                self.analysis_manager.screenshot_machine()
             if count >= 5:
                 log.debug("Task #%s: Analysis is still running (id=%s, ip=%s)", self.task_id, self.vmid, self.ipaddr)
                 count = 0


### PR DESCRIPTION
Follow up to https://github.com/kevoreilly/CAPEv2/pull/1814, make logs quieter. The machinery based screenshots work well but logs are too noisy.