### PR TITLE
bump optional ImageHash to 4.3.1

### DIFF
--- a/conf/processing.conf
+++ b/conf/processing.conf
@@ -210,7 +210,7 @@ userdb_signature = no
 replace_patterns = no
 
 # Deduplicate screenshots
-# You need to install dependency ImageHash>=4.2.1
+# You need to install dependency ImageHash>=4.3.1
 [deduplication]
 #
 # Available hashs functions:

--- a/conf/processing.conf
+++ b/conf/processing.conf
@@ -303,3 +303,4 @@ tight_strings = yes
 min_length = 5
 # Download FLOSS signatures from https://github.com/mandiant/flare-floss/tree/master/sigs
 sigs_path = data/flare-signatures
+

--- a/conf/processing.conf
+++ b/conf/processing.conf
@@ -210,7 +210,7 @@ userdb_signature = no
 replace_patterns = no
 
 # Deduplicate screenshots
-# You need to install dependency ImageHash>=4.3.1
+# You need to install dependency ImageHash>=4.2.1
 [deduplication]
 #
 # Available hashs functions:

--- a/conf/processing.conf.default
+++ b/conf/processing.conf.default
@@ -219,8 +219,7 @@ userdb_signature = no
 # https://capev2.readthedocs.io/en/latest/usage/patterns_replacement.html
 replace_patterns = no
 
-# Deduplicate screenshots
-# You need to install dependency ImageHash>=4.3.1
+# Deduplicate screenshots - You need to install dependency ImageHash>=4.3.1
 [deduplication]
 #
 # Available hashs functions:

--- a/conf/processing.conf.default
+++ b/conf/processing.conf.default
@@ -220,7 +220,7 @@ userdb_signature = no
 replace_patterns = no
 
 # Deduplicate screenshots
-# You need to install dependency ImageHash>=4.2.1
+# You need to install dependency ImageHash>=4.3.1
 [deduplication]
 #
 # Available hashs functions:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ yara-python = "4.3.1"
 netstruct = "1.1.2"
 pymongo = ">=4.0.1"
 psutil = "5.8.0"
-# ImageHash = "4.2.1"
+# ImageHash = "4.3.1"
 LnkParse3 = "1.2.0"
 cachetools = "^5.3.0"
 django-allauth = "0.54.0"  # https://django-allauth.readthedocs.io/en/latest/configuration.html


### PR DESCRIPTION
This fixes messages like these in the processing logs:
```
    [Task 32818466] [root] ERROR: module 'PIL.Image' has no attribute 'ANTIALIAS'
```

Follow up on https://github.com/kevoreilly/CAPEv2/pull/1871