### PR TITLE
added nginx config enable in docs

### DIFF
--- a/docs/book/src/usage/web.rst
+++ b/docs/book/src/usage/web.rst
@@ -206,6 +206,14 @@ Replace ``www.capesandbox.com`` with your actual hostname.
         }
     }
 
+Now enable the nginx configuration by executing the following: 
+
+.. code:: bash
+
+   rm -f /etc/nginx/sites-enabled/default
+   ln -s /etc/nginx/sites-available/cape /etc/nginx/sites-enabled/default
+
+
 If you want to block users from changing their own email addresses, add the following `location` directive inside of the `server` directive:
 
 .. code-block:: nginx


### PR DESCRIPTION
I added 2 bash lines in the web Documentation, so that users know they also have to enable the newly created nginx config.  This is mandatory in order for the nginx config to work.