### PR TITLE
Scheduler fix

### DIFF
--- a/utils/dist.py
+++ b/utils/dist.py
@@ -284,7 +284,6 @@ def node_submit_task(task_id, node_id, main_task_id):
             if not path_exists(task.path):
                 task.finished = True
                 task.retrieved = True
-                # Missed? with main_db.session.begin():
                 main_db.set_status(task.main_task_id, TASK_FAILED_REPORTING)
                 try:
                     db.commit()


### PR DESCRIPTION
The previous change to find_next_serviceable_task has a bug if
allow_static is True. In this case, we would only call
find_pending_task_not_requiring_machinery and never call
find_pending_task_to_service.
Instead, we want to track if the maximum number of machines has been
reached and use that information to make the determination of which
function to call.

The calls to main_db.set_status in node_submit_task should not be
in a begin() block because node_submit_task is already called from
within a transaction.