### PR TITLE
Fill categories when fetching signature data for scoring

### DIFF
--- a/lib/cuckoo/common/abstracts.py
+++ b/lib/cuckoo/common/abstracts.py
@@ -1633,6 +1633,7 @@ class Signature:
         return dict(
             name=self.name,
             description=self.description,
+            categories=self.categories,
             severity=self.severity,
             weight=self.weight,
             confidence=self.confidence,


### PR DESCRIPTION
The current scoring script relies on signature categories, which currently are not filled when getting the signature info through `as_result()`. This fixes the score generation for executables on reports, and should not break if any signature doesn't define categories as it would simply provide an empty list.

It might be worth adding any of the other signature fields which aren't currently filled, but as I don't know if this should be the case and I currently only needed the malscore I haven't checked for the rest.