### PR TITLE
Fix write_files for non existing files

### DIFF
--- a/modules/processing/behavior.py
+++ b/modules/processing/behavior.py
@@ -636,8 +636,8 @@ class Summary:
                     and (access & 0x40000000 or access & 0x10000000 or access & 0x02000000 or access & 0x6)
                     and filename not in self.write_files
                 ):
-                    self._filtering_helper(self.write_files, srcfilename)
-                    self._add_file_activity(process, "write_files", srcfilename)
+                    self._filtering_helper(self.write_files, srcfilename or filename)
+                    self._add_file_activity(process, "write_files", srcfilename or filename)
                 if filename not in self.files:
                     self._filtering_helper(self.files, filename)
             if srcfilename:


### PR DESCRIPTION
`write_files` was not working if `ExistingFileName` was `None`

```
            "category": "filesystem",
            "api": "NtCreateFile",
            "status": true,
            "return": "0x00000000",
            "arguments": [
              {
                "name": "FileHandle",
                "value": "0x00000a10"
              },
              {
                "name": "DesiredAccess",
                "value": "0x40100080",
                "pretty_value": "GENERIC_WRITE|FILE_READ_ATTRIBUTES|SYNCHRONIZE"
              },
              {
                "name": "FileName",
                "value": "C:\\Users\\Bruno\\AppData\\Local\\Temp\\new_file"
              },
              {
                "name": "CreateDisposition",
                "value": "5",
                "pretty_value": "FILE_OVERWRITE_IF"
              },
              {
                "name": "ShareAccess",
                "value": "1",
                "pretty_value": "FILE_SHARE_READ"
              },
              {
                "name": "FileAttributes",
                "value": "0x00000000"
              },
              {
                "name": "ExistedBefore",
                "value": "no"
              },
              {
                "name": "StackPivoted",
                "value": "no"
              }
            ],
```