### PR TITLE
Agent:  support streaming a file off the guest. 

### DIFF
--- a/agent/agent.py
+++ b/agent/agent.py
@@ -290,7 +290,7 @@ class send_file:
                     continue
                 try:
                     sock.write(line)
-                except BrokenPipeError:
+                except (BrokenPipeError, ConnectionResetError):
                     httplog.log_message(f"Client disconnected while reading {self.path}")
                     break
 

--- a/agent/agent.py
+++ b/agent/agent.py
@@ -175,8 +175,8 @@ class MiniHTTPServer:
         port: int = 8000,
         event: multiprocessing.Event = None,
     ):
-        socketserver.TCPServer.allow_reuse_address = True
-        self.s = socketserver.TCPServer((host, port), self.handler)
+        socketserver.ThreadingTCPServer.allow_reuse_address = True
+        self.s = socketserver.ThreadingTCPServer((host, port), self.handler)
 
         # tell anyone waiting that they're good to go
         if event:
@@ -220,6 +220,7 @@ class MiniHTTPServer:
             self.close_connection = True
 
     def shutdown(self):
+
         # BaseServer also features a .shutdown() method, but you can't use
         # that from the same thread as that will deadlock the whole thing.
         if hasattr(self, "s"):
@@ -267,8 +268,6 @@ class send_file:
         self.streaming = False
         if streaming == "1":
             self.streaming = True
-
-        print(f'streaming: {self.streaming}')
 
     def okay_to_send(self):
         return os.path.isfile(self.path) and os.access(self.path, os.R_OK)

--- a/agent/agent.py
+++ b/agent/agent.py
@@ -596,17 +596,6 @@ def do_retrieve():
                      request.form.get("streaming", "")
                      )
 
-@app.route("/stream_file", methods=["POST"])
-def do_retrieve():
-    if "filepath" not in request.form:
-        return json_error(400, "No filepath has been provided")
-
-    return send_file(request.form["filepath"],
-                     request.form.get("encoding", ""),
-                     request.form.get("streaming", "")
-                     )
-
-
 
 @app.route("/extract", methods=["POST"])
 def do_extract():

--- a/agent/agent.py
+++ b/agent/agent.py
@@ -19,6 +19,7 @@ import socketserver
 import stat
 import subprocess
 import sys
+import time
 import tempfile
 import traceback
 from io import StringIO
@@ -258,26 +259,50 @@ class jsonify:
 class send_file:
     """Wrapper that represents Flask.send_file functionality."""
 
-    def __init__(self, path, encoding):
+    def __init__(self, path, encoding, streaming):
         self.length = None
         self.path = path
         self.status_code = 200
         self.encoding = encoding
+        self.streaming = False
+        if streaming == "1":
+            self.streaming = True
+
+        print(f'streaming: {self.streaming}')
 
     def okay_to_send(self):
         return os.path.isfile(self.path) and os.access(self.path, os.R_OK)
 
     def init(self):
         if self.okay_to_send():
-            if self.encoding != BASE_64_ENCODING:
+            if self.encoding != BASE_64_ENCODING and not self.streaming:
                 self.length = os.path.getsize(self.path)
         else:
             self.status_code = 404
+
+    def write_streaming(self, httplog, sock):
+        """Streaming output. similar to using 'tail -f <file>"""
+
+        with open(self.path, "rb") as f:
+            while True:
+                line = f.readline()
+                if not line:
+                    time.sleep(0.1)
+                    continue
+                try:
+                    sock.write(line)
+                except BrokenPipeError:
+                    httplog.log_message(f"Client disconnected while reading {self.path}")
+                    break
+
 
     def write(self, httplog, sock):
         if not self.okay_to_send():
             return
 
+        if self.streaming:
+            self.write_streaming(httplog, sock)
+            return
         try:
             with open(self.path, "rb") as f:
                 buf = f.read(1024 * 1024)
@@ -290,7 +315,8 @@ class send_file:
             httplog.log_error(f"Error reading file {self.path}: {ex}")
 
     def headers(self, obj):
-        obj.send_header("Content-Length", self.length)
+        if self.length is not None:
+            obj.send_header("Content-Length", self.length)
 
 
 class request:
@@ -565,7 +591,21 @@ def do_retrieve():
     if "filepath" not in request.form:
         return json_error(400, "No filepath has been provided")
 
-    return send_file(request.form["filepath"], request.form.get("encoding", ""))
+    return send_file(request.form["filepath"],
+                     request.form.get("encoding", ""),
+                     request.form.get("streaming", "")
+                     )
+
+@app.route("/stream_file", methods=["POST"])
+def do_retrieve():
+    if "filepath" not in request.form:
+        return json_error(400, "No filepath has been provided")
+
+    return send_file(request.form["filepath"],
+                     request.form.get("encoding", ""),
+                     request.form.get("streaming", "")
+                     )
+
 
 
 @app.route("/extract", methods=["POST"])

--- a/agent/test_agent.py
+++ b/agent/test_agent.py
@@ -211,6 +211,10 @@ class TestAgent:
         shutil.rmtree(DIRPATH, ignore_errors=True)
         assert not os.path.isdir(DIRPATH)
 
+        if sys.platform == "win32":
+            # shutdown will hang on win32 without this
+            self.agent_process.terminate()
+
         # Ensure agent process completes; release resources.
         self.agent_process.join()
         self.agent_process.close()

--- a/agent/test_agent.py
+++ b/agent/test_agent.py
@@ -206,6 +206,7 @@ class TestAgent:
             r = requests.get(f"{BASE_URL}/kill")
             assert r.status_code == 200
             assert r.json()["message"] == "Quit the CAPE Agent"
+            self.agent_process.terminate()
         except requests.exceptions.ConnectionError:
             pass
         shutil.rmtree(DIRPATH, ignore_errors=True)

--- a/agent/test_agent.py
+++ b/agent/test_agent.py
@@ -206,7 +206,6 @@ class TestAgent:
             r = requests.get(f"{BASE_URL}/kill")
             assert r.status_code == 200
             assert r.json()["message"] == "Quit the CAPE Agent"
-            self.agent_process.terminate()
         except requests.exceptions.ConnectionError:
             pass
         shutil.rmtree(DIRPATH, ignore_errors=True)


### PR DESCRIPTION
General idea is to add a handler that can support streaming out of the guest VM.  Something similar to doing   `tail -f <log-file>`

 You can test this by doing something like
`curl.exe -v --no-buffer -d streaming=1 -d filepath="c:\tmp\sysmon.xml" http://localhost:8000/retrieve`

Rationale:
* streaming can provide resilience if guest is rebooted. 
* Will allow future work with real time feedback.
 

Added `ThreadingTCPServer`  because the existing tcp server can only support a single connection at a time.   `ThreadingTCPServer`  would allow multiple connections at the same time. 