### PR TITLE
Updates to detect-it-easy handling.

### DIFF
--- a/conf/default/processing.conf.default
+++ b/conf/default/processing.conf.default
@@ -142,7 +142,6 @@ definitions = data/trid/triddefs.trd
 [die]
 # Detect it Easy
 enabled = no
-binary = /usr/bin/diec
 
 [virustotal]
 enabled = yes

--- a/lib/cuckoo/common/integrations/file_extra_info.py
+++ b/lib/cuckoo/common/integrations/file_extra_info.py
@@ -264,9 +264,6 @@ def static_file_info(
 
 
 def detect_it_easy_info(file_path: str):
-    if not path_exists(processing_conf.die.binary):
-        return []
-
     try:
         try:
             result_json = die.scan_file(file_path, die.ScanFlags.RESULT_AS_JSON, str(die.database_path / "db"))
@@ -347,7 +344,7 @@ def _extracted_files_metadata(
             if processing_conf.trid.enabled:
                 file_info["trid"] = trid_info(full_path)
 
-            if processing_conf.die.enabled:
+            if processing_conf.die.enabled and HAVE_DIE:
                 file_info["die"] = detect_it_easy_info(full_path)
 
             dest_path = os.path.join(destination_folder, file_info["sha256"])


### PR DESCRIPTION
Don't require the diec binary to exist since we're now using the python bindings.