### PR TITLE
A bunch of fixes for a bunch of tests

### DIFF
--- a/lib/cuckoo/common/config.py
+++ b/lib/cuckoo/common/config.py
@@ -107,12 +107,13 @@ class Config(_BaseConfig, metaclass=ConfigMeta):
         self._read_files(files)
 
     def _get_files_to_read(self, fname_base):
-        files = [
-            os.path.join(CUCKOO_ROOT, "conf", f"{fname_base}.conf.default"),
-            os.path.join(CUCKOO_ROOT, "conf", f"{fname_base}.conf"),
-            os.path.join(CUSTOM_CONF_DIR, f"{fname_base}.conf"),
-        ]
-        files.extend(sorted(glob.glob(os.path.join(CUCKOO_ROOT, "conf", f"{fname_base}.conf.d", "*.conf"))))
+        # Allows test workflows to ignore custom root configs
+        include_root_configs = "CAPE_DISABLE_ROOT_CONFIGS" not in os.environ
+        files = [os.path.join(CUCKOO_ROOT, "conf", f"{fname_base}.conf.default")]
+        if include_root_configs:
+            files.append(os.path.join(CUCKOO_ROOT, "conf", f"{fname_base}.conf"))
+            files.extend(sorted(glob.glob(os.path.join(CUCKOO_ROOT, "conf", f"{fname_base}.conf.d", "*.conf"))))
+        files.append(os.path.join(CUSTOM_CONF_DIR, f"{fname_base}.conf"))
         files.extend(sorted(glob.glob(os.path.join(CUSTOM_CONF_DIR, f"{fname_base}.conf.d", "*.conf"))))
         return files
 

--- a/lib/cuckoo/common/integrations/file_extra_info_modules/__init__.py
+++ b/lib/cuckoo/common/integrations/file_extra_info_modules/__init__.py
@@ -11,7 +11,6 @@ from typing import List, Optional, TypedDict
 from lib.cuckoo.common.config import Config
 from lib.cuckoo.common.path_utils import path_mkdir, path_object
 
-cfg = Config()
 log = logging.getLogger(__name__)
 
 
@@ -50,6 +49,7 @@ def time_tracker(func):
 
 @contextlib.contextmanager
 def extractor_ctx(filepath, tool_name, prefix=None):
+    cfg = Config()
     folder = os.path.join(cfg.cuckoo.get("tmppath", "/tmp"), "cape-external")
     path_mkdir(folder, exist_ok=True)
 

--- a/lib/cuckoo/common/integrations/file_extra_info_modules/__init__.py
+++ b/lib/cuckoo/common/integrations/file_extra_info_modules/__init__.py
@@ -8,7 +8,6 @@ import tempfile
 import timeit
 from typing import List, Optional, TypedDict
 
-from lib.cuckoo.common.config import Config
 from lib.cuckoo.common.path_utils import path_mkdir, path_object
 
 log = logging.getLogger(__name__)
@@ -48,9 +47,7 @@ def time_tracker(func):
 
 
 @contextlib.contextmanager
-def extractor_ctx(filepath, tool_name, prefix=None):
-    cfg = Config()
-    folder = os.path.join(cfg.cuckoo.get("tmppath", "/tmp"), "cape-external")
+def extractor_ctx(filepath, tool_name, prefix=None, folder="/tmp/cape-external"):
     path_mkdir(folder, exist_ok=True)
 
     tempdir = tempfile.mkdtemp(prefix=prefix, dir=folder)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,22 @@
+import pathlib
 import pytest
+from lib.cuckoo.common.config import ConfigMeta
 
+import lib.cuckoo.common.config
 import lib.cuckoo.core.database
 
 
 @pytest.fixture
 def tmp_cuckoo_root(monkeypatch, tmp_path):
     monkeypatch.setattr(lib.cuckoo.core.database, "CUCKOO_ROOT", str(tmp_path))
+    yield tmp_path
+
+
+@pytest.fixture(autouse=True)
+def custom_conf_path(request, monkeypatch, tmp_cuckoo_root):
+    ConfigMeta.reset()
+    monkeypatch.setenv("CAPE_DISABLE_ROOT_CONFIGS", "1")
+    path: pathlib.Path = tmp_cuckoo_root / "custom" / "conf"
+    path.mkdir(mode=0o755, parents=True)
+    monkeypatch.setattr(lib.cuckoo.common.config, "CUSTOM_CONF_DIR", str(path))
+    yield path

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -14,7 +14,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from lib.cuckoo.common.exceptions import CuckooOperationalError
 from lib.cuckoo.common.path_utils import path_mkdir
 from lib.cuckoo.common.utils import store_temp_file
-from lib.cuckoo.core.database import Database, Machine, Tag, Task, machines_tags, tasks_tags
+from lib.cuckoo.core.database import Database, Error, Machine, Tag, Task, machines_tags, tasks_tags
 
 
 @pytest.fixture(autouse=True)
@@ -57,11 +57,13 @@ class TestDatabaseEngine:
             stmt3 = delete(machines_tags)
             stmt4 = delete(tasks_tags)
             stmt5 = delete(Tag)
+            stmt6 = delete(Error)
             self.session.execute(stmt)
             self.session.execute(stmt2)
             self.session.execute(stmt3)
             self.session.execute(stmt4)
             self.session.execute(stmt5)
+            self.session.execute(stmt6)
             self.session.commit()
 
     def teardown_method(self):

--- a/tests/test_file_extra_info.py
+++ b/tests/test_file_extra_info.py
@@ -8,11 +8,15 @@ import pytest
 
 from lib.cuckoo.common.integrations import file_extra_info
 
+self_extraction_dir = (pathlib.Path(__file__).parent / "data" / "selfextraction")
 
 @pytest.mark.skipif(
-    not (pathlib.Path(__file__).parent / "data" / "selfextraction").exists(), reason="Required data file is not present"
+    not (self_extraction_dir).exists(), reason="Required data file is not present"
 )
 class TestFileExtraInfo:
+    @pytest.mark.skipif(
+        not (self_extraction_dir / "0ea5e25b12ab314bc9a0569c3ca756f205f40b792119f8e0fc62c874628dfea0.msi").exists(), reason="Required data file is not present"
+    )   
     def test_generic_file_extractors(self):
         results = {}
         data_dictionary = {"type": "MSI Installer"}
@@ -20,7 +24,7 @@ class TestFileExtraInfo:
         tmpdir = tempfile.mkdtemp()
         duplicated = {"sha256": set()}
         file_extra_info.generic_file_extractors(
-            "tests/data/selfextraction/0ea5e25b12ab314bc9a0569c3ca756f205f40b792119f8e0fc62c874628dfea0.msi",
+            f"{self_extraction_dir}/0ea5e25b12ab314bc9a0569c3ca756f205f40b792119f8e0fc62c874628dfea0.msi",
             tmpdir,
             data_dictionary,
             options_dict,
@@ -31,6 +35,9 @@ class TestFileExtraInfo:
         assert data_dictionary["extracted_files_tool"] == "MsiExtract"
         assert len(data_dictionary["extracted_files"]) == 2
 
+    @pytest.mark.skipif(
+        not (self_extraction_dir / "5b354397f6393ed777639b7d40dec3f37215dcb5078c63993e8a9703e819e2bc.inno").exists(), reason="Required data file is not present"
+    )
     def test_generic_file_extractors_no_tests(self):
         results = {}
         data_dictionary = {"die": ["Inno Setup"], "type": ""}
@@ -38,7 +45,7 @@ class TestFileExtraInfo:
         tmpdir = tempfile.mkdtemp()
         duplicated = {"sha256": set()}
         file_extra_info.generic_file_extractors(
-            "tests/data/selfextraction/5b354397f6393ed777639b7d40dec3f37215dcb5078c63993e8a9703e819e2bc.inno",
+            f"{self_extraction_dir}/5b354397f6393ed777639b7d40dec3f37215dcb5078c63993e8a9703e819e2bc.inno",
             tmpdir,
             data_dictionary,
             options_dict,
@@ -51,20 +58,23 @@ class TestFileExtraInfo:
     @pytest.mark.skip(reason="Not implemented yet")
     def test_batch_extract(self):
         extracted_files = file_extra_info.batch_extract(
-            file="tests/data/selfextraction/",
+            file=f"{self_extraction_dir}/",
         )
         assert len(extracted_files["result"]["extracted_files"]) == 4
 
+    @pytest.mark.skipif(
+        not (self_extraction_dir / "c738cdd8ec0d65769e17eed1d6fe371893a2972b7a432c6532446d225e166733.vbe").exists(), reason="Required data file is not present"
+    )
     def test_vbe_extract(self):
         extracted_files = file_extra_info.vbe_extract(
-            file="tests/data/selfextraction/c738cdd8ec0d65769e17eed1d6fe371893a2972b7a432c6532446d225e166733.vbe",
+            file=f"{self_extraction_dir}/c738cdd8ec0d65769e17eed1d6fe371893a2972b7a432c6532446d225e166733.vbe",
         )
         assert len(extracted_files["result"]["extracted_files"]) == 1
 
     @pytest.mark.skip(reason="Not implemented yet")
     def test_eziriz_deobfuscate(self):
         extracted_files = file_extra_info.eziriz_deobfuscate(
-            file="tests/data/selfextraction/",
+            file=f"{self_extraction_dir}/",
             data_dictionary={"die": ["Eziriz .NET Reactor"]} ** {"test": True, "options": {}},
         )
         self.assertEqual(len(extracted_files["result"]["extracted_files"]), 4, "Failed to extract.")
@@ -72,21 +82,27 @@ class TestFileExtraInfo:
     @pytest.mark.skip(reason="Not implemented yet")
     def test_de4dot_deobfuscate(self):
         extracted_files = file_extra_info.de4dot_deobfuscate(
-            file="tests/data/selfextraction/", filetype="Mono", **{"test": True, "options": {}}
+            file=f"{self_extraction_dir}/", filetype="Mono", **{"test": True, "options": {}}
         )
         self.assertEqual(len(extracted_files["result"]["extracted_files"]), 4, "Failed to extract.")
 
+    @pytest.mark.skipif(
+        not (self_extraction_dir / "0ea5e25b12ab314bc9a0569c3ca756f205f40b792119f8e0fc62c874628dfea0.msi").exists(), reason="Required data file is not present"
+    )
     def test_msi_extract(self):
         extracted_files = file_extra_info.msi_extract(
-            file="tests/data/selfextraction/0ea5e25b12ab314bc9a0569c3ca756f205f40b792119f8e0fc62c874628dfea0.msi",
+            file=f"{self_extraction_dir}/0ea5e25b12ab314bc9a0569c3ca756f205f40b792119f8e0fc62c874628dfea0.msi",
             filetype="MSI Installer",
             **{"tests": True, "options": {}},
         )
         assert len(extracted_files["result"]["extracted_files"]) == 2
 
+    @pytest.mark.skipif(
+        not (self_extraction_dir / "5b354397f6393ed777639b7d40dec3f37215dcb5078c63993e8a9703e819e2bc.inno").exists(), reason="Required data file is not present"
+    )
     def test_Inno_extract(self):
         extracted_files = file_extra_info.Inno_extract(
-            file="tests/data/selfextraction/5b354397f6393ed777639b7d40dec3f37215dcb5078c63993e8a9703e819e2bc.inno",
+            file=f"{self_extraction_dir}/5b354397f6393ed777639b7d40dec3f37215dcb5078c63993e8a9703e819e2bc.inno",
             data_dictionary={"die": ["Inno Setup"]},
         )
         assert len(extracted_files["result"]["extracted_files"]) == 1
@@ -95,22 +111,25 @@ class TestFileExtraInfo:
     @pytest.mark.skip(reason="Not implemented yet - need to include community repo")
     def test_kixtart_extract(self):
         extracted_files = file_extra_info.kixtart_extract(
-            file="tests/data/selfextraction/d0d415dbe02e893fb1b2d6112c0f38d8ce65ab3268c896bfc64ba06096d4d09a.kix",
+            file=f"{self_extraction_dir}/d0d415dbe02e893fb1b2d6112c0f38d8ce65ab3268c896bfc64ba06096d4d09a.kix",
         )
         assert len(extracted_files["result"]["extracted_files"]) == 4
 
     @pytest.mark.skip(reason="Not implemented yet")
     def test_UnAutoIt_extract(self):
         extracted_files = file_extra_info.kixtart_extract(
-            file="tests/data/selfextraction/5b354397f6393ed777639b7d40dec3f37215dcb5078c63993e8a9703e819e2bc.inno",
+            file=f"{self_extraction_dir}/5b354397f6393ed777639b7d40dec3f37215dcb5078c63993e8a9703e819e2bc.inno",
             data_dictionary={"yara": [{"name": "AutoIT_Compiled"}]},
             **{"test": True, "options": {}},
         )
         assert len(extracted_files["result"]["extracted_files"]) == 4
 
+    @pytest.mark.skipif(
+        not (self_extraction_dir / "1b0c4149df7892b2497c955dc393ed49e458062324a81288589b15492ce8b50b.upx").exists(), reason="Required data file is not present"
+    )
     def test_UPX_unpack(self):
         extracted_files = file_extra_info.UPX_unpack(
-            file="tests/data/selfextraction/1b0c4149df7892b2497c955dc393ed49e458062324a81288589b15492ce8b50b.upx",
+            file=f"{self_extraction_dir}/1b0c4149df7892b2497c955dc393ed49e458062324a81288589b15492ce8b50b.upx",
             filetype="UPX compressed",
             data_dictionary={},
             **{"test": True, "options": {}},
@@ -120,9 +139,12 @@ class TestFileExtraInfo:
             "1b0c4149df7892b2497c955dc393ed49e458062324a81288589b15492ce8b50b.upx_unpacked"
         ]
 
+    @pytest.mark.skipif(
+        not (self_extraction_dir / "ab77ea6ad4b6766e0db88d4f49c2c0075ba18b3573d7c6d07ee878bd6e71c388.7z").exists(), reason="Required data file is not present"
+    )
     def test_SevenZip_unpack(self):
         extracted_files = file_extra_info.SevenZip_unpack(
-            file="tests/data/selfextraction/ab77ea6ad4b6766e0db88d4f49c2c0075ba18b3573d7c6d07ee878bd6e71c388.7z",
+            file=f"{self_extraction_dir}/ab77ea6ad4b6766e0db88d4f49c2c0075ba18b3573d7c6d07ee878bd6e71c388.7z",
             data_dictionary={"die": ["7-zip Installer data"]},
             filetype="",
             **{"test": True, "options": {}},
@@ -137,18 +159,25 @@ class TestFileExtraInfo:
             "自述.txt",
         ]
 
+    @pytest.mark.skipif(
+        not (self_extraction_dir / "9e69c36d967afbb1a948a022fcfb1a6384b35b233a47e7d859145db19018d21e.sfx").exists(), reason="Required data file is not present"
+    )
     def test_RarSFX_extract(self):
         extracted_files = file_extra_info.RarSFX_extract(
-            file="tests/data/selfextraction/9e69c36d967afbb1a948a022fcfb1a6384b35b233a47e7d859145db19018d21e.sfx",
+            file=f"{self_extraction_dir}/9e69c36d967afbb1a948a022fcfb1a6384b35b233a47e7d859145db19018d21e.sfx",
             data_dictionary={"type": "RAR self-extracting archive"},
             options={},
         )
         assert len(extracted_files["result"]["extracted_files"]) == 3
         assert sorted(extracted_files["result"]["extracted_files"]) == ["Manag.exe", "mLib.cs", "x64.xr"]
 
+
+    @pytest.mark.skipif(
+        not (self_extraction_dir / "12c4d9eddce807d10e3578fcf2918366def586ec374a35957880a65dbd467efc.one").exists(), reason="Required data file is not present"
+    )   
     def test_office_one_extract(self):
         extracted_files = file_extra_info.office_one(
-            file="tests/data/selfextraction/12c4d9eddce807d10e3578fcf2918366def586ec374a35957880a65dbd467efc.one",
+            file=f"{self_extraction_dir}/12c4d9eddce807d10e3578fcf2918366def586ec374a35957880a65dbd467efc.one",
         )
         assert len(extracted_files["result"]["extracted_files"]) == 6
         assert sorted(extracted_files["result"]["extracted_files"]) == [

--- a/tests/test_file_extra_info.py
+++ b/tests/test_file_extra_info.py
@@ -8,6 +8,11 @@ import pytest
 
 from lib.cuckoo.common.integrations import file_extra_info
 
+@pytest.fixture(autouse=True)
+def set_tools_folder():
+    file_extra_info.tools_folder = "/tmp"
+    yield
+
 self_extraction_dir = (pathlib.Path(__file__).parent / "data" / "selfextraction")
 
 @pytest.mark.skipif(


### PR DESCRIPTION
In collaboration with @tbeadle.

- Fix file order precedence in `Config` load. Previously files in the `CUCKOO_ROOT` conf.d directories would be loaded after files in the `CUSTOM_CONF_DIR` directory. Let me know if this was intentional and I'll update the PR.
    - As part of this, introduce a env var to allow tests to skip loading of custom configs. This should, hopefully, make testing more consistent across the board.
- Flush the `Error` table on database test setup to prevent consecutive runs resulting in test failures.
- Make tests use the default config files unless otherwise required.
-  Add additional skip criteria for file_extra_info tests. Some of the samples aren't in the `tests/data` submodule, so they failed if it was present locally.
- Move the `Config()` load out of `file_extra_info_modules/__init__` into the `file_extra_info_modules/__init__::extractor_ctx` function so config isn't loaded prematurely. This gives us the opportunity to manipulate the config that is used in the tests.