### PR TITLE
AzSniffer module

### DIFF
--- a/conf/default/auxiliary.conf.default
+++ b/conf/default/auxiliary.conf.default
@@ -41,6 +41,10 @@ filecollector = yes
 # This is only useful in case you use KVM's dnsmasq. You need to change your range inside of analyzer/windows/modules/auxiliary/disguise.py. Disguise must be enabled
 windows_static_route = no
 
+[AzSniffer]
+# Enable or disable the use of Azure Network Watcher packet capture feature, disable standard sniffer if this is in use to not create concurrent .pcap files
+enabled = no
+
 [sniffer]
 # Enable or disable the use of an external sniffer (tcpdump) [yes/no].
 enabled = yes

--- a/conf/default/az.conf.default
+++ b/conf/default/az.conf.default
@@ -9,6 +9,19 @@ region_name = <region_name>
 vnet_resource_group = <resource_group>
 sandbox_resource_group = <resource_group>
 
+#Sniffer configurations
+# New sniffer logic implementing Azure Watchers packet capture with either local or blob storage file locations 
+# the configurations for AzSniffer module will be used to create the dump.pcap file needed for network analysis when using Azure VMSS for Guest VMs
+resource_group = 
+#Storage account where the .cap  file will be placed by the Azure Packet Capture, soon the local file path logic will be implemented too 
+storage_account = 
+vmss_name = 
+#location of the network watcher (region name)
+location =  
+tenant_id = 
+client_secret = 
+connection_string =
+
 # Subscription ID for Azure
 subscription_id = <subscription_id>
 

--- a/modules/auxiliary/AzSniffer.py
+++ b/modules/auxiliary/AzSniffer.py
@@ -1,0 +1,197 @@
+import logging
+import os
+import json
+from urllib.parse import urlparse
+import subprocess
+try:
+    from azure.identity import ClientSecretCredential
+    from azure.mgmt.network import NetworkManagementClient
+    from azure.mgmt.network.models import PacketCapture, PacketCaptureStorageLocation
+    from azure.mgmt.storage import StorageManagementClient
+    from azure.storage.blob import BlobServiceClient
+    from azure.core.exceptions import AzureError, HttpResponseError
+
+    HAVE_AZURE = True
+except ImportError:
+    HAVE_AZURE = False
+    print("Missing machinery-required libraries.")
+    print("poetry run python -m pip install azure-identity msrest msrestazure azure-mgmt-compute azure-mgmt-network azure-mgmt-storage azure-storage-blob")
+
+from lib.cuckoo.common.abstracts import Auxiliary
+from lib.cuckoo.common.config import Config
+from lib.cuckoo.common.constants import CUCKOO_ROOT
+
+log = logging.getLogger(__name__)
+
+class AzSniffer(Auxiliary):
+    def __init__(self):
+        super().__init__()
+        self.cfg = Config("az")
+        self.az_config = self.cfg.get("az")
+        self.capture_name = None
+        self.resource_group = self.az_config.resource_group
+        self.storage_account = self.az_config.storage_account
+        self.vmss_name = self.az_config.vmss_name
+        self.location = self.az_config.location
+        self.subscription_id = self.az_config.subscription_id
+        self.connection_string = self._clean_connection_string(self.az_config.connection_string)
+        self.tenant_id = self.az_config.tenant_id
+        self.client_id = self.az_config.client_id
+        self.client_secret = self.az_config.client_secret
+
+        self.credentials = self._get_credentials()
+        self.network_client = NetworkManagementClient(self.credentials, self.subscription_id)
+        self.storage_client = StorageManagementClient(self.credentials, self.subscription_id)
+        self.blob_service_client = BlobServiceClient.from_connection_string(self.connection_string)
+        self.blob_url = None
+    
+    def _clean_connection_string(self, connection_string):
+        return connection_string.strip('"')
+
+    def _get_credentials(self):
+        return ClientSecretCredential(
+            tenant_id=self.tenant_id,
+            client_id=self.client_id,
+            client_secret=self.client_secret
+        )
+    
+    def start(self):
+        self.capture_name = f"PacketCapture_{self.task.id}"
+        custom_filters = []
+        self.create_packet_capture(custom_filters)
+
+    def create_packet_capture(self, custom_filters):
+        storage_location = PacketCaptureStorageLocation(
+            storage_id=f"/subscriptions/{self.subscription_id}/resourceGroups/{self.resource_group}/providers/Microsoft.Storage/storageAccounts/{self.storage_account}",
+            storage_path=f"https://{self.storage_account}.blob.core.windows.net/network-watcher-logs/{self.capture_name}.cap"
+        )
+
+        packet_capture = PacketCapture(
+            target=f"/subscriptions/{self.subscription_id}/resourceGroups/{self.resource_group}/providers/Microsoft.Compute/virtualMachineScaleSets/{self.vmss_name}",
+            storage_location=storage_location,
+            time_limit_in_seconds=18000,
+            total_bytes_per_session=1073741824,
+            filters=custom_filters
+        )
+
+        try:
+            poller = self.network_client.packet_captures.begin_create(
+                resource_group_name=self.resource_group,
+                network_watcher_name=f"NetworkWatcher_{self.location}",
+                packet_capture_name=self.capture_name,
+                parameters=packet_capture
+            )
+            result = poller.result()
+
+            self.blob_url = result.storage_location.storage_path
+            log.info(f"Started Azure Network Watcher packet capture: {self.capture_name}")
+            log.debug(f"Blob URL for packet capture: {self.blob_url}")
+        except AzureError as e:
+            log.error(f"Azure error occurred while creating packet capture: {str(e)}")
+            raise
+        except Exception as e:
+            log.error(f"Unexpected error occurred while creating packet capture: {str(e)}")
+            raise
+
+    def stop(self):
+        if not self.capture_name:
+            log.error("No packet capture to stop")
+            return
+
+        self.stop_packet_capture()
+        self.download_packet_capture()
+        self.delete_packet_capture()
+
+    def stop_packet_capture(self):
+        try:
+            poller = self.network_client.packet_captures.begin_stop(
+                resource_group_name=self.resource_group,
+                network_watcher_name=f"NetworkWatcher_{self.location}",
+                packet_capture_name=self.capture_name
+            )
+            poller.result()
+            log.info(f"Stopped Azure Network Watcher packet capture: {self.capture_name}")
+        except AzureError as e:
+            log.error(f"Azure error occurred while stopping packet capture: {str(e)}")
+        except Exception as e:
+            log.error(f"Unexpected error occurred while stopping packet capture: {str(e)}")
+
+    def download_packet_capture(self):
+        if not self.blob_url:
+            log.error("No blob URL available for download")
+            return
+
+        primary_output_dir = f"/opt/CAPEv2/storage/analyses/{self.task.id}"
+        primary_output_file = os.path.join(primary_output_dir, "dump.cap")
+        fallback_output_file = f"/tmp/dump_task_{self.task.id}.cap"
+
+        try:
+            parsed_url = urlparse(self.blob_url)
+            container_name = parsed_url.path.split('/')[1]
+            blob_name = '/'.join(parsed_url.path.split('/')[2:]).strip('"')
+
+            blob_client = self.blob_service_client.get_blob_client(container=container_name, blob=blob_name)
+
+            self._download_to_file(blob_client, primary_output_file)
+            log.info(f"Downloaded packet capture for task {self.task.id} to {primary_output_file}")
+            self.convert_cap_to_pcap(primary_output_file)
+        except AzureError as e:
+            log.error(f"Azure error occurred while downloading packet capture: {str(e)}")
+            self._try_fallback_download(blob_client, fallback_output_file)
+        except Exception as e:
+            log.error(f"Unexpected error occurred while downloading packet capture: {str(e)}")
+            self._try_fallback_download(blob_client, fallback_output_file)
+
+    def _try_fallback_download(self, blob_client, fallback_output_file):
+        try:
+            self._download_to_file(blob_client, fallback_output_file)
+            log.info(f"Downloaded packet capture for task {self.task.id} to fallback location {fallback_output_file}")
+            self.convert_cap_to_pcap(fallback_output_file)
+        except Exception as e:
+            log.error(f"Failed to download packet capture to fallback location: {str(e)}")
+
+    def _download_to_file(self, blob_client, output_file):
+        os.makedirs(os.path.dirname(output_file), exist_ok=True)
+        with open(output_file, "wb") as file:
+            download_stream = blob_client.download_blob()
+            file.write(download_stream.readall())
+
+
+    def convert_cap_to_pcap(self, cap_file_path):
+        output_dir = f"/opt/CAPEv2/storage/analyses/{self.task.id}"
+        pcap_file_path = os.path.join(output_dir, "dump.pcap")
+        convert_cmd = ["editcap", "-F", "pcap", cap_file_path, pcap_file_path]
+        
+        try:
+            os.makedirs(output_dir, exist_ok=True)
+            subprocess.run(convert_cmd, check=True, capture_output=True, text=True)
+            log.info(f"Converted .cap file to .pcap: {pcap_file_path}")
+            os.remove(cap_file_path)  # Remove the original .cap file
+        except subprocess.CalledProcessError as e:
+            log.error(f"Failed to convert .cap file to .pcap: {e.stderr}")
+        except OSError as e:
+            log.error(f"Failed to create directory or remove .cap file: {e}")
+
+    def delete_packet_capture(self):
+        try:
+            poller = self.network_client.packet_captures.begin_delete(
+                resource_group_name=self.resource_group,
+                network_watcher_name=f"NetworkWatcher_{self.location}",
+                packet_capture_name=self.capture_name
+            )
+            poller.result()
+            log.info(f"Deleted Azure Network Watcher packet capture: {self.capture_name}")
+        except AzureError as e:
+            log.error(f"Azure error occurred while deleting packet capture: {str(e)}")
+        except Exception as e:
+            log.error(f"Unexpected error occurred while deleting packet capture: {str(e)}")
+
+
+    def set_task(self, task):
+        self.task = task
+
+    def set_machine(self, machine):
+        self.machine = machine
+
+    def set_options(self, options):
+        self.options = options


### PR DESCRIPTION
# Description:
Following https://github.com/kevoreilly/CAPEv2/issues/2209 issue.
Currently, the CAPE Sandbox doesn't utilize Azure Network Watchers to sniff traffic. To enhance the functionality and monitoring capabilities, I implemented Azure Network Watchers. This required me to update the configuration settings and ensuring the necessary resources are available in Azure. The proposed changes are described below.

## Code details
The auxiliary module AzSniffer.py has been developed to handle packet captures using Azure Network Watchers. Below are the key components and functionalities of the module :


### Initialization
- Imports necessary Azure libraries and modules.
- Sets up logging and configuration reading.
- Initializes credentials and Azure management clients for network and storage operations.

### `az.conf` configurations added
```
# Sniffer configurations
resource_group = 
storage_account =  # where the blob of the capture is created
vmss_name = 
location = 
tenant_id = 
client_secret = 
connection_string =  # blob connection string
```

### Packet Capture Operations
- Starts and stops packet capture using Azure Network Watcher.
- Downloads and converts packet captures from .cap to .pcap format.
- Handles error logging and fallback mechanisms for download operations.

### Functionality
- Uses ClientSecretCredential for authentication.
- Manages packet capture lifecycle: creation, stopping, downloading, and deletion.
- Converts captured files and stores them appropriately.

### Additional Requirements
- Azure Network Watcher must be configured to work with stored captures.
- A storage account with blob capabilities must be added.

### Future Enhancements:
I am also working on adding the capability to store the capture files directly inside the guest VM instead of using a blob container. This will provide more flexibility in how captures are stored and managed.