### PR TITLE
Update Yara CI config

### DIFF
--- a/.yara-ci.yml
+++ b/.yara-ci.yml
@@ -1,12 +1,13 @@
 files:
   accept:
   - "data/yara/**.yar"
+  - "analyzer/windows/data/yara/**.yar"
 
 false_positives:
   ignore:
-    - rule: "CobaltStrikeBeacon"
-    - rule: "Emotet"
-    - rule: "NSIS"
-    - rule: "UPX"
-    - rule: "Syscall"
-    - rule: "FormhookB"
+  - rule: "CobaltStrikeBeacon"
+  - rule: "Emotet"
+  - rule: "NSIS"
+  - rule: "UPX"
+  - rule: "Syscall"
+  - rule: "FormhookB"

--- a/analyzer/windows/data/yara/Blister.yar
+++ b/analyzer/windows/data/yara/Blister.yar
@@ -4,8 +4,8 @@ rule Blister
         author = "kevoreilly"
         description = "Blister Sleep Bypass"
         cape_options = "bp0=$sleep1+6,bp1=$sleep2+7,action0=setsignflag,action1=clearcarryflag,count=3"
-        blister_hash = "0a7778cf6f9a1bd894e89f282f2e40f9d6c9cd4b72be97328e681fe32a1b1a00"
-        blister_hash = "afb77617a4ca637614c429440c78da438e190dd1ca24dc78483aa731d80832c2"
+        packed = "0a7778cf6f9a1bd894e89f282f2e40f9d6c9cd4b72be97328e681fe32a1b1a00"
+        packed = "afb77617a4ca637614c429440c78da438e190dd1ca24dc78483aa731d80832c2"
     strings:
         $sleep1 = {FF FF 83 7D F0 00 (E9|0F 8?)}
         $sleep2 = {81 7D D8 90 B2 08 00 (E9|0F 8?)}

--- a/tests_parsers/test_qakbot.py
+++ b/tests_parsers/test_qakbot.py
@@ -2,6 +2,6 @@ from modules.processing.parsers.CAPE.QakBot import extract_config
 
 
 def test_qakbot():
-    with open("tests/data/malware/0cb0d77ac38df36fff891e072dea96401a8c1e8ff40d6ac741d5a2942aaeddbb ", "rb") as data:
+    with open("tests/data/malware/0cb0d77ac38df36fff891e072dea96401a8c1e8ff40d6ac741d5a2942aaeddbb", "rb") as data:
         conf = extract_config(data.read())
         assert conf == {"C2": "anscowerbrut.com", "Campaign": 2738000827}


### PR DESCRIPTION
Also found another CI issue in Qakbot parser test, but that's only partially fixed since the sample `0cb0d77ac38df36fff891e072dea96401a8c1e8ff40d6ac741d5a2942aaeddbb` is missing from https://github.com/CAPESandbox/CAPE-TestFiles/tree/main/malware and I can't find it on VT.

See https://github.com/kevoreilly/CAPEv2/actions/runs/9015622064/job/24770640690 for details