### PR TITLE
[multimachinery] Remove split by comma from already processed machine list

### DIFF
--- a/modules/machinery/multi.py
+++ b/modules/machinery/multi.py
@@ -58,7 +58,7 @@ class MultiMachinery(Machinery):
 
                 machinery["module"].machines = types.MethodType(list_machines, machinery["module"])
 
-                for machine_name in [machine.strip() for machine in machinery_machines.split(",")]:
+                for machine_name in [machine.strip() for machine in machinery_machines]:
                     machine = machinery["config"].get(machine_name)
                     machine["machinery"] = machinery_name
 


### PR DESCRIPTION
With the current master branch commit, execution fails when using the multimachinery module as its trying to call split by comma on a list that has already been split somewhere else.

Logs:
```
$ sudo -u cape /usr/bin/python3 -m poetry run python cuckoo.py -d

...
Traceback (most recent call last):
  File "/opt/CAPEv2/cuckoo.py", line 143, in <module>
    cuckoo_main(max_analysis_count=args.max_analysis_count)
  File "/opt/CAPEv2/cuckoo.py", line 102, in cuckoo_main
    sched = Scheduler(max_analysis_count)
  File "/opt/CAPEv2/lib/cuckoo/core/scheduler.py", line 66, in __init__
    self.machinery_manager = MachineryManager() if categories_need_VM else None
  File "/opt/CAPEv2/lib/cuckoo/core/machinery_manager.py", line 150, in __init__
    self.machinery: Machinery = self.create_machinery()
  File "/opt/CAPEv2/lib/cuckoo/core/machinery_manager.py", line 204, in create_machinery
    machinery: Machinery = plugin()
  File "/opt/CAPEv2/lib/cuckoo/common/abstracts.py", line 118, in __init__
    self.set_options(self.read_config())
  File "/opt/CAPEv2/modules/machinery/multi.py", line 62, in set_options
    for machine_name in [machine.strip() for machine in machinery_machines.split(",")]:
AttributeError: 'list' object has no attribute 'split'
Exception ignored in: <function ESX.__del__ at 0x7f30e057d000>
Traceback (most recent call last):
  File "/opt/CAPEv2/modules/machinery/esx.py", line 68, in __del__
AttributeError: 'ESX' object has no attribute 'global_conn'
```