### PR TITLE
Url for sysmon.data on linux

### DIFF
--- a/web/analysis/views.py
+++ b/web/analysis/views.py
@@ -1790,7 +1790,7 @@ def file(request, category, task_id, dlfile):
         path = os.path.join(CUCKOO_ROOT, "storage", "analyses", task_id, "rtf_objects", file_name)
     elif category == "tlskeys":
         path = os.path.join(CUCKOO_ROOT, "storage", "analyses", task_id, "tlsdump", "tlsdump.log")
-    # linux sysmon url for xml download
+    # linux sysmon url to download sysmon.data xml
     elif category == "sysmon":
         path = os.path.join(CUCKOO_ROOT, "storage", "analyses", task_id, "sysmon", "sysmon.data")
     elif category == "evtx":

--- a/web/analysis/views.py
+++ b/web/analysis/views.py
@@ -1790,6 +1790,9 @@ def file(request, category, task_id, dlfile):
         path = os.path.join(CUCKOO_ROOT, "storage", "analyses", task_id, "rtf_objects", file_name)
     elif category == "tlskeys":
         path = os.path.join(CUCKOO_ROOT, "storage", "analyses", task_id, "tlsdump", "tlsdump.log")
+    # linux sysmon url for xml download
+    elif category == "sysmon":
+        path = os.path.join(CUCKOO_ROOT, "storage", "analyses", task_id, "sysmon", "sysmon.data")
     elif category == "evtx":
         path = os.path.join(CUCKOO_ROOT, "storage", "analyses", task_id, "evtx", "evtx.zip")
         file_name = f"{task_id}_evtx.zip"


### PR DESCRIPTION
Direct access to download sysmon data directly from Linux analysis, alternatively it might be possible to replace evtx.zip with its contents and store it in the evtx directory so that it can be accessed via the API.