### PR TITLE
Update cape2.sh

### DIFF
--- a/installer/cape2.sh
+++ b/installer/cape2.sh
@@ -23,7 +23,7 @@ nginx_version=1.25.3
 prometheus_version=2.20.1
 grafana_version=7.1.5
 node_exporter_version=1.0.1
-guacamole_version=1.5.2
+guacamole_version=1.5.3
 # if set to 1, enables snmpd and other various bits to support
 # monitoring via LibreNMS
 librenms_enable=0


### PR DESCRIPTION
1.5.2 install either isn't available anymore or was having issues. 1.5.3 seems to be working.