### PR TITLE
Fix stop, use guest name

### DIFF
--- a/web/apiv2/views.py
+++ b/web/apiv2/views.py
@@ -1097,8 +1097,7 @@ def tasks_status(request, task_id):
         status = task.to_dict()["status"]
         resp = {"error": False, "data": status}
     elif request.method == "POST" and apiconf.user_stop.enabled and request.data.get("status", "") == "finish":
-        machine_name = task.guest.name
-        machine = db.view_machine(machine_name)
+        machine = db.view_machine(task.guest.name)
         # Todo probably add task status if pending
         if machine.status == "running":
             try:

--- a/web/apiv2/views.py
+++ b/web/apiv2/views.py
@@ -1097,7 +1097,8 @@ def tasks_status(request, task_id):
         status = task.to_dict()["status"]
         resp = {"error": False, "data": status}
     elif request.method == "POST" and apiconf.user_stop.enabled and request.data.get("status", "") == "finish":
-        machine = db.view_machine(task.machine)
+        machine_name = task.guest.name
+        machine = db.view_machine(machine_name)
         # Todo probably add task status if pending
         if machine.status == "running":
             try:


### PR DESCRIPTION
Use cuckoo context name instead of cape context machine name for stop

Looks like since: https://github.com/kevoreilly/CAPEv2/pull/2037, (not sure if this is the actual PR)
`task.machine` is now `machine.label` instead of `machine.name`