### PR TITLE
Run ruff during pre-commit checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,12 @@ repos:
   #   hooks:
   #     - id: pyproject-flake8
 
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.3.0
+    hooks:
+      - id: ruff
+        args: [ --fix ]
+
   - repo: https://github.com/psf/black
     rev: 22.3.0
     hooks:


### PR DESCRIPTION
I frequently get `ruff` finding issues and this causes CI jobs to abort.

Would this be an improvement? I am not completely sure.