### PR TITLE
Fix zip_compound package

### DIFF
--- a/analyzer/windows/modules/packages/zip_compound.py
+++ b/analyzer/windows/modules/packages/zip_compound.py
@@ -46,8 +46,6 @@ class ZipCompound(Package):
         target_file = target_file or self.options.get("file")
         if not target_file:
             raise CuckooPackageError("File must be specified in the JSON or the web submission UI!")
-        elif not get_interesting_files(target_file):
-            raise CuckooPackageError("Invalid, unsupported or no extension recognised by zip_compound package")
 
         # In case the "file" submittion option is relative, we split here
         target_srcdir, target_name = os.path.split(target_file)
@@ -116,7 +114,8 @@ class ZipCompound(Package):
 
         extract_zip(path, root, password, 0)
 
-        return root, self.process_unzipped_contents(root, json_filename)
+        file_name, file_path = self.process_unzipped_contents(root, json_filename)
+        return root, file_name, file_path
 
     def start(self, path, json_config="__configuration.json"):
         root, file_name, file_path = self.prepare_zip_compound(path, json_config)


### PR DESCRIPTION
`target_file` in `__configuration.json` expects string instead of list. Theoretically, there is no fuzzy logic needed what file is interesting as the `__configuration.json` or `target_file` option need to be specified explicitly by user.

Python 3.10 complaint `not enough values to unpack` upon returning to the caller of `process_unzipped_contents`