### PR TITLE
add platform for some exclusive OS modules

### DIFF
--- a/conf/default/processing.conf.default
+++ b/conf/default/processing.conf.default
@@ -71,6 +71,8 @@ replace_patterns = no
 enabled = no
 # Toggle specific modules within the StraceAnalysis class
 processtree = no
+# Platform specific
+platform = linux
 
 [debug]
 enabled = yes

--- a/lib/cuckoo/core/plugins.py
+++ b/lib/cuckoo/core/plugins.py
@@ -232,6 +232,11 @@ class RunProcessing:
         if not options.enabled:
             return None
 
+        # Check if the module is platform specific, such as strace, to prevent
+        # break processing.
+        if options.platform != self.task.get("platform", ""):
+            return None
+        
         # Give it path to the analysis results.
         current.set_path(self.analysis_path)
         # Give it the analysis task object.


### PR DESCRIPTION
After a lot of testing, I was able to verify that the strace module breaks the summary creation in the processing module when you run Windows and Linux machines for analysis at the same time.

This PR is a suggestion, if you know another better solution I'm able to collaborate to solve.

