### PR TITLE
Make lists in extracted configs not extend outside of the table cell.

### DIFF
--- a/web/analysis/templatetags/analysis_tags.py
+++ b/web/analysis/templatetags/analysis_tags.py
@@ -242,7 +242,7 @@ def malware_config(obj, *args, **kwargs):
             else:
                 result.write(malware_config(obj[0]))
     else:
-        result.write('<pre style="margin: 0">' + escape(str(obj)) + "</pre>")
+        result.write(escape(str(obj)))
 
     ret_result = result.getvalue()
     result.close()

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -296,6 +296,11 @@ pre {
     word-wrap: break-word;
 }
 
+.extracted-config > table > tbody > tr > td {
+    font-family: monospace;
+    font-size: 87.5%;
+}
+
 .tcp-flow {
     list-style-type: none;
 }

--- a/web/templates/analysis/overview/index.html
+++ b/web/templates/analysis/overview/index.html
@@ -11,7 +11,7 @@
                         <a class="btn btn-secondary btn-sm" href="{% url "filereport" analysis.info.id "cents" %}"><span class="fas fa-download"></span> CENTS ruleset</a>
                     {% endif %}
                 </div>
-                <div id="{{family}}_config" class="collapse show">
+                <div id="{{family}}_config" class="collapse show extracted-config">
                     <table class="table table-striped table-bordered" style="table-layout: fixed;">
                         <thead>
                             <tr>


### PR DESCRIPTION
Using the `<pre>` tag caused lists larger than 4 items to extend to the right outside of the extracted config table. This change fixes that, while maintaining the size & font that was being used previously.