### PR TITLE
Allow plugins to run that do not have platform config value

### DIFF
--- a/lib/cuckoo/core/plugins.py
+++ b/lib/cuckoo/core/plugins.py
@@ -235,8 +235,8 @@ class RunProcessing:
         # Check if the module is platform specific, such as strace, to prevent
         # break processing.
         platform = self.task.get("platform", "")
-        if hasattr(options, "platform") and options.platform != platform:
-            log.debug("Plugin not compatible with platform: %s", platform)
+        if getattr(options, "platform", None) and options.platform != platform:
+            log.debug("Plugin %s not compatible with platform: %s", module_name, platform)
             return None
 
         # Give it path to the analysis results.

--- a/lib/cuckoo/core/plugins.py
+++ b/lib/cuckoo/core/plugins.py
@@ -232,8 +232,8 @@ class RunProcessing:
         if not options.enabled:
             return None
 
-        # Check if the module is platform specific, such as strace, to prevent
-        # break processing.
+        # Check if the module is platform specific (e.g. strace) to prevent
+        # processing errors.
         platform = self.task.get("platform", "")
         if getattr(options, "platform", None) and options.platform != platform:
             log.debug("Plugin %s not compatible with platform: %s", module_name, platform)


### PR DESCRIPTION
Follow on from #2154; fix a bug where no results are returned if `options.plaform` exists but is `None`.