### PR TITLE
Fix permissions.py module causing analysis failure

### DIFF
--- a/analyzer/windows/modules/auxiliary/permissions.py
+++ b/analyzer/windows/modules/auxiliary/permissions.py
@@ -22,14 +22,14 @@ class Permissions(Auxiliary):
         self.startupinfo.dwFlags |= STARTF_USESHOWWINDOW
 
     def start(self):
-        if not self.enabled:
+        if not self.enabled or not self.options.get("permissions"):
             return False
 
         # Put locations here that you want to protect. Do NOT put Path.cwd() or "C:\\tmp*" in the locations list,
         # as this will crash CAPE. Try to cherry-pick directories that are important to your analysis.
         # The locations must be pipe-separated. The default for CAPE is to separate items passed via options
         # with a colon, but that does not work with file paths, so | it is!
-        locations = self.options.get("permissions", "")
+        locations = self.options.get("permissions")
         locations = locations.split("|")
 
         log.debug("Adjusting permissions for %s", locations)


### PR DESCRIPTION
This change allows `permissions` to be enabled in `auxiliary.conf` and not break analysis. Currently, when `self.options.get("permissions", "")` returns `""` in [permissions.py](https://github.com/kevoreilly/CAPEv2/blob/bc671524cc1a7f05481cb80ddb3d4f3a6749dd02/analyzer/windows/modules/auxiliary/permissions.py#L32), a `[Errno 13] Permission denied` occurs. Issue #2197 has more detailed information. This was an issue on Windows 10 and 11 machines.

The analysis breaking behavior occurred when `locations` was set to `""` as a return from `self.options.get("permissions", "")` and then again set to `locations = locations.split("|")`, creating a list. As lists are iterable, the for loop uses the empty string as a `location`. I am not entirely sure what happens on the Windows machine, but my assumption is that permissions of the CAPE-created temp directory are changed in this scenario.