### PR TITLE
Fix enforce_timeout

### DIFF
--- a/analyzer/windows/analyzer.py
+++ b/analyzer/windows/analyzer.py
@@ -635,6 +635,7 @@ class Analyzer:
         # we need to override pid_check and disable process monitor.
         if self.config.enforce_timeout:
             log.info("Enabled timeout enforce, running for the full timeout")
+            self.pid_check = False
 
         # next phase; go to the analysis loop
         self.analysis_loop(aux_modules)


### PR DESCRIPTION
`enforce_timeout` logic was removed here:

https://github.com/kevoreilly/CAPEv2/pull/2070/files#diff-5b414b99a827dfb21077aedddb85b188d90b6aeb8f4889bf06262ff2a7f44bbeR631-L608

Bringing it back