### PR TITLE
Better control of environment variable for nektos act

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,0 +1,5 @@
+ # Nektos act runs tests as root. Without this environment variable
+ # being set, CAPE exits at line 10 of web/web/settings.py,
+ # and no tests are run.
+
+ --env CAPE_AS_ROOT=1

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -40,10 +40,6 @@ jobs:
         run: poetry run ruff . --line-length 132 --ignore E501,E402
 
       - name: Run unit tests
-        # Nektos act runs tests as root;
-        # and failing from line 10 on web/web/settings.py
-        env:
-          CAPE_AS_ROOT: 1
         run: poetry run python -m pytest --import-mode=append
 
       - name: See if any parser changed

--- a/.github/workflows/yara-audit.yml
+++ b/.github/workflows/yara-audit.yml
@@ -33,8 +33,4 @@ jobs:
           bash -c "poetry run ./extra/yara_installer.sh"
 
       - name: Run unit tests
-        # Nektos act runs tests as root;
-        # and failing from line 10 on web/web/settings.py
-        env:
-          CAPE_AS_ROOT: 1
         run: poetry run pytest tests/test_yara.py -s --import-mode=append

--- a/docs/book/src/development/code_style.rst
+++ b/docs/book/src/development/code_style.rst
@@ -198,11 +198,8 @@ save it as an input file.
 Example::
 
     {
-      "action": "push",
       "act": true,
       "repository" : {
-        "id": 1,
-        "full_name": "CAPEv2",
         "default_branch": "master"
       }
     }
@@ -214,6 +211,9 @@ So to run the actions that normally are triggered by a push event::
 and to run the actions that are scheduled::
 
    gh act schedule -s GITHUB_TOKEN="$(gh auth token)" --eventpath /tmp/github-event.json
+
+We created a file ``.actrc`` containing ``--env CAPE_AS_ROOT=1`` because ``act`` runs the tests
+as root, and otherwise the tests would exit saying you cannot run CAPE as root.
 
 Poetry and pre-commit hooks
 ===========================


### PR DESCRIPTION
- Moved the setting of the `CAPE_AS_ROOT` environment variable to a new `.actrc` file
  - This is automatically applied when running nektos act, and not otherwise
- Removed the setting of the `CAPE_AS_ROOT` env.var from the github workflow definition files
- Updated the documentation 