### PR TITLE
reapply tid kwarg bug fix used in thread inject

### DIFF
--- a/analyzer/windows/analyzer.py
+++ b/analyzer/windows/analyzer.py
@@ -1302,7 +1302,7 @@ class CommandPipeHandler:
             return
 
         # Open the process and inject the monitor
-        proc = Process(pid=process_id, tid=thread_id)
+        proc = Process(pid=process_id, thread_id=thread_id)
 
         filepath = proc.get_filepath()
         filename = os.path.basename(filepath)


### PR DESCRIPTION
Reapply 90134aaaca07c89fda269a601f05c49a17977d78. The lib.api.process.Process class wants `thread_id`, not `tid`.