### PR TITLE
Fixed problem with not displaying HTTP response when inetsim is enabled

### DIFF
--- a/conf/default/processing.conf.default
+++ b/conf/default/processing.conf.default
@@ -104,9 +104,6 @@ enabled = no
 enabled = yes
 sort_pcap = no
 # DNS whitelisting to ignore domains/IPs configured in network.py
-# This should be disabled when utilizing InetSim/Remnux as we end up resolving
-# the IP from fakedns which would then remove all domains associated with that
-# resolved IP
 dnswhitelist = yes
 # additional entries
 dnswhitelist_file = extra/whitelist_domains.txt


### PR DESCRIPTION
I have solved the problem where the IP address of the inetsim server was added to the ip_passlist when inetsim was enabled. I also fixed the issue where all SMTP/HTTP(S) response results were not output if even one hostname was included in the domain_passlist.