### PR TITLE
Improvement to process.py logging

### DIFF
--- a/analyzer/windows/lib/api/process.py
+++ b/analyzer/windows/lib/api/process.py
@@ -236,7 +236,7 @@ class Process:
         image_name_buf = c_buffer(MAX_PATH)
         n = PSAPI.GetProcessImageFileNameA(self.h_process, image_name_buf, MAX_PATH)
         if not n:
-            log.debug("Failed getting image name for pid %s", self.pid)
+            log.debug("Failed getting image name for pid %d", self.pid)
             return ret
         image_name = image_name_buf.value.decode()
         return image_name.split("\\")[-1]

--- a/analyzer/windows/lib/api/process.py
+++ b/analyzer/windows/lib/api/process.py
@@ -147,7 +147,7 @@ class Process:
                 self.h_process = KERNEL32.OpenProcess(PROCESS_ALL_ACCESS, False, self.pid)
                 if not self.h_process:
                     log.warning("OpenProcess(PROCESS_ALL_ACCESS, ...) failed for process %d", self.pid)
-                    log.debug("opening process with limited info %d", self.pid)
+                    log.debug("Opening process with limited info %d", self.pid)
                     self.h_process = KERNEL32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, self.pid)
 
             ret = True
@@ -193,7 +193,7 @@ class Process:
         exit_code = c_ulong(0)
         ok = KERNEL32.GetExitCodeProcess(self.h_process, byref(exit_code))
         if not ok:
-            log.debug("failed getting exit code for %s", self)
+            log.debug("Failed getting exit code for %s", self)
             return None
         # Uncommenting the lines below will spam the analyzer.log file.
         # if exit_code.value == STILL_ACTIVE:
@@ -236,7 +236,7 @@ class Process:
         image_name_buf = c_buffer(MAX_PATH)
         n = PSAPI.GetProcessImageFileNameA(self.h_process, image_name_buf, MAX_PATH)
         if not n:
-            log.debug("failed getting image name for pid %s", self.pid)
+            log.debug("Failed getting image name for pid %s", self.pid)
             return ret
         image_name = image_name_buf.value.decode()
         return image_name.split("\\")[-1]

--- a/analyzer/windows/tests/lib/api/test_process.py
+++ b/analyzer/windows/tests/lib/api/test_process.py
@@ -1,0 +1,18 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from lib.api.process import Process
+
+
+class ProcessTests(unittest.TestCase):
+    @patch("lib.api.process.PSAPI", MagicMock(), create=True)
+    def test_unknown_image_name(self):
+        process = Process()
+        assert f"{process}" == "<Process 0 ???>"
+
+    def test_known_image_name(self):
+        mock_image_name = MagicMock()
+        mock_image_name.return_value = self.id()
+        with patch("lib.api.process.Process.get_image_name", mock_image_name):
+            process = Process()
+            assert f"{process}" == f"<Process 0 {self.id()}>"


### PR DESCRIPTION
Log the image name as well as the process ID; added tests. 
Also, restore the process is_alive check, disabled 4 years ago.

Credit: @nbargnesi

Sample log entries:
```
2024-03-10 12:12:13,411 [lib.api.process] DEBUG: getting exit code for <Process 17492 aspnet_compiler.exe>
2024-03-10 12:12:13,411 [lib.api.process] DEBUG: <Process 17492 aspnet_compiler.exe> exit code is 259
2024-03-10 12:12:13,411 [lib.api.process] DEBUG: <Process 17492 aspnet_compiler.exe> is still active
```