### PR TITLE
chore: Update doc references

### DIFF
--- a/lib/cuckoo/common/integrations/virustotal.py
+++ b/lib/cuckoo/common/integrations/virustotal.py
@@ -183,7 +183,7 @@ def get_vt_consensus(namelist: list):
     return ""
 
 
-# https://developers.virustotal.com/v3.0/reference#file-info
+# https://docs.virustotal.com/reference/files
 def vt_lookup(category: str, target: str, results: dict = {}, on_demand: bool = False):
     if not processing_conf.virustotal.enabled or processing_conf.virustotal.get("on_demand", False) and not on_demand:
         return {}


### PR DESCRIPTION
We are updating the references to VirusTotal documentation from the old documentation to the current one in order to keep it updated.