### PR TITLE
Customisable ignore noisy files as drop files on Linux

### DIFF
--- a/analyzer/linux/modules/auxiliary/filecollector.py
+++ b/analyzer/linux/modules/auxiliary/filecollector.py
@@ -113,6 +113,13 @@ class FileCollector(Auxiliary, Thread):
 
     def process_generator(self, cls, method):
         # log.info("Generating message %s", method)
+
+        # excluded files or directories
+        noisy_content = [
+                "sysmon",
+                "gvfs-metadata"
+        ]
+
         def _method_name(self, event):
             try:
                 # log.info("Got file %s %s", event.pathname, method)
@@ -130,6 +137,10 @@ class FileCollector(Auxiliary, Thread):
                     return
 
                 if "strace.log" in os.path.basename(event.pathname):
+                    return
+
+                if any(noisy in event.pathname for noisy in noisy_content):
+                    #log.info("Skipping noisy file %s", event.pathname)
                     return
 
                 try:


### PR DESCRIPTION
Using sysmon together with strace will generate unnecessary files from sysmon's load and possibly other related files.

With this exclusion list, it can be configured as needed to clean up the scan result as discarded files.