### PR TITLE
Add dots for decimal separator

### DIFF
--- a/web/dashboard/views.py
+++ b/web/dashboard/views.py
@@ -46,8 +46,8 @@ def index(request):
     db = Database()
 
     report = dict(
-        total_samples=f"{db.count_samples():,}",
-        total_tasks=f"{db.count_tasks():,}",
+        total_samples=f"{db.count_samples():,}".replace(',',' '),
+        total_tasks=f"{db.count_tasks():,}".replace(',',' '),
         states_count={},
         estimate_hour=None,
         estimate_day=None

--- a/web/dashboard/views.py
+++ b/web/dashboard/views.py
@@ -40,14 +40,17 @@ class conditional_login_required:
         return self.decorator(func)
 
 
+def format_number_with_space(number):
+    return f"{number:,}".replace(',',' ')
+
 @require_safe
 @conditional_login_required(login_required, settings.WEB_AUTHENTICATION)
 def index(request):
     db = Database()
 
     report = dict(
-        total_samples=f"{db.count_samples():,}".replace(',',' '),
-        total_tasks=f"{db.count_tasks():,}".replace(',',' '),
+        total_samples=format_number_with_space(db.count_samples()),
+        total_tasks=format_number_with_space(db.count_tasks()),
         states_count={},
         estimate_hour=None,
         estimate_day=None
@@ -83,8 +86,8 @@ def index(request):
         else:
             hourly = 0
 
-        report["estimate_hour"] = int(hourly)
-        report["estimate_day"] = int(24 * hourly)
+        report["estimate_hour"] = format_number_with_space(int(hourly))
+        report["estimate_day"] = format_number_with_space(int(24 * hourly))
         report["top_detections"] = top_detections()
 
     return render(request, "dashboard/index.html", {"report": report})

--- a/web/dashboard/views.py
+++ b/web/dashboard/views.py
@@ -46,7 +46,11 @@ def index(request):
     db = Database()
 
     report = dict(
-        total_samples=db.count_samples(), total_tasks=db.count_tasks(), states_count={}, estimate_hour=None, estimate_day=None
+        total_samples=f"{db.count_samples():,}",
+        total_tasks=f"{db.count_tasks():,}",
+        states_count={},
+        estimate_hour=None,
+        estimate_day=None
     )
 
     states = (

--- a/web/templates/dashboard/index.html
+++ b/web/templates/dashboard/index.html
@@ -8,13 +8,13 @@
 <div class="row">
     <div class="col-md-6">
         <div class="jumbotron" style="text-align: center;">
-            <h1>{{report.total_tasks"}}</h1>
+            <h1>{{report.total_tasks}}</h1>
             Total tasks
         </div>
     </div>
     <div class="col-md-6">
         <div class="jumbotron" style="text-align: center;">
-            <h1>{{report.total_samples"}}</h1>
+            <h1>{{report.total_samples}}</h1>
             Total samples
         </div>
     </div>

--- a/web/templates/dashboard/index.html
+++ b/web/templates/dashboard/index.html
@@ -2,19 +2,19 @@
 {% block content %}
 
 <div class="alert alert-primary" style="text-align: center;font-size: 22px; color: white;">
-    Estimating ~<b>{{report.estimate_hour}}</b> analysis per hour, <b>{{report.estimate_day}}</b> per day.
+    Estimating ~<b>{{report.estimate_hour|stringformat:",d"}}</b> analysis per hour, <b>{{report.estimate_day|stringformat:",d"}}</b> per day.
 </div>
 
 <div class="row">
     <div class="col-md-6">
         <div class="jumbotron" style="text-align: center;">
-            <h1>{{report.total_tasks}}</h1>
+            <h1>{{report.total_tasks|stringformat:",d"}}</h1>
             Total tasks
         </div>
     </div>
     <div class="col-md-6">
         <div class="jumbotron" style="text-align: center;">
-            <h1>{{report.total_samples}}</h1>
+            <h1>{{report.total_samples|stringformat:",d"}}</h1>
             Total samples
         </div>
     </div>

--- a/web/templates/dashboard/index.html
+++ b/web/templates/dashboard/index.html
@@ -2,19 +2,19 @@
 {% block content %}
 
 <div class="alert alert-primary" style="text-align: center;font-size: 22px; color: white;">
-    Estimating ~<b>{{report.estimate_hour|stringformat:",d"}}</b> analysis per hour, <b>{{report.estimate_day|stringformat:",d"}}</b> per day.
+    Estimating ~<b>{{report.estimate_hour}}</b> analysis per hour, <b>{{report.estimate_day}}</b> per day.
 </div>
 
 <div class="row">
     <div class="col-md-6">
         <div class="jumbotron" style="text-align: center;">
-            <h1>{{report.total_tasks|stringformat:",d"}}</h1>
+            <h1>{{report.total_tasks"}}</h1>
             Total tasks
         </div>
     </div>
     <div class="col-md-6">
         <div class="jumbotron" style="text-align: center;">
-            <h1>{{report.total_samples|stringformat:",d"}}</h1>
+            <h1>{{report.total_samples"}}</h1>
             Total samples
         </div>
     </div>


### PR DESCRIPTION
A simple visibility / readability improvement. This is **not tested**, it should work, but would be great if someone can test!


_Example_
Will change
<img width="148" alt="image" src="https://github.com/kevoreilly/CAPEv2/assets/3075118/95d997b3-3053-48b9-946a-207736669327">


into:
<img width="177" alt="image" src="https://github.com/kevoreilly/CAPEv2/assets/3075118/ce2ee874-eb83-4e0e-865e-f6e3ff967714">
