### PR TITLE
Resolved the issue with manual detonation 

### DIFF
--- a/web/templates/submission/index.html
+++ b/web/templates/submission/index.html
@@ -656,7 +656,7 @@ $(document).ready( function() {
                             </div>
                             <div class="form-check">
                                 <label>
-                                    <input type="checkbox" name="manual_detonation" /> Manual detonation. Must be used with Interactive desktop
+                                    <input type="checkbox" name="manual" /> Manual detonation. Must be used with Interactive desktop
                                 </label>
                             </div>
                             {% if config.kernel %}


### PR DESCRIPTION
The renaming changes from manual_detonation to manual in other files (e.g., commit: 5673ecb) caused an issue with the manual detonation functionality. This change adjusted the file to reflect the changes in the code and restored the correct operation of manual detonation.