### PR TITLE
Add an option to fetch machine VNC port in machine view API

### DIFF
--- a/conf/default/api.conf.default
+++ b/conf/default/api.conf.default
@@ -271,6 +271,7 @@ rps = 1/s
 enabled = no
 auth_only = no
 rps = 1/s
+fetch_vnc_port = no
 #rpm = 10/m
 
 # Pull information about the Cuckoo host server.


### PR DESCRIPTION
This PR adds the virtual machine's VNC port to the machine view API route, only when the corresponding flag is enabled in the route's configuration.

This allows users to dynamically connect to a virtual machine by querying the machine view API for the VNC port and using the provided port for the connection.

