### PR TITLE
feat: Add check_shellcode to options, to provide an option to turn it off

### DIFF
--- a/docs/book/src/usage/submit.rst
+++ b/docs/book/src/usage/submit.rst
@@ -165,6 +165,7 @@ some options (in this case a command line argument for the malware)::
 - ``pre_script_timeout``: pre_script_timeout will default to 60 seconds. Script will stop after timeout Example: pre_script_timeout=30
 - ``during_script_args``: Command line arguments for during_script. Example: during_script_args=file1 file2 file3
 - ``pwsh``: - for ps1 package: prefer PowerShell Core, if available in the vm
+- ``check_shellcode``: - Setting check_shellcode=0 will disable checking for shellcode during package identification and extracting from archive
 
 .. _webpy:
 

--- a/lib/cuckoo/common/demux.py
+++ b/lib/cuckoo/common/demux.py
@@ -191,7 +191,7 @@ def _sf_children(child: sfFile) -> bytes:
     return path_to_extract.encode()
 
 
-def demux_sflock(filename: bytes, options: str) -> List[bytes]:
+def demux_sflock(filename: bytes, options: str, check_shellcode: bool = True) -> List[bytes]:
     retlist = []
     # do not extract from .bin (downloaded from us)
     if os.path.splitext(filename)[1] == b".bin":
@@ -200,7 +200,7 @@ def demux_sflock(filename: bytes, options: str) -> List[bytes]:
     try:
         password = options2passwd(options) or "infected"
         try:
-            unpacked = unpack(filename, password=password, check_shellcode=True)
+            unpacked = unpack(filename, password=password, check_shellcode=check_shellcode)
         except UnpackException:
             unpacked = unpack(filename, check_shellcode=True)
 
@@ -286,8 +286,13 @@ def demux_sample(filename: bytes, package: str, options: str, use_sflock: bool =
         return retlist
 
     new_retlist = []
+
+    check_shellcode = True
+    if options and "check_shellcode=0" in options:
+        check_shellcode = False
+
     # all in one unarchiver
-    retlist = demux_sflock(filename, options) if HAS_SFLOCK and use_sflock else []
+    retlist = demux_sflock(filename, options, check_shellcode) if HAS_SFLOCK and use_sflock else []
     # if it isn't a ZIP or an email, or we aren't able to obtain anything interesting from either, then just submit the
     # original file
     if not retlist:

--- a/web/templates/submission/index.html
+++ b/web/templates/submission/index.html
@@ -529,6 +529,10 @@ $(document).ready( function() {
                                                     <td><code>unpacker</code></td>
                                                     <td>Ex: unpacker=2 - Add description here</td>
                                                 </tr>
+                                                <tr>
+                                                    <td><code>check_shellcode</code></td>
+                                                    <td>Setting check_shellcode=0 will disable checking for shellcode during package identification and extracting from archive</td>
+                                                </tr>
                                             </tbody>
                                         </table>
                                     </div>


### PR DESCRIPTION
Related to this issue: https://github.com/kevoreilly/CAPEv2/issues/2237

I added `check_shellcode` to the submission options, and wrote a description of what it does

If there is a better way to pass this parameter, please let me know and I will implement it accordingly.

Thanks 