### PR TITLE
Put MSOffice documents in to a "trusted location".

### DIFF
--- a/analyzer/windows/analyzer.py
+++ b/analyzer/windows/analyzer.py
@@ -38,7 +38,6 @@ from lib.common.defines import ADVAPI32, EVENT_MODIFY_STATE, KERNEL32, MAX_PATH,
 from lib.common.exceptions import CuckooError, CuckooPackageError
 from lib.common.hashing import hash_file
 from lib.common.results import upload_to_host
-from lib.core.compound import create_custom_folders
 from lib.core.config import Config
 from lib.core.packages import choose_package
 from lib.core.pipe import PipeDispatcher, PipeForwarder, PipeServer, disconnect_pipes
@@ -402,9 +401,6 @@ class Analyzer:
         # E.g., for some samples it might be useful to run from %APPDATA%
         # instead of %TEMP%.
         if self.config.category == "file":
-            # Try to create the folders for the cases of the custom paths other than %TEMP%
-            if "curdir" in self.options:
-                create_custom_folders(self.options["curdir"])
             self.target = self.package.move_curdir(self.target)
         log.debug("New location of moved file: %s", self.target)
 

--- a/analyzer/windows/lib/common/abstracts.py
+++ b/analyzer/windows/lib/common/abstracts.py
@@ -9,6 +9,7 @@ import shutil
 
 from lib.api.process import Process
 from lib.common.exceptions import CuckooPackageError
+from lib.core.compound import create_custom_folders
 
 log = logging.getLogger(__name__)
 
@@ -17,6 +18,7 @@ class Package:
     """Base abstract analysis package."""
 
     PATHS = []
+    default_curdir = None
 
     def __init__(self, options=None, config=None):
         """@param options: options dict."""
@@ -154,8 +156,12 @@ class Package:
         """
         if "curdir" in self.options:
             self.curdir = os.path.expandvars(self.options["curdir"])
+        elif self.default_curdir:
+            self.curdir = os.path.expandvars(self.default_curdir)
         else:
             self.curdir = os.getenv("TEMP")
+        # Try to create the folders for the cases of the custom paths other than %TEMP%
+        create_custom_folders(self.curdir)
         newpath = os.path.join(self.curdir, os.path.basename(filepath))
         shutil.move(filepath, newpath)
         return newpath

--- a/analyzer/windows/lib/common/constants.py
+++ b/analyzer/windows/lib/common/constants.py
@@ -25,3 +25,12 @@ CAPEMON64_NAME = f"dll\\{random_string(6, 8)}.dll"
 LOADER32_NAME = f"bin\\{random_string(7)}.exe"
 LOADER64_NAME = f"bin\\{random_string(8)}.exe"
 LOGSERVER_PREFIX = f"\\\\.\\PIPE\\{random_string(8, 12)}"
+
+""" Excel, Word, and Powerpoint won't have macros enabled without interaction for
+documents that are outside one of its "Trusted Locations". Unless the user has
+provided a 'curdir' option, use MSOFFICE_TRUSTED_PATH as the directory where
+the document will be saved and executed from since that is a default trusted
+location for all 3 apps. See
+https://learn.microsoft.com/en-us/deployoffice/security/trusted-locations
+"""
+MSOFFICE_TRUSTED_PATH = os.path.join("%SystemDrive%", "Program Files", "Microsoft Office", "root", "Templates")

--- a/analyzer/windows/modules/packages/doc.py
+++ b/analyzer/windows/modules/packages/doc.py
@@ -4,11 +4,14 @@
 
 from lib.common.abstracts import Package
 from lib.common.common import check_file_extension
+from lib.common.constants import MSOFFICE_TRUSTED_PATH
 from lib.common.exceptions import CuckooPackageError
 
 
 class DOC(Package):
     """Word analysis package."""
+
+    default_curdir = MSOFFICE_TRUSTED_PATH
 
     def __init__(self, options=None, config=None):
         if options is None:

--- a/analyzer/windows/modules/packages/doc2016.py
+++ b/analyzer/windows/modules/packages/doc2016.py
@@ -4,10 +4,13 @@
 
 from lib.common.abstracts import Package
 from lib.common.common import check_file_extension
+from lib.common.constants import MSOFFICE_TRUSTED_PATH
 
 
 class DOC2016(Package):
     """Word analysis package."""
+
+    default_curdir = MSOFFICE_TRUSTED_PATH
 
     def __init__(self, options=None, config=None):
         if options is None:

--- a/analyzer/windows/modules/packages/doc_antivm.py
+++ b/analyzer/windows/modules/packages/doc_antivm.py
@@ -3,6 +3,7 @@ import time
 
 from lib.common.abstracts import Package
 from lib.common.common import check_file_extension
+from lib.common.constants import MSOFFICE_TRUSTED_PATH
 from lib.common.exceptions import CuckooPackageError
 
 
@@ -16,6 +17,7 @@ class DOC_ANTIVM(Package):
         ("ProgramFiles", "Microsoft Office*", "root", "Office*", "WINWORD.EXE"),
         ("ProgramFiles", "Microsoft Office", "WORDVIEW.EXE"),
     ]
+    default_curdir = MSOFFICE_TRUSTED_PATH
 
     def start(self, path):
         # Determine if the submitter wants the sample to be monitored

--- a/analyzer/windows/modules/packages/ppt.py
+++ b/analyzer/windows/modules/packages/ppt.py
@@ -3,10 +3,13 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 from lib.common.abstracts import Package
+from lib.common.constants import MSOFFICE_TRUSTED_PATH
 
 
 class PPT(Package):
     """PowerPoint analysis package."""
+
+    default_curdir = MSOFFICE_TRUSTED_PATH
 
     def __init__(self, options=None, config=None):
         if options is None:

--- a/analyzer/windows/modules/packages/ppt2016.py
+++ b/analyzer/windows/modules/packages/ppt2016.py
@@ -3,10 +3,13 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 from lib.common.abstracts import Package
+from lib.common.constants import MSOFFICE_TRUSTED_PATH
 
 
 class PPT2007(Package):
     """PowerPoint analysis package."""
+
+    default_curdir = MSOFFICE_TRUSTED_PATH
 
     def __init__(self, options=None, config=None):
         if options is None:

--- a/analyzer/windows/modules/packages/xls.py
+++ b/analyzer/windows/modules/packages/xls.py
@@ -4,10 +4,13 @@
 
 from lib.common.abstracts import Package
 from lib.common.common import check_file_extension
+from lib.common.constants import MSOFFICE_TRUSTED_PATH
 
 
 class XLS(Package):
     """Excel analysis package."""
+
+    default_curdir = MSOFFICE_TRUSTED_PATH
 
     def __init__(self, options=None, config=None):
         if options is None:

--- a/analyzer/windows/modules/packages/xls2016.py
+++ b/analyzer/windows/modules/packages/xls2016.py
@@ -4,10 +4,13 @@
 
 from lib.common.abstracts import Package
 from lib.common.common import check_file_extension
+from lib.common.constants import MSOFFICE_TRUSTED_PATH
 
 
 class XLS2207(Package):
     """Excel analysis package."""
+
+    default_curdir = MSOFFICE_TRUSTED_PATH
 
     def __init__(self, options={}, config=None):
         self.config = config


### PR DESCRIPTION
Excel, Word, and Powerpoint won't have macros enabled without interaction for documents that are outside one of its "Trusted Locations". Unless the user has provided a 'curdir' option, use MSOFFICE_TRUSTED_PATH as the directory where the document will be saved and executed from since that is a default trusted location for all 3 apps. See
https://learn.microsoft.com/en-us/deployoffice/security/trusted-locations

Note, I have only tested this with MSOffice LTSC 2021.