### PR TITLE
Allow plugins to run that do not have platform config value

### DIFF
--- a/lib/cuckoo/core/plugins.py
+++ b/lib/cuckoo/core/plugins.py
@@ -234,13 +234,11 @@ class RunProcessing:
 
         # Check if the module is platform specific, such as strace, to prevent
         # break processing.
-        try:
-            platform = self.task.get("platform", "")
-            if options.platform and options.platform != platform:
+        platform = self.task.get("platform", "")
+        if hasattr(options, "platform"):
+            if options.platform != platform:
+                log.debug("Plugin not compatible with platform: %s", platform)
                 return None
-        except Exception as e:
-            log.debug("Platform not found: %s", e)
-            return
 
         # Give it path to the analysis results.
         current.set_path(self.analysis_path)


### PR DESCRIPTION
Replace the existing try/catch with a `hasattr` statement. This fixes a bug where attempting to access `options.platform` in the try for plugins without a platform value causes an AttributeError to be raised. The AttributeError is caught by the generic Exception clause and `None` is returned.