### PR TITLE
Fix AgentTesla.py

### DIFF
--- a/modules/processing/parsers/CAPE/AgentTesla.py
+++ b/modules/processing/parsers/CAPE/AgentTesla.py
@@ -14,7 +14,7 @@ def extract_config(data):
             if base:
 
                 # Check if string true or false is next string
-                if (lines[base + 1] == "false") or (lines[base + 1] == "true"): 
+                if (lines[base + 1] == "false") or (lines[base + 1] == "true"):
                     base = base + 1
 
                 # Data Exfiltration via Telegram
@@ -38,14 +38,14 @@ def extract_config(data):
 
                 # Data Exfiltration via SMTP
                 elif "@" in lines[base + 3]:
-        
+
                     config_dict["Protocol"] = "SMTP"
                     config_dict["Port"] = lines[base + 1]
                     config_dict["C2"] = lines[base + 2]
                     config_dict["Username"] = lines[base + 3]
                     config_dict["Password"] = lines[base + 4]
 
-                #Get Payload Filename
+                # Get Payload Filename
                 for x in range(1, 10):
                     if ".exe" in lines[base + x]:
                         config_dict["Filename"] = lines[base + x]

--- a/modules/processing/parsers/CAPE/AgentTesla.py
+++ b/modules/processing/parsers/CAPE/AgentTesla.py
@@ -12,29 +12,44 @@ def extract_config(data):
         with suppress(Exception):
             base = next(i for i, line in enumerate(lines) if "Mozilla/5.0" in line)
             if base:
-                if "telegram.org" in lines[base + 2]:
+
+                # Check if string true or false is next string
+                if (lines[base + 1] == "false") or (lines[base + 1] == "true"): 
+                    base = base + 1
+
+                # Data Exfiltration via Telegram
+                if "api.telegram.org" in lines[base + 1]:
                     config_dict["Protocol"] = "Telegram"
-                    config_dict["C2"] = lines[base + 2]
-                    config_dict["Password"] = lines[base + 3]
-                    return config_dict
-                if "discord.com" in lines[base + 2]:
+                    config_dict["C2"] = lines[base + 1]
+                    config_dict["Password"] = lines[base + 2]
+
+                # Data Exfiltration via Discord
+                elif "discord.com" in lines[base + 1]:
                     config_dict["Protocol"] = "Discord"
-                    config_dict["C2"] = lines[base + 2]
-                    return config_dict
-                elif ".exe" in lines[base + 4]:
-                    config_dict["Filename"] = lines[base + 4]
-                    return config_dict
-                elif ".exe" in lines[base + 5]:
-                    config_dict["Filename"] = lines[base + 5]
-                    return config_dict
-                elif "ftp" in lines[base + 3]:
+                    config_dict["C2"] = lines[base + 1]
+
+                # Data Exfiltration via FTP
+                elif "ftp:" in lines[base + 1]:
+
                     config_dict["Protocol"] = "FTP"
-                elif "@" in lines[base + 4]:
+                    config_dict["C2"] = lines[base + 1]
+                    config_dict["Username"] = lines[base + 2]
+                    config_dict["Password"] = lines[base + 3]
+
+                # Data Exfiltration via SMTP
+                elif "@" in lines[base + 3]:
+        
                     config_dict["Protocol"] = "SMTP"
-                config_dict["Port"] = lines[base + 2]
-                config_dict["C2"] = lines[base + 3]
-                config_dict["Username"] = lines[base + 4]
-                config_dict["Password"] = lines[base + 5]
+                    config_dict["Port"] = lines[base + 1]
+                    config_dict["C2"] = lines[base + 2]
+                    config_dict["Username"] = lines[base + 3]
+                    config_dict["Password"] = lines[base + 4]
+
+                #Get Payload Filename
+                for x in range(1, 10):
+                    if ".exe" in lines[base + x]:
+                        config_dict["Filename"] = lines[base + x]
+
                 return config_dict
         return
     try:

--- a/modules/processing/parsers/CAPE/AgentTesla.py
+++ b/modules/processing/parsers/CAPE/AgentTesla.py
@@ -12,49 +12,39 @@ def extract_config(data):
         with suppress(Exception):
             base = next(i for i, line in enumerate(lines) if "Mozilla/5.0" in line)
             if base:
-
                 # Check if string true or false is next string
                 if (lines[base + 1] == "false") or (lines[base + 1] == "true"):
                     base = base + 1
-
                 # Data Exfiltration via Telegram
                 if "api.telegram.org" in lines[base + 1]:
                     config_dict["Protocol"] = "Telegram"
                     config_dict["C2"] = lines[base + 1]
                     config_dict["Password"] = lines[base + 2]
-
                 # Data Exfiltration via Discord
                 elif "discord.com" in lines[base + 1]:
                     config_dict["Protocol"] = "Discord"
                     config_dict["C2"] = lines[base + 1]
-
                 # Data Exfiltration via FTP
                 elif "ftp:" in lines[base + 1]:
-
                     config_dict["Protocol"] = "FTP"
                     config_dict["C2"] = lines[base + 1]
                     config_dict["Username"] = lines[base + 2]
                     config_dict["Password"] = lines[base + 3]
-
                 # Data Exfiltration via SMTP
                 elif "@" in lines[base + 3]:
-
                     config_dict["Protocol"] = "SMTP"
                     config_dict["Port"] = lines[base + 1]
                     config_dict["C2"] = lines[base + 2]
                     config_dict["Username"] = lines[base + 3]
                     config_dict["Password"] = lines[base + 4]
-
                 # Get Payload Filename
                 for x in range(1, 10):
                     if ".exe" in lines[base + x]:
                         config_dict["Filename"] = lines[base + x]
-
                 return config_dict
         return
     try:
         lines = data.decode().split("\n")
-
         i = 0
         while len(lines[i]) != 1:
             i += 1


### PR DESCRIPTION
In some AgentTesla samples a "true" or "false" string appears after user-agent string "Mozilla/5.0..", in some it does not.
That breaks the parser/config.
Added search for filename.
Below are some examples.

---
![1295](https://github.com/kevoreilly/CAPEv2/assets/35531629/d0f340e4-c7f7-4328-8f3a-e546129ae024)
new:

![1295_fixed](https://github.com/kevoreilly/CAPEv2/assets/35531629/45b61bd2-28f3-442f-883f-dcaf3be56298)
---
![1381](https://github.com/kevoreilly/CAPEv2/assets/35531629/62341952-2fb3-40dd-bdce-101ec85ae22f)
 new:

![1381_fixed](https://github.com/kevoreilly/CAPEv2/assets/35531629/bf7e0546-59e8-4637-b16f-b7233f05b96e)
---
![1408](https://github.com/kevoreilly/CAPEv2/assets/35531629/8a56fddb-42c3-49f9-9ec1-68deee388c3d)
 new:

![1408_fixed](https://github.com/kevoreilly/CAPEv2/assets/35531629/5fc67c9f-b26c-4225-a27d-e349026e3a8e)
---
![1413](https://github.com/kevoreilly/CAPEv2/assets/35531629/b08845a0-2542-4364-82b9-26353781437e)

 new:
![1413_fixed](https://github.com/kevoreilly/CAPEv2/assets/35531629/1e9dd597-db70-4601-94e9-34a0313d47d3)