### PR TITLE
Github action pip-audit needs requirements.txt as input

### DIFF
--- a/.github/workflows/pip-audit.yml
+++ b/.github/workflows/pip-audit.yml
@@ -18,4 +18,4 @@ jobs:
 
       - uses: pypa/gh-action-pip-audit@v1.0.8
         with:
-          inputs: .
+          inputs: requirements.txt


### PR DESCRIPTION
The github action for pip-audit needs us to specify the requirements.txt as input.

Otherwise it's not really doing anything.

Previous runs have been failing to give any output.
https://github.com/kevoreilly/CAPEv2/actions/workflows/pip-audit.yml

Running `pip-audit .` outside of github gives:
```
ERROR:pip_audit._cli:pyproject file pyproject.toml does not contain `project` section
```

Create an empty `[project]` section and you get this:
```
WARNING:pip_audit._dependency_source.pyproject:pyproject file pyproject.toml
   does not contain `dependencies` list
```

Instead I ran `pip-audit -r requirements.txt` on yesterday's requirements.txt and got this:
```
Found 1 known vulnerability in 1 package
Name   Version ID            Fix Versions
------ ------- ------------- ------------
orjson 3.8.5   PYSEC-2024-40 3.9.15
```

Requirements.txt has since been updated, and now we get the desired output:
```
No known vulnerabilities found
```