### PR TITLE
public and private package configuration

### DIFF
--- a/analyzer/windows/analyzer.py
+++ b/analyzer/windows/analyzer.py
@@ -408,7 +408,7 @@ class Analyzer:
 
         # Initialize the analysis package.
         log.debug('Initializing analysis package "%s"...', package)
-        self.package = package_class(self.options, self.config)
+        self.package = package_class(package_name, self.options, self.config)
         # log.debug('Initialized analysis package "%s"', package)
 
         # Move the sample to the current working directory as provided by the

--- a/analyzer/windows/analyzer.py
+++ b/analyzer/windows/analyzer.py
@@ -567,7 +567,7 @@ class Analyzer:
 
         # Do any package configuration stored in "data/packages/<package_name>"
         try:
-            self.package.configure_from_data(self.package, self.target)
+            self.package.configure_from_data(self.target)
         except ModuleNotFoundError:
             # let it go, not every package is configurable from data
             log.debug("package %s does not support data configuration, ignoring", package_name)

--- a/analyzer/windows/lib/common/abstracts.py
+++ b/analyzer/windows/lib/common/abstracts.py
@@ -6,6 +6,9 @@ import glob
 import logging
 import os
 import shutil
+import importlib
+import inspect
+from typing import Dict, Any
 
 from lib.api.process import Process
 from lib.common.common import check_file_extension
@@ -49,6 +52,43 @@ class Package:
     def check(self):
         """Check."""
         return True
+
+    def configure(self, target: str):
+        """Do package-specific configuration.
+
+        Analysis packages can implement this method to perform pre-analysis
+        configuration in the execution environment. This method will be called
+        after the auxiliary modules are started but before the package start
+        method is called.
+
+        See the "configure_from_data" method for an alternative approach to
+        package-specific configuration that lets configuration be treated as
+        runtime data separate from the analysis package.
+        """
+        raise NotImplementedError
+
+    def configure_from_data(self, target: str):
+        """Do private package-specific configuration.
+
+        Analysis packages can implement this method to perform pre-analysis
+        configuration based on runtime data contained in "data/packages/<package_name>".
+
+        This method raises:
+         - ImportError when any exception occurs during import
+         - AttributeError if the module configure function is invalid.
+         - ModuleNotFoundError if the module does not support configuration from data
+        """
+        module_name = f"data.packages.{self.name}"
+        try:
+            m = importlib.import_module(module_name)
+        except Exception as e:
+            raise ImportError(f"error importing {module_name}: {e}") from e
+
+        spec = inspect.getfullargspec(m.configure)
+        if len(spec.args) != 2:
+            err_msg = f"{module_name}.configure: expected 2 arguments, got {len(spec.args)}"
+            raise AttributeError(err_msg)
+        m.configure(self, target)
 
     def get_paths(self):
         """Get the default list of paths."""

--- a/analyzer/windows/lib/common/abstracts.py
+++ b/analyzer/windows/lib/common/abstracts.py
@@ -40,7 +40,7 @@ class Package:
         """
         self.pids = pids
 
-    def start(self):
+    def start(self, target: str):
         """Run analysis package.
         @raise NotImplementedError: this method is abstract.
         """

--- a/analyzer/windows/lib/common/abstracts.py
+++ b/analyzer/windows/lib/common/abstracts.py
@@ -8,7 +8,7 @@ import os
 import shutil
 import importlib
 import inspect
-from typing import Dict, Any
+# from typing import Dict, Any
 
 from lib.api.process import Process
 from lib.common.common import check_file_extension

--- a/analyzer/windows/lib/common/abstracts.py
+++ b/analyzer/windows/lib/common/abstracts.py
@@ -24,8 +24,9 @@ class Package:
     PATHS = []
     default_curdir = None
 
-    def __init__(self, options=None, config=None):
+    def __init__(self, name: str, options=None, config=None):
         """@param options: options dict."""
+        self.name = name
         if options is None:
             options = {}
         self.config = config

--- a/analyzer/windows/tests/lib/common/test_abstracts.py
+++ b/analyzer/windows/tests/lib/common/test_abstracts.py
@@ -1,0 +1,38 @@
+import importlib
+import unittest
+from unittest.mock import MagicMock, patch
+
+from lib.common import abstracts
+
+
+class TestPackageConfiguration(unittest.TestCase):
+
+    def test_private_package_configuration(self):
+        # test analysis package
+        package_module = "configuration_package"
+        # and its private configuration module
+        module_name = f"data.packages.{package_module}"
+
+        class TestPackage(abstracts.Package):
+            pass
+
+        test_pkg = TestPackage(package_module)
+
+        # private package configuration function with 2 args
+        configure_called = False
+
+        def configure(package, target):
+            self.assertIs(package, test_pkg)
+            self.assertEqual(target, self.id())
+            nonlocal configure_called
+            configure_called = True
+
+        mock_module = MagicMock()
+        mock_module.configure = configure
+
+        with patch.object(importlib, "import_module", return_value=mock_module) as m:
+            # do the private package configuration
+            test_pkg.configure_from_data(self.id())
+            # check it imported the private configuration module
+            m.assert_called_once_with(module_name)
+        self.assertTrue(configure_called)

--- a/analyzer/windows/tests/modules/packages/test_ps1.py
+++ b/analyzer/windows/tests/modules/packages/test_ps1.py
@@ -6,7 +6,9 @@ from modules.packages.ps1 import PS1
 class TestPS1(unittest.TestCase):
     def test_get_paths(self):
         """By default, the first path should be powershell.exe"""
-        ps1_module = PS1()
+        package_name = "modules.packages.ps1"
+        __import__(package_name, globals(), locals(), ["dummy"])
+        ps1_module = PS1(package_name)
         paths = ps1_module.get_paths()
         assert paths[0][-1] == "powershell.exe"
         all_paths = set([path[-1] for path in paths])
@@ -15,7 +17,9 @@ class TestPS1(unittest.TestCase):
     def test_get_paths_powershell_core(self):
         """When option pwsh selected, the first path should be pwsh.exe"""
         options = {"pwsh": True}
-        ps1_module = PS1(options=options)
+        package_name = "modules.packages.ps1"
+        __import__(package_name, globals(), locals(), ["dummy"])
+        ps1_module = PS1(package_name, options=options)
         paths = ps1_module.get_paths()
         assert paths[0][-1] == "pwsh.exe"
         all_paths = set([path[-1] for path in paths])


### PR DESCRIPTION
This adds two new methods to [lib.common.abstracts.Package](https://github.com/kevoreilly/CAPEv2/blob/76754ee2d76e136285d85234ccdab79b3ff1e6e8/analyzer/windows/lib/common/abstracts.py#L21):
1. [configure(target)](https://github.com/nbargnesi/CAPEv2/blob/8f8c4b08c7105f8c5fe11c2dec15c899235fbf30/analyzer/windows/lib/common/abstracts.py#L56)
2. [configure_from_data(target)](https://github.com/nbargnesi/CAPEv2/blob/8f8c4b08c7105f8c5fe11c2dec15c899235fbf30/analyzer/windows/lib/common/abstracts.py#L70)

Both methods are optional.

If a package doesn't provide a configure method, it's [logged but ignored](https://github.com/nbargnesi/CAPEv2/blob/8f8c4b08c7105f8c5fe11c2dec15c899235fbf30/analyzer/windows/analyzer.py#L563). Likewise if no private configuration is importable from `data.packages.<package_name>`, it's also [logged but ignored](https://github.com/nbargnesi/CAPEv2/blob/8f8c4b08c7105f8c5fe11c2dec15c899235fbf30/analyzer/windows/analyzer.py#L573).

With this PR, packages like [DOC_ANTIVM](https://github.com/kevoreilly/CAPEv2/blob/master/analyzer/windows/modules/packages/doc_antivm.py) can separate 40 lines of configuration into a separate method, and provide a way to mask sensitive configuration.