### PR TITLE
Fix problem preventing automatic installation of cape2.sh

### DIFF
--- a/installer/cape2.sh
+++ b/installer/cape2.sh
@@ -765,7 +765,7 @@ function install_yara() {
     # for root
     pip3 install ./yara-python
     if [ -d yara-python ]; then
-        sudo rm -r yara-python
+        sudo rm -rf yara-python
     fi
 
     if id "cape" >/dev/null 2>&1; then
@@ -774,7 +774,7 @@ function install_yara() {
         cd -
     fi
     if [ -d yara-python ]; then
-        sudo rm -r yara-python
+        sudo rm -rf yara-python
     fi
 
 }
@@ -1197,7 +1197,7 @@ function install_CAPE() {
     #packages are needed for build options in extra/yara_installer.sh
     apt-get install libjansson-dev libmagic1 libmagic-dev -y
     sudo -u ${USER} bash -c 'poetry run extra/yara_installer.sh'
-    sudo rm -r yara-python
+    sudo rm -rf yara-python
 
     sudo usermod -aG kvm ${USER}
     sudo usermod -aG libvirt ${USER}


### PR DESCRIPTION
Fixed a problem in which the message 'rm: remove write-protected regular file' was displayed while installing CAPE with cape2.sh, waiting for user input.