### PR TITLE
Update mongodb URL to .com to be able to download PGP key dur…

### DIFF
--- a/installer/cape2.sh
+++ b/installer/cape2.sh
@@ -781,7 +781,7 @@ function install_mongo(){
 			MONGO_VERSION="4.4"
 		fi
 
-		sudo curl -fsSL "https://pgp.mongodb.org/server-${MONGO_VERSION}.asc" | sudo gpg --dearmor -o /etc/apt/keyrings/mongo.gpg --yes
+		sudo curl -fsSL "https://pgp.mongodb.com/server-${MONGO_VERSION}.asc" | sudo gpg --dearmor -o /etc/apt/keyrings/mongo.gpg --yes
 		echo "deb [signed-by=/etc/apt/keyrings/mongo.gpg arch=amd64] https://repo.mongodb.org/apt/ubuntu $(lsb_release -cs)/mongodb-org/${MONGO_VERSION} multiverse" > /etc/apt/sources.list.d/mongodb.list
 
 		apt update 2>/dev/null


### PR DESCRIPTION
During the mongo install phase the command to download the PGP key fails with "No pgp data found"
After referring to the offical documentation is appears the URL is pgp.mongodb.com not .org