### PR TITLE
Avoid unicorn exit in Emotet.py

### DIFF
--- a/modules/processing/parsers/CAPE/Emotet.py
+++ b/modules/processing/parsers/CAPE/Emotet.py
@@ -251,6 +251,26 @@ def emulate(code, ep):
     return uc
 
 
+def have_enough_memory_for_unicorn():
+    """
+    Avoid unicorn calling exit(1) due to memory leak.
+    - https://github.com/unicorn-engine/unicorn/issues/1766
+    - https://github.com/unicorn-engine/unicorn/pull/1629
+    """
+    try:
+        from mmap import mmap, MAP_ANON, MAP_PRIVATE, PROT_EXEC, PROT_READ, PROT_WRITE
+
+        mm = mmap(
+            -1,
+            1024 * 1024 * 1024,
+            MAP_PRIVATE | MAP_ANON, PROT_WRITE | PROT_READ | PROT_EXEC,
+        )
+        mm.close()
+        return True
+    except OSError:
+        return False
+
+
 def extract_config(filebuf):
     conf_dict = {}
     pe = None
@@ -550,6 +570,9 @@ def extract_config(filebuf):
             offset += 8
     elif c2_funcs:
         for address in c2_funcs:
+            if not have_enough_memory_for_unicorn():
+                log.warning("not enough memory for unicorn")
+                continue
             uc = emulate(code, address - pe.sections[0].PointerToRawData)
             c2_address = socket.inet_ntoa(struct.pack("!L", int.from_bytes(uc.mem_read(stack + 0x104, 4), byteorder="big")))
             flag = str(int.from_bytes(uc.mem_read(stack + 0x108, 2), byteorder="little"))


### PR DESCRIPTION
Context:

- https://github.com/unicorn-engine/unicorn/issues/1766
- https://github.com/unicorn-engine/unicorn/pull/1629

It seems like will be fixed in unicorn 2.1