### PR TITLE
Fix: RedLine Parser

### DIFF
--- a/modules/processing/parsers/CAPE/RedLine.py
+++ b/modules/processing/parsers/CAPE/RedLine.py
@@ -168,7 +168,10 @@ def extract_config(data):
         return
 
     config_dict = {"C2": c2, "Botnet": botnet, "Key": key}
-
+    if "Authorization" in user_strings:
+        base_location = user_strings.index("Authorization")
+        if base_location:
+            config_dict["Authorization"] = user_strings[base_location - 1]
     return config_dict
 
 

--- a/modules/processing/parsers/CAPE/RedLine.py
+++ b/modules/processing/parsers/CAPE/RedLine.py
@@ -78,7 +78,7 @@ def extract_config(data):
     \x72(...)\x70\x80...\x04
     """
     )
-    
+
     # If the config file is stored in plaintext format
     pattern6 = re.compile(
         Rb"""(?x)
@@ -157,7 +157,7 @@ def extract_config(data):
                         botnet = decrypt(extracted[1], key)
                         if "." in c2:
                             break
-                    
+
                     # Case-2: If the config file is stored in plaintext format
                     else:
                         c2 = extracted[0]
@@ -170,3 +170,10 @@ def extract_config(data):
     config_dict = {"C2": c2, "Botnet": botnet, "Key": key}
 
     return config_dict
+
+
+if __name__ == "__main__":
+    import sys
+
+    with open(sys.argv[1], "rb") as f:
+        print(extract_config(f.read()))

--- a/tests_parsers/test_redline.py
+++ b/tests_parsers/test_redline.py
@@ -1,0 +1,11 @@
+# Copyright (C) 2010-2015 Cuckoo Foundation.
+# This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
+# See the file "docs/LICENSE" for copying permission.
+
+from modules.processing.parsers.CAPE.RedLine import extract_config
+
+
+def test_redline():
+    with open("tests/data/malware/redline", "rb") as data:
+        conf = extract_config(data.read())
+        assert conf == {"C2": "77.91.68.68:19071", "Botnet": "krast", "Key": "Formative"}

--- a/tests_parsers/test_redline.py
+++ b/tests_parsers/test_redline.py
@@ -6,6 +6,6 @@ from modules.processing.parsers.CAPE.RedLine import extract_config
 
 
 def test_redline():
-    with open("tests/data/malware/redline", "rb") as data:
+    with open("tests/data/malware/000608d875638ba7d6c467ece976c1496e6a6ec8ce3e7f79e0fd195ae3045078", "rb") as data:
         conf = extract_config(data.read())
         assert conf == {"C2": "77.91.68.68:19071", "Botnet": "krast", "Key": "Formative"}

--- a/tests_parsers/test_redline.py
+++ b/tests_parsers/test_redline.py
@@ -8,4 +8,4 @@ from modules.processing.parsers.CAPE.RedLine import extract_config
 def test_redline():
     with open("tests/data/malware/000608d875638ba7d6c467ece976c1496e6a6ec8ce3e7f79e0fd195ae3045078", "rb") as data:
         conf = extract_config(data.read())
-        assert conf == {"C2": "77.91.68.68:19071", "Botnet": "krast", "Key": "Formative"}
+        assert conf == {"Authorization": "9059ea331e4599de3746df73ccb24514","C2": "77.91.68.68:19071", "Botnet": "krast", "Key": "Formative"}


### PR DESCRIPTION
The parser failed due to key error of "Authorization", so I have removed it.

Also I have updated it to include RedLine samples with plaintext configs