### PR TITLE
Fix bug when finding tasks not requiring machinery.

### DIFF
--- a/lib/cuckoo/core/scheduler.py
+++ b/lib/cuckoo/core/scheduler.py
@@ -149,10 +149,6 @@ class Scheduler:
         return task, machine
 
     def find_pending_task_not_requiring_machinery(self) -> Optional[Task]:
-        # This function must only be called when we're configured to not process any tasks
-        # that require machinery.
-        assert not self.machinery_manager
-
         task: Optional[Task] = None
         tasks = self.db.list_tasks(
             category=[category for category in self.analyzing_categories if category not in CATEGORIES_NEEDING_VM],


### PR DESCRIPTION
If max_machines_reached is True, then
find_pending_task_not_requiring_machinery can be called (if allow_static is True). Don't assert that there's no machinery_manager.