### PR TITLE
Make sure file_data is defined.

### DIFF
--- a/modules/processing/CAPE.py
+++ b/modules/processing/CAPE.py
@@ -271,6 +271,7 @@ class CAPE(Processing):
                 )
 
         # Get the file data
+        file_data = None
         if path_exists(file_info["path"]):
             file_data = Path(file_info["path"]).read_bytes()
             for yara in file_info["cape_yara"]:


### PR DESCRIPTION
We later check file_data, but we should make sure that it's always defined, not only if path_exists(file_info["path"]).