### PR TITLE
Update github actions to new versions

### DIFF
--- a/.github/workflows/export-requirements.yml
+++ b/.github/workflows/export-requirements.yml
@@ -17,13 +17,13 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install poetry
         run: pip install poetry
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           # check-latest: true
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/pip-audit.yml
+++ b/.github/workflows/pip-audit.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - uses: pypa/gh-action-pip-audit@v1.0.8
         with:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,12 +19,12 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
       - name: Checkout test files repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: CAPESandbox/CAPE-TestFiles
           path: tests/data/
@@ -37,7 +37,7 @@ jobs:
         run: pip install poetry
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           # check-latest: true
           python-version: ${{ matrix.python-version }}
@@ -59,7 +59,7 @@ jobs:
         run: poetry run python -m pytest --import-mode=append
 
       # Test parsers only if any parser changed
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@v3
         id: changes
         with:
           filters: |
@@ -80,7 +80,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install dependencies
         run: |
@@ -90,7 +90,7 @@ jobs:
         run: pip install poetry
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           check-latest: true
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/yara-audit.yml
+++ b/.github/workflows/yara-audit.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Checkout test files repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: CAPESandbox/CAPE-TestFiles
           path: tests/data/
@@ -30,7 +30,7 @@ jobs:
         run: pip install poetry
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           # check-latest: true
           python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
Github actions showed warnings about node 16 being deprecated. Example: https://github.com/kevoreilly/CAPEv2/actions/runs/8055258257

The new versions of these actions use node 20.