### PR TITLE
Fix issues with looking for specific config files

### DIFF
--- a/lib/cuckoo/common/config.py
+++ b/lib/cuckoo/common/config.py
@@ -10,7 +10,7 @@ from typing import Dict, Iterable
 from lib.cuckoo.common.colors import bold, red
 from lib.cuckoo.common.constants import CUCKOO_ROOT, CUSTOM_CONF_DIR
 from lib.cuckoo.common.dictionary import Dictionary
-from lib.cuckoo.common.exceptions import CuckooOperationalError
+from lib.cuckoo.common.exceptions import CuckooCriticalError, CuckooOperationalError
 
 
 def parse_options(options: str) -> Dict[str, str]:
@@ -115,6 +115,8 @@ class Config(_BaseConfig, metaclass=ConfigMeta):
             files.extend(sorted(glob.glob(os.path.join(CUCKOO_ROOT, "conf", f"{fname_base}.conf.d", "*.conf"))))
         files.append(os.path.join(CUSTOM_CONF_DIR, f"{fname_base}.conf"))
         files.extend(sorted(glob.glob(os.path.join(CUSTOM_CONF_DIR, f"{fname_base}.conf.d", "*.conf"))))
+        if not files:
+            raise CuckooCriticalError(f"No {fname_base} config files could be found!")
         return files
 
 

--- a/lib/cuckoo/core/scheduler.py
+++ b/lib/cuckoo/core/scheduler.py
@@ -878,14 +878,6 @@ class Scheduler:
         # Initialize the machine manager.
         machinery = plugin()
 
-        # Find its configuration file.
-        conf = os.path.join(CUCKOO_ROOT, "conf", f"{machinery_name}.conf")
-
-        if not path_exists(conf):
-            raise CuckooCriticalError(
-                f'The configuration file for machine manager "{machinery_name}" does not exist at path: {conf}'
-            )
-
         # Provide a dictionary with the configuration options to the
         # machine manager instance.
         machinery.set_options(Config(machinery_name))

--- a/lib/cuckoo/core/startup.py
+++ b/lib/cuckoo/core/startup.py
@@ -118,9 +118,9 @@ def check_configs():
     @raise CuckooStartupError: if config files do not exist.
     """
     configs = [
-        os.path.join(CUCKOO_ROOT, "conf", "cuckoo.conf"),
-        os.path.join(CUCKOO_ROOT, "conf", "reporting.conf"),
-        os.path.join(CUCKOO_ROOT, "conf", "auxiliary.conf"),
+        os.path.join(CUCKOO_ROOT, "conf", "default", "cuckoo.conf.default"),
+        os.path.join(CUCKOO_ROOT, "conf", "default", "reporting.conf.default"),
+        os.path.join(CUCKOO_ROOT, "conf", "default", "auxiliary.conf.default"),
     ]
 
     for config in configs:


### PR DESCRIPTION
There might not be a conf/cuckoo.conf file, i.e. if the user has simply created custom/conf/cuckoo.conf to override the defaults.