### PR TITLE
Refactor Linux strace

### DIFF
--- a/analyzer/linux/analyzer.py
+++ b/analyzer/linux/analyzer.py
@@ -306,12 +306,6 @@ class Analyzer:
                     upload_to_host(package[0], os.path.join("files", package[1]))
         except Exception as e:
             log.warning('The package "%s" package_files function raised an exception: %s', package_class, e)
-        try:
-            # Upload the strace logs to host
-            for file in os.listdir(PATHS["logs"]):
-                upload_to_host(os.path.join(PATHS["logs"], file), os.path.join("logs", file))
-        except Exception as e:
-            log.warning("The strace log failed to transfer:", e)
 
         # Terminate the Auxiliary modules.
         log.info("Stopping auxiliary modules")

--- a/analyzer/linux/lib/common/results.py
+++ b/analyzer/linux/lib/common/results.py
@@ -58,9 +58,8 @@ def append_buffer_to_host(buffer, nc=None):
         while idx < size:
             nc.send(buffer[idx : idx + BUFSIZE], retry=True)
             idx += BUFSIZE
-    except Exception as e:
-        log.exception("Exception uploading buffer %s to host.")
-        log.exception(e)
+    except Exception:
+        log.exception("exception uploading buffer to host")
 
     nc.buffer_size += size
 

--- a/analyzer/linux/lib/common/results.py
+++ b/analyzer/linux/lib/common/results.py
@@ -53,13 +53,13 @@ def append_buffer_to_host(buffer, nc=None):
         log.warning("Buffer is too big: %d; max size: %d", size + nc.buffer_size, config.upload_max_size)
         return
 
-    try:
-        idx = 0
-        while idx < size:
-            nc.send(buffer[idx : idx + BUFSIZE], retry=True)
+    idx = 0
+    while idx < size:
+        try:
+            nc.send(buffer[idx : idx + BUFSIZE], retry=False)
             idx += BUFSIZE
-    except Exception:
-        log.exception("exception uploading buffer to host")
+        except Exception:
+            raise ConnectionResetError        
 
     nc.buffer_size += size
 

--- a/analyzer/linux/lib/common/results.py
+++ b/analyzer/linux/lib/common/results.py
@@ -44,6 +44,27 @@ def upload_to_host(file_path, dump_path, pids="", ppids="", metadata="", categor
             nc.close()
 
 
+def append_buffer_to_host(buffer, nc=None):
+    if nc.sock is None:
+        raise ConnectionResetError
+
+    size = len(buffer)
+    if config.upload_max_size < size + nc.buffer_size and not config.do_upload_max_size:
+        log.warning("Buffer is too big: %d; max size: %d", size + nc.buffer_size, config.upload_max_size)
+        return
+
+    try:
+        idx = 0
+        while idx < size:
+            nc.send(buffer[idx : idx + BUFSIZE], retry=True)
+            idx += BUFSIZE
+    except Exception as e:
+        log.exception("Exception uploading buffer %s to host.")
+        log.exception(e)
+
+    nc.buffer_size += size
+
+
 class NetlogConnection:
     def __init__(self, proto=""):
         config = Config(cfg="analysis.conf")
@@ -51,6 +72,13 @@ class NetlogConnection:
         self.sock = None
         self.proto = proto
         self.connected = False
+        self.buffer_size = 0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, tb):
+        self.close()
 
     def connect(self):
         # Try to connect as quickly as possible. Just sort of force it to
@@ -87,13 +115,15 @@ class NetlogConnection:
             self.close()
 
     def close(self):
+        if not self.sock:
+            return
+
         try:
             self.sock.shutdown(socket.SHUT_RDWR)
             self.sock.close()
             self.sock = None
         except Exception as e:
             print(e)
-            pass
 
 
 class NetlogBinary(NetlogConnection):

--- a/analyzer/linux/lib/core/packages.py
+++ b/analyzer/linux/lib/core/packages.py
@@ -10,11 +10,8 @@ from threading import Thread
 import timeit
 from os import environ, path, sys
 
-from lib.api.process import Process
-from lib.core.config import Config
 from lib.common.results import NetlogFile, append_buffer_to_host
 
-config = Config(cfg="analysis.conf")
 log = logging.getLogger(__name__)
 
 
@@ -168,7 +165,7 @@ class Package:
         target_cmd = f"{self.target}"
         if "args" in kwargs:
             target_cmd += f' {" ".join(kwargs["args"])}'
-        
+
         # Tricking strace into always showing PID on stderr output
         # https://github.com/strace/strace/issues/278#issuecomment-1815914576
         cmd = f"sudo strace -o /dev/stderr -ttf {target_cmd}"

--- a/analyzer/linux/lib/core/packages.py
+++ b/analyzer/linux/lib/core/packages.py
@@ -121,10 +121,10 @@ class Package:
             # Remove the trailing slash (if any)
             self.target = filepath.rstrip("/")
         self.prepare()
-        self.strace_analysis()
         self.nc.init("logs/strace.log", False)
         self.thread = Thread(target=self.thread_send_strace_buffer, daemon=True)
         self.thread.start()
+        self.strace_analysis()
 
         return self.proc.pid
 

--- a/lib/cuckoo/core/plugins.py
+++ b/lib/cuckoo/core/plugins.py
@@ -390,9 +390,6 @@ class RunSignatures:
         if not self._check_signature_version(signature):
             return False
 
-        if not self._check_signature_platform(signature):
-            return False
-
         return True
 
     def _load_overlay(self):

--- a/lib/cuckoo/core/plugins.py
+++ b/lib/cuckoo/core/plugins.py
@@ -461,7 +461,7 @@ class RunSignatures:
         if platform in module:
             return True
 
-        if "all" in module:
+        if ".all." in module:
             return True
 
         if "custom" in module:

--- a/lib/cuckoo/core/plugins.py
+++ b/lib/cuckoo/core/plugins.py
@@ -390,6 +390,9 @@ class RunSignatures:
         if not self._check_signature_version(signature):
             return False
 
+        if not self._check_signature_platform(signature):
+            return False
+
         return True
 
     def _load_overlay(self):

--- a/modules/processing/strace.py
+++ b/modules/processing/strace.py
@@ -74,7 +74,7 @@ class ParseProcessLog(list):
         return iter(super().__iter__())
 
     def __repr__(self):
-        return f"<ParseProcessLog log-path: {self._log_path}>"
+        return f"<ParseProcessLog for pid: {self.process_id}>"
 
     def begin_reporting(self):
         pass
@@ -366,11 +366,11 @@ class Processes:
 
         if not path_exists(self._logs_path):
             log.warning('Strace logs does not exist at path "%s"', self._logs_path)
-            return self.results
+            return [1]
         
         if not os.stat(self._logs_path).st_size > 0:
             log.warning('Strace logs does not contain data at path "%s"', self._logs_path)
-            return self.results
+            return [2]
 
         processes = self.normalize_logs()
 

--- a/modules/processing/strace.py
+++ b/modules/processing/strace.py
@@ -55,10 +55,10 @@ fd_syscalls = [
 class ParseProcessLog(list):
     """Parses the process log file"""
 
-    def __init__(self, log_path, syscalls_info, options):
+    def __init__(self, process_id, logs, syscalls_info, options):
         """@param log_path: log file path."""
-        self._log_path = log_path
-        self.process_id = int(log_path.split(".")[-1])
+        self.logs = logs
+        self.process_id = process_id
         self.children_ids = []
         self.first_seen = None
         self.process_name = None
@@ -67,9 +67,8 @@ class ParseProcessLog(list):
         self.options = options
         # Limit of API calls per process
         # self.api_limit = self.options.analysis_call_limit
-
-        if path_exists(log_path) and os.stat(log_path).st_size > 0:
-            self.fetch_calls(syscalls_info)
+        
+        self.fetch_calls(syscalls_info)
 
     def __iter__(self):
         return iter(super().__iter__())
@@ -79,50 +78,6 @@ class ParseProcessLog(list):
 
     def begin_reporting(self):
         pass
-
-    def log_concat(self, unfinished, resumed):
-        """
-        Concatenates all the respective unfinished and resumed strace logs into a string,
-        matching '<unfinished ...>' and '<... {syscall} resumed>' strings accordingly,
-        returns the `resumed` time as that is the completed syscall time.
-        """
-        data = ""
-        for head in unfinished:
-            for tail in resumed:
-                if head["syscall"] != tail["syscall"]:
-                    continue
-                data += " ".join([tail["time"], head["unfinished"] + tail["resumed"] + "\n"])
-                resumed.remove(tail)
-                break
-        return data
-
-    def extract_logs(self, raw_logs, pattern):
-        return [match.groupdict() for match in pattern.finditer(raw_logs)]
-
-    def normalize_logs(self):
-        """
-        Normalize the logs into a standard format to process the syscall information.
-        Returns a list of dictionaries containing syscall information.
-        """
-        log_pattern = re.compile(
-            r"(?P<time>\d+:\d+:\d+\.\d+)\s+\[\s+\d+\]\s+(?P<syscall>\w+)\((?P<args>.*)\)\s+=\s(?P<retval>.+)\n"
-        )
-        unfinished_pattern = re.compile(r"\d+:\d+:\d+\.\d+\s+(?P<unfinished>\[\s+\d+\]\s+(?P<syscall>\w+)\(.*)<unfinished\s...>\n")
-        resumed_pattern = re.compile(
-            r"(?P<time>\d+:\d+:\d+\.\d+)\s+\[\s+\d+\]\s+<\.\.\.\s(?P<syscall>\w+)\sresumed>(?P<resumed>.*)\n"
-        )
-        with open(self._log_path, "r") as log_file:
-            raw_logs = log_file.read()
-
-        normal_logs = self.extract_logs(raw_logs, log_pattern)
-        unfinished_logs = self.extract_logs(raw_logs, unfinished_pattern)
-        resumed_logs = self.extract_logs(raw_logs, resumed_pattern)
-
-        concat_logs = self.log_concat(unfinished_logs, resumed_logs)
-        normal_logs.extend(self.extract_logs(concat_logs, log_pattern))
-
-        normal_logs.sort(key=lambda d: d["time"])
-        return normal_logs
 
     def split_arguments(self, args_str):
         args = []
@@ -143,7 +98,7 @@ class ParseProcessLog(list):
         return [x.strip() for x in args if x.strip() != ""]
 
     def fetch_calls(self, syscalls_info):
-        for event in self.normalize_logs():
+        for event in self.logs:
             time = event["time"]
             category = "misc"
             syscall = event["syscall"]
@@ -165,11 +120,14 @@ class ParseProcessLog(list):
 
             if len(self.calls) == 0:
                 self.first_seen = time
-                self.process_name = syscall + "(" + event["args"] + ")"
+
+            if syscall == "execve":
+                self.process_name = " ".join(eval(args[1]))
 
             if syscall in ["fork", "vfork", "clone", "clone3"]:
+                # append children and the corresponding API call that spawns it
                 self.children_ids.append((int(retval), syscall + "(" + event["args"] + ")"))
-
+            
             self.calls.append(
                 {
                     "timestamp": time,
@@ -236,6 +194,7 @@ class Processes:
         self._logs_path = logs_path
         self.syscalls_info = self.load_syscalls_args()
         self.options = options
+        self.results = []
 
     def load_syscalls_args(self):
         """
@@ -253,7 +212,7 @@ class Processes:
             for syscall in syscalls_dict["syscalls"]
         }
 
-    def update_file_descriptors(self, process_list, fd_calls):
+    def update_file_descriptors(self, fd_calls):
         """
         Returns an updated process list where file-access related calls have
         the matching file descriptor at the time of it being opened.
@@ -279,9 +238,8 @@ class Processes:
                 "time_closed": None,
             },
         ]
-        sorted_fd_calls = sorted(fd_calls, key=lambda x: x["time"])
 
-        for fd_call in sorted_fd_calls:
+        for fd_call in fd_calls:
             # Retrieve the relevant informaton from syscalls that open/duplicate/close file descriptors
             match fd_call["syscall"]:
                 case syscall if syscall in ["open", "creat", "openat", "openat2"]:
@@ -309,7 +267,7 @@ class Processes:
                         if fd["time_closed"] is None and fd_call["fd"] == fd["fd"]:
                             fd["time_closed"] = fd_call["time"]
 
-        for process in process_list:
+        for process in self.results:
             for call in process["calls"]:
                 if call["api"] in fd_syscalls:
                     # append filename to file descriptor according to relevant time that fd is opened
@@ -322,14 +280,13 @@ class Processes:
                         ):
                             call["arguments"][0]["value"] += f' ({fd["filename"]})'
 
-        return process_list
 
-    def update_parent_ids(self, process_list, relations):
+    def update_parent_ids(self, relations):
         """
         Returns an updated process list with the matched parent IDs
         """
         # Create a dictionary to map process IDs to their respective entries
-        process_dict = {entry["process_id"]: entry for entry in process_list}
+        process_dict = {entry["process_id"]: entry for entry in self.results}
 
         # Iterate through the parent_relations dictionary
         for parent_id, children in relations.items():
@@ -339,39 +296,89 @@ class Processes:
                 for child_id, name in children:
                     if child_id in process_dict:
                         process_dict[child_id]["parent_id"] = parent_id
-                        process_dict[child_id]["process_name"] = name
+                        if process_dict[child_id]["process_name"] is None:
+                            process_dict[child_id]["process_name"] = name
 
         # Convert the dictionary back to a list of entries
-        updated_process_list = list(process_dict.values())
+        self.results = list(process_dict.values())
 
-        return updated_process_list
+    def log_concat(self, unfinished, resumed):
+        """
+        Concatenates all the respective unfinished and resumed strace logs into a string,
+        matching '<unfinished ...>' and '<... {syscall} resumed>' strings accordingly,
+        returns the `resumed` time as that is the completed syscall time.
+        """
+        data = ""
+        for key in unfinished.keys():
+            for head in unfinished[key]:
+                for tail in resumed[key]:
+                    if head["syscall"] != tail["syscall"]:
+                      continue
+                    data += " ".join([str(key), tail["time"], head["unfinished"] + tail["resumed"] + "\n"])
+                    resumed[key].remove(tail)
+                    break
+        return data
+
+    def extract_logs(self, raw_logs, pattern):
+        extracted_logs = dict()
+        for match in pattern.finditer(raw_logs):
+            match = match.groupdict()
+            pid = int(match.pop("pid"))
+            if pid not in extracted_logs:
+                extracted_logs[pid] = []
+            extracted_logs[pid].append(match)
+        return extracted_logs
+
+    def normalize_logs(self):
+        """
+        Normalize the logs into a standard format to process the syscall information.
+        Returns a list of dictionaries containing syscall information.
+        """
+        log_pattern = re.compile(
+            r"(?P<pid>\d+)\s+(?P<time>\d+:\d+:\d+\.\d+)\s+(?P<syscall>\w+)\((?P<args>.*)\)\s+=\s(?P<retval>.+)\n"
+        )
+        unfinished_pattern = re.compile(
+            r"(?P<pid>\d+)\s+\d+:\d+:\d+\.\d+\s+(?P<unfinished>(?P<syscall>\w+)\(.*)\s+<unfinished\s...>\n"
+        )
+        resumed_pattern = re.compile(
+            r"(?P<pid>\d+)\s+(?P<time>\d+:\d+:\d+\.\d+)\s+<\.\.\.\s(?P<syscall>\w+)\sresumed>(?P<resumed>.*)\n"
+        )
+        with open(self._logs_path, "r") as log_file:
+            raw_logs = log_file.read()
+
+        normal_logs = self.extract_logs(raw_logs, log_pattern)
+        unfinished_logs = self.extract_logs(raw_logs, unfinished_pattern)
+        resumed_logs = self.extract_logs(raw_logs, resumed_pattern)
+
+        concat_raw_logs = self.log_concat(unfinished_logs, resumed_logs)
+        concat_logs = self.extract_logs(concat_raw_logs, log_pattern)
+        for pid in normal_logs.keys():
+            normal_logs[pid].extend(concat_logs[pid])
+
+        for pid in normal_logs.keys():
+            normal_logs[pid].sort(key=lambda d: d["time"])
+        return normal_logs
 
     def run(self):
-        results = []
         parent_child_relation = {}
         fd = []
 
         if not path_exists(self._logs_path):
-            log.warning('Analysis results folder does not exist at path "%s"', self._logs_path)
-            return results
+            log.warning('Strace logs does not exist at path "%s"', self._logs_path)
+            return self.results
+        
+        if not os.stat(self._logs_path).st_size > 0:
+            log.warning('Strace logs does not contain data at path "%s"', self._logs_path)
+            return self.results
 
-        if len(os.listdir(self._logs_path)) == 0:
-            log.info("Analysis results folder does not contain any file or injection was disabled")
-            return results
+        processes = self.normalize_logs()
 
-        for file_name in os.listdir(self._logs_path):
-            file_path = os.path.join(self._logs_path, file_name)
-
-            if os.path.isdir(file_path):
-                continue
-
-            current_log = ParseProcessLog(file_path, self.syscalls_info, self.options)
-            if current_log.process_id is None:
-                continue
-
+        for pid in processes.keys():
+            current_log = ParseProcessLog(pid, processes[pid], self.syscalls_info, self.options)
+            
             parent_child_relation[current_log.process_id] = current_log.children_ids
 
-            results.append(
+            self.results.append(
                 {
                     "process_id": current_log.process_id,
                     "process_name": current_log.process_name,
@@ -383,14 +390,14 @@ class Processes:
 
             fd += current_log.file_descriptors
 
-        results = self.update_parent_ids(results, parent_child_relation)
-        results = self.update_file_descriptors(results, fd)
+        self.update_parent_ids(parent_child_relation)
+        self.update_file_descriptors(fd)
 
         # Sort the items in the results list chronologically. In this way we
         # can have a sequential order of spawned processes.
-        results.sort(key=lambda process: process["first_seen"])
+        self.results.sort(key=lambda process: process["first_seen"])
 
-        return results
+        return self.results
 
 
 class ProcessTree:
@@ -480,7 +487,7 @@ class StraceAnalysis(Processing):
         Run analysis on strace logs
         @return: results dict.
         """
-        strace = {"processes": Processes(self.logs_path, self.options).run()}
+        strace = {"processes": Processes(os.path.join(self.logs_path, "strace.log"), self.options).run()}
 
         instances = [
             ProcessTree(),

--- a/modules/processing/strace.py
+++ b/modules/processing/strace.py
@@ -352,11 +352,12 @@ class Processes:
 
         concat_raw_logs = self.log_concat(unfinished_logs, resumed_logs)
         concat_logs = self.extract_logs(concat_raw_logs, log_pattern)
-        for pid in normal_logs.keys():
+        for pid in concat_logs.keys():
+            if pid not in normal_logs:
+                normal_logs[pid] = []
             normal_logs[pid].extend(concat_logs[pid])
-
-        for pid in normal_logs.keys():
             normal_logs[pid].sort(key=lambda d: d["time"])
+        
         return normal_logs
 
     def run(self):

--- a/modules/processing/strace.py
+++ b/modules/processing/strace.py
@@ -67,7 +67,7 @@ class ParseProcessLog(list):
         self.options = options
         # Limit of API calls per process
         # self.api_limit = self.options.analysis_call_limit
-        
+
         self.fetch_calls(syscalls_info)
 
     def __iter__(self):
@@ -127,7 +127,7 @@ class ParseProcessLog(list):
             if syscall in ["fork", "vfork", "clone", "clone3"]:
                 # append children and the corresponding API call that spawns it
                 self.children_ids.append((int(retval), syscall + "(" + event["args"] + ")"))
-            
+
             self.calls.append(
                 {
                     "timestamp": time,
@@ -280,7 +280,6 @@ class Processes:
                         ):
                             call["arguments"][0]["value"] += f' ({fd["filename"]})'
 
-
     def update_parent_ids(self, relations):
         """
         Returns an updated process list with the matched parent IDs
@@ -313,7 +312,7 @@ class Processes:
             for head in unfinished[key]:
                 for tail in resumed[key]:
                     if head["syscall"] != tail["syscall"]:
-                      continue
+                        continue
                     data += " ".join([str(key), tail["time"], head["unfinished"] + tail["resumed"] + "\n"])
                     resumed[key].remove(tail)
                     break
@@ -357,7 +356,7 @@ class Processes:
                 normal_logs[pid] = []
             normal_logs[pid].extend(concat_logs[pid])
             normal_logs[pid].sort(key=lambda d: d["time"])
-        
+
         return normal_logs
 
     def run(self):
@@ -367,7 +366,7 @@ class Processes:
         if not path_exists(self._logs_path):
             log.warning('Strace logs does not exist at path "%s"', self._logs_path)
             return [1]
-        
+
         if not os.stat(self._logs_path).st_size > 0:
             log.warning('Strace logs does not contain data at path "%s"', self._logs_path)
             return [2]
@@ -376,7 +375,7 @@ class Processes:
 
         for pid in processes.keys():
             current_log = ParseProcessLog(pid, processes[pid], self.syscalls_info, self.options)
-            
+
             parent_child_relation[current_log.process_id] = current_log.children_ids
 
             self.results.append(

--- a/modules/processing/strace.py
+++ b/modules/processing/strace.py
@@ -373,11 +373,11 @@ class Processes:
 
         if not path_exists(self._logs_path):
             log.warning('Strace logs does not exist at path "%s"', self._logs_path)
-            return [1]
+            return self.results
 
         if not os.stat(self._logs_path).st_size > 0:
             log.warning('Strace logs does not contain data at path "%s"', self._logs_path)
-            return [2]
+            return self.results
 
         processes = self.normalize_logs()
 


### PR DESCRIPTION
Previous implementation outputted strace logs onto the Linux guest VM. This refactor allows the strace logs to streamed directly to the CAPE result server on the host while the sample is running.