### PR TITLE
Systemd service files need comments on their own line.

### DIFF
--- a/systemd/cape.service
+++ b/systemd/cape.service
@@ -11,7 +11,8 @@ User=cape
 Group=cape
 Restart=always
 RestartSec=5m
-TimeoutStopSec=4m # send SIGKILL if analysis is still ongoing 4m after SIGTERM
+# send SIGKILL if analysis is still ongoing 4m after SIGTERM
+TimeoutStopSec=4m
 LimitNOFILE=100000
 
 [Install]


### PR DESCRIPTION
I saw this line in the logs:
```
Failed to parse TimeoutStopSec= parameter, ignoring: 4m # send SIGKILL if analysis is still ongoing 4m after SIGTERM
```