### PR TITLE
Adding ability to try a password list for archive files

### DIFF
--- a/analyzer/windows/lib/common/zip_utils.py
+++ b/analyzer/windows/lib/common/zip_utils.py
@@ -163,6 +163,7 @@ def extract_zip(zip_path, extract_path, password=b"infected", recursion_depth=1,
         for pword in passwords:
             try:
                 archive.extractall(path=extract_path, pwd=pword)
+                password_fail = False
             except BadZipfile as e:
                 raise CuckooPackageError("Invalid Zip file") from e
             except RuntimeError as e:
@@ -177,7 +178,6 @@ def extract_zip(zip_path, extract_path, password=b"infected", recursion_depth=1,
                     except RuntimeError as e:
                         raise CuckooPackageError(f"Unable to extract Zip file: {e}") from e
             finally:
-                password_fail = False
                 if recursion_depth < 4:
                     # Extract nested archives.
                     for name in archive.namelist():

--- a/analyzer/windows/lib/common/zip_utils.py
+++ b/analyzer/windows/lib/common/zip_utils.py
@@ -198,6 +198,9 @@ def extract_zip(zip_path, extract_path, password=b"infected", recursion_depth=1,
                                 )
                             except RuntimeError as run_err:
                                 log.error("Error extracting nested Zip file %s with details: %s", name, run_err)
+                # If password_fail is False, then we either do not need a password, or we have used the correct password
+                if not password_fail:
+                    break
 
         if password_fail:
             raise CuckooPackageError(f"Unable to extract password-protected Zip file with the password(s): {passwords}")

--- a/analyzer/windows/modules/packages/archive.py
+++ b/analyzer/windows/modules/packages/archive.py
@@ -20,7 +20,7 @@ from lib.common.exceptions import CuckooPackageError
 from lib.common.hashing import hash_file
 from lib.common.parse_pe import choose_dll_export, is_pe_image
 from lib.common.results import upload_to_host
-from lib.common.zip_utils import extract_archive, get_file_names, winrar_extractor
+from lib.common.zip_utils import extract_archive, get_file_names, winrar_extractor, attempt_multiple_passwords
 
 log = logging.getLogger(__name__)
 
@@ -139,7 +139,8 @@ class Archive(Package):
 
         file_names = get_file_names(seven_zip_path, path)
         if len(file_names):
-            extract_archive(seven_zip_path, path, root, password)
+            try_multiple_passwords = attempt_multiple_passwords(self.options, password)
+            extract_archive(seven_zip_path, path, root, password, try_multiple_passwords)
 
         # Try extract with winrar, in some cases 7z-full fails with .Iso
         if not file_names:

--- a/analyzer/windows/modules/packages/zip.py
+++ b/analyzer/windows/modules/packages/zip.py
@@ -15,7 +15,7 @@ from lib.common.abstracts import Package
 from lib.common.common import check_file_extension
 from lib.common.exceptions import CuckooPackageError
 from lib.common.parse_pe import is_pe_image
-from lib.common.zip_utils import extract_archive, extract_zip, get_file_names, get_infos
+from lib.common.zip_utils import extract_archive, extract_zip, get_file_names, get_infos, attempt_multiple_passwords
 
 log = logging.getLogger(__name__)
 
@@ -103,6 +103,7 @@ class Zip(Package):
 
     def start(self, path):
         password = self.options.get("password", "infected")
+        try_multiple_passwords = attempt_multiple_passwords(self.options, password)
         appdata = self.options.get("appdata")
         root = os.environ["APPDATA"] if appdata else os.environ["TEMP"]
         file_names = []
@@ -121,7 +122,7 @@ class Zip(Package):
             seven_zip_path = self.get_path_app_in_path("7z.exe")
             file_names = get_file_names(seven_zip_path, path)
             if len(file_names):
-                extract_archive(seven_zip_path, path, root, password)
+                extract_archive(seven_zip_path, path, root, password, try_multiple_passwords)
 
         # If the .zip only contains a 7zip file, then do:
         if len(file_names) == 1 and file_names[0].endswith(".7z"):
@@ -129,7 +130,7 @@ class Zip(Package):
             nested_7z = os.path.join(root, file_names[0])
             file_names = get_file_names(seven_zip_path, nested_7z)
             if len(file_names):
-                extract_archive(seven_zip_path, nested_7z, root, password)
+                extract_archive(seven_zip_path, nested_7z, root, password, try_multiple_passwords)
 
         file_name = self.options.get("file")
         # If no file name is provided via option, discover files to execute.

--- a/analyzer/windows/modules/packages/zip.py
+++ b/analyzer/windows/modules/packages/zip.py
@@ -109,7 +109,7 @@ class Zip(Package):
         file_names = []
         try:
             zipinfos = get_infos(path)
-            extract_zip(path, root, password, 0)
+            extract_zip(path, root, password, 0, try_multiple_passwords)
             for f in zipinfos:
                 file_names.append(f.filename)
         except CuckooPackageError as e:


### PR DESCRIPTION
Addresses https://cccs.atlassian.net/browse/AL-2600

We are currently able to support a single password being passed to an archive-related package. It would be great if we can just pass a list of possible passwords and the package will try all of them until it succeeds in extracting the file! This PR should do that :)

Currently only supporting Zip and Archive packages for this capability