### PR TITLE
fix/rework private package configuration

### DIFF
--- a/analyzer/windows/analyzer.py
+++ b/analyzer/windows/analyzer.py
@@ -397,7 +397,7 @@ class Analyzer:
         except Exception as e:
             log.exception(e)
         # Initialize the package parent abstract.
-        Package(package_name)
+        Package()
         # Enumerate the abstract subclasses.
         try:
             package_class = Package.__subclasses__()[0]
@@ -408,7 +408,7 @@ class Analyzer:
 
         # Initialize the analysis package.
         log.debug('Initializing analysis package "%s"...', package)
-        self.package = package_class(package_name, self.options, self.config)
+        self.package = package_class(self.options, self.config)
         # log.debug('Initialized analysis package "%s"', package)
 
         # Move the sample to the current working directory as provided by the

--- a/analyzer/windows/lib/common/abstracts.py
+++ b/analyzer/windows/lib/common/abstracts.py
@@ -29,9 +29,8 @@ class Package:
     PATHS = []
     default_curdir = None
 
-    def __init__(self, name: str, options=None, config=None):
+    def __init__(self, options=None, config=None):
         """@param options: options dict."""
-        self.name = name
         if options is None:
             options = {}
         self.config = config
@@ -80,7 +79,8 @@ class Package:
          - AttributeError if the module configure function is invalid.
          - ModuleNotFoundError if the module does not support configuration from data
         """
-        module_name = f"data.packages.{self.name}"
+        package_module_name = self.__class__.__module__.split('.')[-1]
+        module_name = f"data.packages.{package_module_name}"
         try:
             m = importlib.import_module(module_name)
         except Exception as e:

--- a/analyzer/windows/tests/lib/common/test_abstracts.py
+++ b/analyzer/windows/tests/lib/common/test_abstracts.py
@@ -9,7 +9,7 @@ class TestPackageConfiguration(unittest.TestCase):
 
     def test_private_package_configuration(self):
         # test analysis package
-        package_module = "configuration_package"
+        package_module = self.__class__.__module__
         # and its private configuration module
         module_name = f"data.packages.{package_module}"
 

--- a/analyzer/windows/tests/modules/packages/test_ps1.py
+++ b/analyzer/windows/tests/modules/packages/test_ps1.py
@@ -8,7 +8,7 @@ class TestPS1(unittest.TestCase):
         """By default, the first path should be powershell.exe"""
         package_name = "modules.packages.ps1"
         __import__(package_name, globals(), locals(), ["dummy"])
-        ps1_module = PS1(package_name)
+        ps1_module = PS1()
         paths = ps1_module.get_paths()
         assert paths[0][-1] == "powershell.exe"
         all_paths = set([path[-1] for path in paths])
@@ -19,7 +19,7 @@ class TestPS1(unittest.TestCase):
         options = {"pwsh": True}
         package_name = "modules.packages.ps1"
         __import__(package_name, globals(), locals(), ["dummy"])
-        ps1_module = PS1(package_name, options=options)
+        ps1_module = PS1(options=options)
         paths = ps1_module.get_paths()
         assert paths[0][-1] == "pwsh.exe"
         all_paths = set([path[-1] for path in paths])


### PR DESCRIPTION
Some analyzer packages provide their own `__init__`. Rather than having to pass the package name to itself, rework private package configuration to derive the importable package from the package class module name.

So for example if the "pdf" package is used, `self.__class__.__module__` is:

    modules.packages.pdf

And the data module derived from it becomes:
 
    data.packages.pdf