### PR TITLE
Added support for IMDS authentication in the AWS machinery module

### DIFF
--- a/conf/default/aws.conf.default
+++ b/conf/default/aws.conf.default
@@ -8,6 +8,8 @@ availability_zone = us-east-1a
 # Access keys consist of two parts: an access key ID (for example, AKIAIOSFODNN7EXAMPLE)
 # and a secret access key (for example, wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY).
 # To create access keys for your AWS account root user, you must use the AWS Management Console.
+# There is an option to attach an IAM role directly to the instance itself, instead of providing access and secret keys.
+# If access and secret keys are not provided, the machinery module will attempt to authenticate using IMDS.
 aws_access_key_id = AWS_ACCESS_KEY
 aws_secret_access_key = AWS_SECRET_KEY
 

--- a/modules/machinery/aws.py
+++ b/modules/machinery/aws.py
@@ -43,14 +43,28 @@ class AWS(Machinery):
         self.dynamic_machines_sequence = 0
         self.dynamic_machines_count = 0
         log.info("connecting to AWS:{}".format(self.options.aws.region_name))
-        self.ec2_resource = boto3.resource(
-            "ec2",
-            region_name=self.options.aws.region_name,
-            aws_access_key_id=self.options.aws.aws_access_key_id,
-            aws_secret_access_key=self.options.aws.aws_secret_access_key,
-        )
 
-        # Iterate over all instances with tag that has a key of AUTOSCALE_CUCKOO
+        # Performing a check to see if the access and secret keys were passed through the configuration file
+        access_key = getattr(self.options.aws, 'aws_access_key_id', None)
+        secret_key = getattr(self.options.aws, 'aws_secret_access_key', None)
+
+        # Use the provided credentials if available; otherwise, fall back to the IAM role attached to the EC2 instance
+        if access_key and secret_key:
+            log.info("Using provided AWS keys for authentication.")
+            self.ec2_resource = boto3.resource(
+                "ec2",
+                region_name=self.options.aws.region_name,
+                aws_access_key_id=self.options.aws.aws_access_key_id,
+                aws_secret_access_key=self.options.aws.aws_secret_access_key,
+            )
+        else:
+            log.info("No AWS keys provided; attempting to use IAM Role through IMDSv2")
+            self.ec2_resource = boto3.resource(
+                "ec2",
+                region_name=self.options.aws.region_name
+            )
+
+            # Iterate over all instances with tag that has a key of AUTOSCALE_CUCKOO
         for instance in self.ec2_resource.instances.filter(
             Filters=[
                 {

--- a/modules/machinery/aws.py
+++ b/modules/machinery/aws.py
@@ -45,8 +45,8 @@ class AWS(Machinery):
         log.info("connecting to AWS:{}".format(self.options.aws.region_name))
 
         # Performing a check to see if the access and secret keys were passed through the configuration file
-        access_key = getattr(self.options.aws, 'aws_access_key_id', None)
-        secret_key = getattr(self.options.aws, 'aws_secret_access_key', None)
+        access_key = getattr(self.options.aws, "aws_access_key_id", None)
+        secret_key = getattr(self.options.aws, "aws_secret_access_key", None)
 
         # Use the provided credentials if available; otherwise, fall back to the IAM role attached to the EC2 instance
         if access_key and secret_key:
@@ -59,10 +59,7 @@ class AWS(Machinery):
             )
         else:
             log.info("No AWS keys provided; attempting to use IAM Role through IMDSv2")
-            self.ec2_resource = boto3.resource(
-                "ec2",
-                region_name=self.options.aws.region_name
-            )
+            self.ec2_resource = boto3.resource("ec2", region_name=self.options.aws.region_name)
 
             # Iterate over all instances with tag that has a key of AUTOSCALE_CUCKOO
         for instance in self.ec2_resource.instances.filter(


### PR DESCRIPTION
Using a secret and access key directly from an AWS EC2 instance is considered a bad security practice. 
In addition to the option of authenticating using a secret and access key, I have added the option to use IMDS authentication. The machinery module will by default try to perform authentication using the secret and access key. 
However, if no access and secret key are provided, the boto3 library will attempt to use credentials from the Instance Metadata Service. If the user has attached an IAM role to the instance, it will work just like with the access and secret key.