### PR TITLE
Update vmwarerest machinery module

### DIFF
--- a/conf/default/vmwarerest.conf.default
+++ b/conf/default/vmwarerest.conf.default
@@ -1,0 +1,51 @@
+[vmwarerest]
+
+host = 192.168.52.1
+port = 8697
+
+interface = ens33
+
+# Specify a comma-separated list of available machines to be used. For each
+# specified ID you have to define a dedicated section containing the details
+# on the respective machine. (E.g. cuckoo1,cuckoo2,cuckoo3)
+machines = win7x64sp1
+
+username = VMwareREST
+password = C@PE$@ndb0x
+
+[win7x64sp1]
+############
+id = win7x64sp1
+platform = windows
+ip = 192.168.142.129
+arch = x64
+
+# (Optional) Specify the name of the network interface that should be used
+# when dumping network traffic from this machine with tcpdump. If specified,
+# overrides the default interface specified in auxiliary.conf
+# Example (virbr0 is the interface name):
+# interface = virbr0
+
+# (Optional) Specify the IP of the Result Server, as your virtual machine sees it.
+# The Result Server will always bind to the address and port specified in cuckoo.conf,
+# however you could set up your virtual network to use NAT/PAT, so you can specify here
+# the IP address for the Result Server as your machine sees it. If you don't specify an
+# address here, the machine will use the default value from cuckoo.conf.
+# NOTE: if you set this option you have to set result server IP to 0.0.0.0 in cuckoo.conf.
+# Example:
+# resultserver_ip = 192.168.122.101
+
+# (Optional) Specify the port for the Result Server, as your virtual machine sees it.
+# The Result Server will always bind to the address and port specified in cuckoo.conf,
+# however you could set up your virtual network to use NAT/PAT, so you can specify here
+# the port for the Result Server as your machine sees it. If you don't specify a port
+# here, the machine will use the default value from cuckoo.conf.
+# Example:
+# resultserver_port = 2042
+
+# (Optional) Set your own tags. These are comma separated and help to identify
+# specific VMs. You can run samples on VMs with tag you require.
+# Note that the 64_bit tag is currently special.  For submitted 64-bit PE files,
+# the 64_bit tag will automatically be added, forcing them to be run on a 64-bit
+# VM.  For this reason, make sure all 64-bit VMs have the 64_bit tag.
+# tags = windows_xp_sp3,32_bit,acrobat_reader_6

--- a/conf/default/vmwarerest.conf.default
+++ b/conf/default/vmwarerest.conf.default
@@ -2,6 +2,7 @@
 
 host = 192.168.52.1
 port = 8697
+enable_tls = no
 
 interface = ens33
 

--- a/modules/machinery/vmwarerest.py
+++ b/modules/machinery/vmwarerest.py
@@ -32,6 +32,12 @@ class VMwareREST(Machinery):
         if not self.options.vmwarerest.port:
             raise CuckooMachineError("VMwareREST server port address missing, please add it to vmwarerest.conf")
         self.port = str(self.options.vmwarerest.port)
+
+        if self.options.vmwarerest.enable_tls:
+            self.api_url = f"https://{self.host}:{self.port}/api"
+        else:
+            self.api_url = f"http://{self.host}:{self.port}/api"
+
         if not self.options.vmwarerest.username:
             raise CuckooMachineError("VMwareREST username missing, please add it to vmwarerest.conf")
         self.username = self.options.vmwarerest.username
@@ -44,7 +50,7 @@ class VMwareREST(Machinery):
         log.info("VMwareREST machinery module initialised (%s:%s)", self.host, self.port)
 
     def get_vms(self):
-        vms = s.get(f"https://{self.host}:{self.port}/api/vms", auth=(self.username, self.password))
+        vms = s.get(f"{self.api_url}/vms", auth=(self.username, self.password))
         if "Authentication failed" in vms.text:
             log.info("Authentication failed, please check credentials in vmwarerest.conf")
             return None
@@ -62,7 +68,7 @@ class VMwareREST(Machinery):
         vmmoid = self.get_vmmoid(id)
         if vmmoid:
             status = s.put(
-                f"https://{self.host}:{self.port}/api/vms/{vmmoid}",
+                f"{self.api_url}/vms/{vmmoid}",
                 data=json.dumps({}),
                 auth=(self.username, self.password),
             )
@@ -75,7 +81,7 @@ class VMwareREST(Machinery):
         vmmoid = self.get_vmmoid(id)
         if vmmoid:
             return s.get(
-                f"https://{self.host}:{self.port}/api/vms/{vmmoid}",
+                f"{self.api_url}/vms/{vmmoid}",
                 auth=(self.username, self.password),
             )
 
@@ -86,7 +92,7 @@ class VMwareREST(Machinery):
         if vmmoid:
             log.info("Powering on vm %s", id)
             status = s.put(
-                f"https://{self.host}:{self.port}/api/vms/{vmmoid}/power",
+                f"{self.api_url}/vms/{vmmoid}/power",
                 auth=(self.username, self.password),
                 data="on",
                 headers={"content-type": "application/vnd.vmware.vmw.rest-v1+json"},
@@ -102,7 +108,7 @@ class VMwareREST(Machinery):
         if vmmoid:
             log.info("Powering off vm %s", id)
             return s.put(
-                f"https://{self.host}:{self.port}/api/vms/{vmmoid}/power",
+                f"{self.api_url}/vms/{vmmoid}/power",
                 auth=(self.username, self.password),
                 data="off",
                 headers={"content-type": "application/vnd.vmware.vmw.rest-v1+json"},
@@ -113,7 +119,7 @@ class VMwareREST(Machinery):
         vmmoid = self.get_vmmoid(id)
         if vmmoid:
             return s.get(
-                f"https://{self.host}:{self.port}/api/vms/{vmmoid}/power",
+                f"{self.api_url}/vms/{vmmoid}/power",
                 auth=(self.username, self.password),
             )
 

--- a/modules/machinery/vmwarerest.py
+++ b/modules/machinery/vmwarerest.py
@@ -1,6 +1,7 @@
 import json
 import logging
 
+import os
 import requests
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
 
@@ -120,7 +121,8 @@ class VMwareREST(Machinery):
         vms = self.get_vms()
         if vms:
             for vm in vms:
-                if vm["path"].endswith(f"{id}.vmx"):
+                vmx_filename = os.path.basename(vm["path"].replace("\\", os.sep))
+                if vmx_filename == f"{id}.vmx":
                     return vm["id"]
         raise CuckooMachineError("There was a problem getting vmmoid for vm %s", id)
 

--- a/modules/machinery/vmwarerest.py
+++ b/modules/machinery/vmwarerest.py
@@ -64,29 +64,6 @@ class VMwareREST(Machinery):
                     return vm["id"]
         log.info("There was a problem getting vmmoid for vm %s", id)
 
-    def set_vm_settings(self, id):
-        vmmoid = self.get_vmmoid(id)
-        if vmmoid:
-            status = s.put(
-                f"{self.api_url}/vms/{vmmoid}",
-                data=json.dumps({}),
-                auth=(self.username, self.password),
-            )
-            if "Authentication failed" in status.text:
-                log.info("Authentication failed, please check credentials in vmwarerest.conf")
-                return None
-        log.info("There was a problem setting settings for vm %s", id)
-
-    def get_vm_settings(self, id):
-        vmmoid = self.get_vmmoid(id)
-        if vmmoid:
-            return s.get(
-                f"{self.api_url}/vms/{vmmoid}",
-                auth=(self.username, self.password),
-            )
-
-        log.info("There was a problem getting settings for vm %s", id)
-
     def poweron_vm(self, id):
         vmmoid = self.get_vmmoid(id)
         if vmmoid:
@@ -134,10 +111,6 @@ class VMwareREST(Machinery):
         if self._is_running(id):
             log.info("Stopping vm %s", id)
             self.poweroff_vm(id)
-
-    def _revert(self, id, snapshot):
-        log.info("Revert snapshot for vm %s: %s", id, snapshot)
-        self.poweroff_vm(id)
 
     def _is_running(self, id):
         log.info("Checking vm %s", id)

--- a/modules/machinery/vmwarerest.py
+++ b/modules/machinery/vmwarerest.py
@@ -49,12 +49,72 @@ class VMwareREST(Machinery):
 
         log.info("VMwareREST machinery module initialised (%s:%s)", self.host, self.port)
 
+    def check_response(self, response):
+        if response.status_code == 200:
+            return response.json()
+        elif response.status_code == 400:
+            raise CuckooMachineError("VMwareREST: Invalid parameters")
+        elif response.status_code == 401:
+            raise CuckooMachineError("VMwareREST: Authentication failed, please check credentials in vmwarerest.conf")
+        elif response.status_code == 403:
+            raise CuckooMachineError("VMwareREST: Permission denied")
+        elif response.status_code == 404:
+            raise CuckooMachineError("VMwareREST: No such resource")
+        elif response.status_code == 406:
+            raise CuckooMachineError("VMwareREST: Content type was not supported")
+        elif response.status_code == 409:
+            raise CuckooMachineError("VMwareREST: Resource state conflicts")
+        elif response.status_code == 500:
+            raise CuckooMachineError("VMwareREST: Server error")
+        else:
+            raise CuckooMachineError("VMwareREST: Unexpected error")
+
     def get_vms(self):
-        vms = s.get(f"{self.api_url}/vms", auth=(self.username, self.password))
-        if "Authentication failed" in vms.text:
-            log.info("Authentication failed, please check credentials in vmwarerest.conf")
-            return None
-        return vms.json()
+        """Returns a list of VM IDs and paths for all VMs."""
+        try:
+            response = s.get(
+                f"{self.api_url}/vms",
+                auth=(self.username, self.password),
+                headers={
+                    "Accept": "application/vnd.vmware.vmw.rest-v1+json"
+                },
+            )
+        except Exception:
+            raise CuckooMachineError(f"VMwareREST: Couldn't connect to vmrest server.")
+
+        return self.check_response(response)
+
+    def get_power(self, vmmoid):
+        """Returns the power state of the VM."""
+        try:
+            response = s.get(
+                f"{self.api_url}/vms/{vmmoid}/power",
+                auth=(self.username, self.password),
+                headers={
+                    "Accept": "application/vnd.vmware.vmw.rest-v1+json"
+                },
+            )
+        except Exception:
+            raise CuckooMachineError(f"VMwareREST: Couldn't connect to vmrest server.")
+
+        return self.check_response(response)
+
+    def change_power_state(self, vmmoid, operation):
+        """Changes the VM power state."""
+        try:
+            response = s.put(
+                f"{self.api_url}/vms/{vmmoid}/power",
+                auth=(self.username, self.password),
+                data=operation,
+                headers={
+                    "Content-Type": "application/vnd.vmware.vmw.rest-v1+json",
+                    "Accept": "application/vnd.vmware.vmw.rest-v1+json",
+                },
+            )
+        except Exception:
+            raise CuckooMachineError(f"VMwareREST: Couldn't connect to vmrest server.")
+
+        return self.check_response(response)
 
     def get_vmmoid(self, id):
         vms = self.get_vms()
@@ -62,45 +122,27 @@ class VMwareREST(Machinery):
             for vm in vms:
                 if vm["path"].endswith(f"{id}.vmx"):
                     return vm["id"]
-        log.info("There was a problem getting vmmoid for vm %s", id)
+        raise CuckooMachineError("There was a problem getting vmmoid for vm %s", id)
 
     def poweron_vm(self, id):
         vmmoid = self.get_vmmoid(id)
         if vmmoid:
             log.info("Powering on vm %s", id)
-            status = s.put(
-                f"{self.api_url}/vms/{vmmoid}/power",
-                auth=(self.username, self.password),
-                data="on",
-                headers={"content-type": "application/vnd.vmware.vmw.rest-v1+json"},
-            )
-            if "Authentication failed" in status.text:
-                log.info("Authentication failed, please check credentials in vmwarerest.conf")
-                return None
-            return status
-        log.info("There was a problem powering on vm %s", id)
+            return self.change_power_state(vmmoid, "on")
+        raise CuckooMachineError("There was a problem powering on vm %s", id)
 
     def poweroff_vm(self, id):
         vmmoid = self.get_vmmoid(id)
         if vmmoid:
             log.info("Powering off vm %s", id)
-            return s.put(
-                f"{self.api_url}/vms/{vmmoid}/power",
-                auth=(self.username, self.password),
-                data="off",
-                headers={"content-type": "application/vnd.vmware.vmw.rest-v1+json"},
-            )
-        log.info("There was a problem powering off vm %s", id)
+            return self.change_power_state(vmmoid, "off")
+        raise CuckooMachineError("There was a problem powering off vm %s", id)
 
     def get_power_for_vm(self, id):
         vmmoid = self.get_vmmoid(id)
         if vmmoid:
-            return s.get(
-                f"{self.api_url}/vms/{vmmoid}/power",
-                auth=(self.username, self.password),
-            )
-
-        log.info("There was a problem querying power status for vm %s", id)
+            return self.get_power(vmmoid)
+        raise CuckooMachineError("There was a problem querying power status for vm %s", id)
 
     def start(self, id):
         log.info("Starting vm %s", id)
@@ -116,8 +158,9 @@ class VMwareREST(Machinery):
         log.info("Checking vm %s", id)
         power_state = self.get_power_for_vm(id)
 
-        if power_state and "poweredOn" in power_state.text:
+        if power_state["power_state"] == "poweredOn":
             log.info("Vm %s is running", id)
-            return id
+            return True
         else:
             log.info("Vm %s is not running", id)
+            return False

--- a/modules/machinery/vmwarerest.py
+++ b/modules/machinery/vmwarerest.py
@@ -1,4 +1,3 @@
-import json
 import logging
 
 import os
@@ -81,7 +80,7 @@ class VMwareREST(Machinery):
                 },
             )
         except Exception:
-            raise CuckooMachineError(f"VMwareREST: Couldn't connect to vmrest server.")
+            raise CuckooMachineError("VMwareREST: Couldn't connect to vmrest server.")
 
         return self.check_response(response)
 
@@ -96,7 +95,7 @@ class VMwareREST(Machinery):
                 },
             )
         except Exception:
-            raise CuckooMachineError(f"VMwareREST: Couldn't connect to vmrest server.")
+            raise CuckooMachineError("VMwareREST: Couldn't connect to vmrest server.")
 
         return self.check_response(response)
 
@@ -113,7 +112,7 @@ class VMwareREST(Machinery):
                 },
             )
         except Exception:
-            raise CuckooMachineError(f"VMwareREST: Couldn't connect to vmrest server.")
+            raise CuckooMachineError("VMwareREST: Couldn't connect to vmrest server.")
 
         return self.check_response(response)
 


### PR DESCRIPTION
The following items have been updated.
- Added default configuration file.
- Added HTTP/HTTPS toggle feature for the REST API.
- Updated error handling.
- Fixed an issue where a VM other than the specified one would start if a similarly named VM exists.

References:
- https://docs.vmware.com/jp/VMware-Workstation-Pro/17/com.vmware.ws.using.doc/GUID-9FAAA4DD-1320-450D-B684-2845B311640F.html
- https://developer.broadcom.com/xapis/vmware-workstation-pro-api/latest/
- https://github.com/ctxis/CAPE/blob/master/conf/vmwarerest.conf
- https://capev2.readthedocs.io/en/latest/customization/machinery.html