### PR TITLE
Skip tests that require data files if the data files are not present.

### DIFF
--- a/tests/test_file_extra_info.py
+++ b/tests/test_file_extra_info.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2010-2015 Cuckoo Foundation.
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
+import pathlib
 import tempfile
 
 import pytest
@@ -8,6 +9,9 @@ import pytest
 from lib.cuckoo.common.integrations import file_extra_info
 
 
+@pytest.mark.skipif(
+    not (pathlib.Path(__file__).parent / "data" / "selfextraction").exists(), reason="Required data file is not present"
+)
 class TestFileExtraInfo:
     def test_generic_file_extractors(self):
         results = {}

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -4,6 +4,7 @@
 
 import copy
 import logging
+import pathlib
 import tempfile
 
 import pytest
@@ -98,6 +99,7 @@ class TestEmptyFile:
             assert key in empty_file["file"].get_all()[0]
 
 
+@pytest.mark.skipif(not (pathlib.Path(__file__).parent / "data" / "malware").exists(), reason="Required data file is not present")
 def test_filetype():
     filetype = File("tests/data/malware/53622590bb3138dcbf12b0105af96dd72aedc40de8984f97c8e882343a769b45").get_type()
     assert filetype == "PE32 executable (GUI) Intel 80386 Mono/.Net assembly, for MS Windows"

--- a/tests/test_quarantine.py
+++ b/tests/test_quarantine.py
@@ -2,6 +2,7 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
+import pathlib
 import tempfile
 
 import pytest
@@ -68,6 +69,9 @@ class TestUnquarantine:
         filename = tmp_path
     """
 
+    @pytest.mark.skipif(
+        not (pathlib.Path(__file__).parent / "data" / "quarantine").exists(), reason="Required data file is not present"
+    )
     def test_mbam(self):
         assert (
             mbam_unquarantine("tests/data/quarantine/d0f51ff313ede61e1c4d7d57b644507a4bd46455e3e617e66c922c8c0c07024b.mbam").rsplit(
@@ -76,6 +80,9 @@ class TestUnquarantine:
             == b"MBAMDequarantineFile"
         )
 
+    @pytest.mark.skipif(
+        not (pathlib.Path(__file__).parent / "data" / "quarantine").exists(), reason="Required data file is not present"
+    )
     def test_mse(self):
         assert (
             mse_unquarantine("tests/data/quarantine/70dbb01654db5a1518091377f27f9a382657c5e32ecdec5074680215dc3a7f65.mse").rsplit(

--- a/tests/test_yara.py
+++ b/tests/test_yara.py
@@ -1,5 +1,9 @@
 # import pytest
 
+import pathlib
+
+import pytest
+
 from lib.cuckoo.common.objects import File
 
 try:
@@ -33,6 +37,7 @@ def test_yara():
     _ = yara.compile(source='import "dotnet" rule a { condition: false }')
 
 
+@pytest.mark.skipif(not (pathlib.Path(__file__).parent / "data" / "malware").exists(), reason="Required data file is not present")
 def test_get_yaras():
     File.init_yara()
     yara_matches = File("tests/data/malware/f8a6eddcec59934c42ea254cdd942fb62917b5898f71f0feeae6826ba4f3470d").get_yara(


### PR DESCRIPTION
This makes it easier for teams that have forked the repo and don't have those test samples.