### PR TITLE
Bring Azure machinery auto-scaling up to date.

### DIFF
--- a/conf/default/az.conf.default
+++ b/conf/default/az.conf.default
@@ -59,6 +59,11 @@ total_machines_limit = 50
 # Specify the machine's instance type(for example, Standard_F2s_v2, Standard_DS3_v2)
 instance_type = <instance_type>
 
+# Determines which type of ephemeral os disk to use. Be sure to research which machine supports which type and at what sizes.
+# Possible values are CacheDisk, ResourceDisk, and NvmeDisk. Defaults to CacheDisk
+# https://learn.microsoft.com/en-us/rest/api/compute/virtual-machines/list?view=rest-compute-2024-03-02&tabs=HTTP#diffdisksettings
+ephemeral_os_disk_placement =
+
 # This boolean flag is used to indicate if we want to programmatically determine how many cores are used
 # per VM of the instance_type mentioned above.
 # NOTE: If enabled, this is a long call that takes ~ 1 minute to complete. It takes place at
@@ -101,6 +106,9 @@ overprovision = 0
 # This time, in seconds, is used to build up a queue of machines that need to be reimaged,
 # such that we can perform bulk reimaging.
 wait_time_to_reimage = 4
+
+# This time, in seconds, is the wait between checking if VMSSs should be scaled up/down.
+monitor_rate = 300
 
 # This boolean value is used to indicate if we want to use Azure Spot instances rather than
 # normal instances

--- a/lib/cuckoo/core/guest.py
+++ b/lib/cuckoo/core/guest.py
@@ -393,7 +393,7 @@ class GuestManager:
 
             if status["status"] in ("complete", "failed"):
                 completed_as = "completed successfully" if status["status"] == "complete" else "failed"
-                log.info("Task #%s: Analysis %s (id=%s, ip=%s)", completed_as, self.task_id, self.vmid, self.ipaddr)
+                log.info("Task #%s: Analysis %s (id=%s, ip=%s)", self.task_id, completed_as, self.vmid, self.ipaddr)
                 self.set_status_in_db("complete")
                 return
             elif status["status"] == "exception":

--- a/lib/cuckoo/core/machinery_manager.py
+++ b/lib/cuckoo/core/machinery_manager.py
@@ -149,6 +149,7 @@ class MachineryManager:
         self.machinery_name: str = self.cfg.cuckoo.machinery
         self.machinery: Machinery = self.create_machinery()
         self.pool_scaling_lock = threading.Lock()
+        self.machines_limit: Optional[int] = None
         if self.machinery.module_name != self.machinery_name:
             raise CuckooCriticalError(
                 f"Incorrect machinery module was imported. "
@@ -179,15 +180,14 @@ class MachineryManager:
             # If the user wants to use the scaling bounded semaphore, check what machinery is specified, and then
             # grab the required configuration key for setting the upper limit
             machinery_opts = self.machinery.options.get(self.machinery_name)
-            machines_limit: int = 0
             if self.machinery_name == "az":
-                machines_limit = machinery_opts.get("total_machines_limit")
+                self.machines_limit = machinery_opts.get("total_machines_limit")
             elif self.machinery_name == "aws":
-                machines_limit = machinery_opts.get("dynamic_machines_limit")
-            if machines_limit:
+                self.machines_limit = machinery_opts.get("dynamic_machines_limit")
+            if self.machines_limit:
                 # The ScalingBoundedSemaphore is used to keep feeding available machines from the pending tasks queue
-                log.info("upper limit for ScalingBoundedSemaphore = %d", machines_limit)
-                retval = ScalingBoundedSemaphore(value=len(self.machinery.machines()), upper_limit=machines_limit)
+                log.info("upper limit for ScalingBoundedSemaphore = %d", self.machines_limit)
+                retval = ScalingBoundedSemaphore(value=len(self.machinery.machines()), upper_limit=self.machines_limit)
             else:
                 log.warning(
                     "scaling_semaphore is set but the %s machinery does not set the machines limit. Ignoring scaling semaphore.",
@@ -295,6 +295,12 @@ class MachineryManager:
             self.machinery.scale_pool(machine)
 
     def start_machine(self, machine: Machine) -> None:
+        if (
+            isinstance(self.machine_lock, ScalingBoundedSemaphore)
+            and self.db.count_machines_running <= self.machines_limit
+            and self.machine_lock._value == 0
+        ):
+            self.machine_lock.release()
         with self.machine_lock:
             self.machinery.start(machine.label)
 

--- a/lib/cuckoo/core/machinery_manager.py
+++ b/lib/cuckoo/core/machinery_manager.py
@@ -297,7 +297,7 @@ class MachineryManager:
     def start_machine(self, machine: Machine) -> None:
         if (
             isinstance(self.machine_lock, ScalingBoundedSemaphore)
-            and self.db.count_machines_running <= self.machines_limit
+            and self.db.count_machines_running() <= self.machines_limit
             and self.machine_lock._value == 0
         ):
             self.machine_lock.release()

--- a/modules/machinery/az.py
+++ b/modules/machinery/az.py
@@ -104,6 +104,15 @@ class Azure(Machinery):
     WINDOWS_PLATFORM = "windows"
     LINUX_PLATFORM = "linux"
 
+    def set_options(self, options: dict) -> None:
+        """Set machine manager options.
+        @param options: machine manager options dict.
+        """
+        self.options = options
+        mmanager_opts = self.options.get(self.module_name)
+        if not isinstance(mmanager_opts["scale_sets"], list):
+            mmanager_opts["scale_sets"] = str(mmanager_opts["scale_sets"]).strip().split(",")
+
     def _initialize(self):
         """
         Overloading abstracts.py:_initialize()
@@ -111,10 +120,6 @@ class Azure(Machinery):
         @param module_name: module name
         @raise CuckooDependencyError: if there is a problem with the dependencies call
         """
-        mmanager_opts = self.options.get(self.module_name)
-        if not isinstance(mmanager_opts["scale_sets"], list):
-            mmanager_opts["scale_sets"] = mmanager_opts["scale_sets"].strip().split(",")
-
         # Replace a list of IDs with dictionary representations
         scale_sets = mmanager_opts.pop("scale_sets")
         mmanager_opts["scale_sets"] = {}

--- a/modules/machinery/az.py
+++ b/modules/machinery/az.py
@@ -466,8 +466,9 @@ class Azure(Machinery):
                 time.sleep(5)
                 with reimage_lock:
                     label_in_reimage_vm_list = label in [f"{vm['vmss']}_{vm['id']}" for vm in reimage_vm_list]
-        else:
-            self.delete_machine(label)
+        # TODO: Find a way to enable machine deletion here without causing a sqlalchemy.orm.exc.StaleDataError
+        # else:
+        #     self.delete_machine(label)
 
     def availables(self, label=None, platform=None, tags=None, arch=None, include_reserved=False, os_version=[]):
         """

--- a/modules/machinery/az.py
+++ b/modules/machinery/az.py
@@ -238,7 +238,7 @@ class Azure(Machinery):
                 threading.Thread(target=self._thr_scale_machine_pool, args=(vals["tag"],)).start()
 
         # Check the machine pools every 5 minutes
-        threading.Timer(300, self._thr_machine_pool_monitor).start()
+        threading.Timer(self.options.az.monitor_rate, self._thr_machine_pool_monitor).start()
 
     def _set_vmss_stage(self):
         """
@@ -716,7 +716,10 @@ class Azure(Machinery):
             managed_disk=vmss_managed_disk,
             # Ephemeral disk time
             caching="ReadOnly",
-            diff_disk_settings=models.DiffDiskSettings(option="Local"),
+            diff_disk_settings=models.DiffDiskSettings(
+                option="Local",
+                placement=self.options.az.ephemeral_os_disk_placement
+            ),
         )
         vmss_storage_profile = models.VirtualMachineScaleSetStorageProfile(
             image_reference=vmss_image_ref,

--- a/modules/machinery/az.py
+++ b/modules/machinery/az.py
@@ -109,9 +109,6 @@ class Azure(Machinery):
         @param options: machine manager options dict.
         """
         self.options = options
-        mmanager_opts = self.options.get(self.module_name)
-        if not isinstance(mmanager_opts["scale_sets"], list):
-            mmanager_opts["scale_sets"] = str(mmanager_opts["scale_sets"]).strip().split(",")
 
     def _initialize(self):
         """
@@ -120,6 +117,11 @@ class Azure(Machinery):
         @param module_name: module name
         @raise CuckooDependencyError: if there is a problem with the dependencies call
         """
+        # Using "scale_sets" here instead of "machines" to avoid KeyError
+        mmanager_opts = self.options.get(self.module_name)
+        if not isinstance(mmanager_opts["scale_sets"], list):
+            mmanager_opts["scale_sets"] = str(mmanager_opts["scale_sets"]).strip().split(",")
+
         # Replace a list of IDs with dictionary representations
         scale_sets = mmanager_opts.pop("scale_sets")
         mmanager_opts["scale_sets"] = {}

--- a/modules/machinery/az.py
+++ b/modules/machinery/az.py
@@ -1118,7 +1118,7 @@ class Azure(Machinery):
         """
         # The number of relevant machines are those from the list of locked and unlocked machines
         # that have the correct tag in their name
-        return [machine for machine in self.db.list_machines() if tag in machine.label]
+        return [machine for machine in self.db.list_machines([tag])]
 
     @staticmethod
     def _wait_for_concurrent_operations_to_complete():

--- a/web/submission/views.py
+++ b/web/submission/views.py
@@ -537,15 +537,16 @@ def index(request, task_id=None, resubmit_hash=None):
             # load multi machinery tags:
             # Get enabled machinery
             machinery = cfg.cuckoo.get("machinery")
+            machinery_tags = "scale_sets" if machinery == "az" else "machines"
             if machinery == "multi":
                 for mmachinery in Config(machinery).multi.get("machinery").split(","):
-                    vms = [x.strip() for x in getattr(Config(mmachinery), mmachinery).get("machines").split(",") if x.strip()]
+                    vms = [x.strip() for x in getattr(Config(mmachinery), mmachinery).get(machinery_tags).split(",") if x.strip()]
                     if any(["tags" in list(getattr(Config(mmachinery), vmtag).keys()) for vmtag in vms]):
                         enabledconf["tags"] = True
                         break
             else:
                 # Get VM names for machinery config elements
-                vms = [x.strip() for x in str(getattr(Config(machinery), machinery).get("machines")).split(",") if x.strip()]
+                vms = [x.strip() for x in str(getattr(Config(machinery), machinery).get(machinery_tag)).split(",") if x.strip()]
                 # Check each VM config element for tags
                 if any(["tags" in list(getattr(Config(machinery), vmtag).keys()) for vmtag in vms]):
                     enabledconf["tags"] = True

--- a/web/submission/views.py
+++ b/web/submission/views.py
@@ -546,7 +546,7 @@ def index(request, task_id=None, resubmit_hash=None):
                         break
             else:
                 # Get VM names for machinery config elements
-                vms = [x.strip() for x in str(getattr(Config(machinery), machinery).get(machinery_tag)).split(",") if x.strip()]
+                vms = [x.strip() for x in str(getattr(Config(machinery), machinery).get(machinery_tags)).split(",") if x.strip()]
                 # Check each VM config element for tags
                 if any(["tags" in list(getattr(Config(machinery), vmtag).keys()) for vmtag in vms]):
                     enabledconf["tags"] = True


### PR DESCRIPTION
Updated the Azure machinery, specifically with auto-scaling, to a usable state out-of-the-box.

**Updates include**:
- Config key to allow the selection of ephemeral OS disk type, allowing a wider range of Azure VM types to be used.
- Config key to allow changing the timer set for the monitor thread to scale up/down the VMSS.
- Fix for the missing `machines` key in the config, which was leading to errors.
- Change the method of finding "relevant" machines for submitted tasks, allowing more flexibility in naming your VMSS in the config. This removes the need to append the `pool_tag` to the end of the VMSS name.
- Workaround to semaphore deadlocking issues.
- Removal of machine deletion in the `modules/machinery/az.py` method `stop` when the scale-set is set to `is_scaling_down`, which was leading to a `StaleDataError`.
- Tiny, non-critical, update to a log in `lib/cuckoo/core/guest.py` correcting the order of variables.

**Concerns**:
The fix for the `StaleDataError` is not ideal. It means that the process of scaling down when no relevant tasks are available must wait for all current tasks to finish AND for the monitor thread to wake up and run. What would be a much better fix would be to find a way to signal the machine for deletion in az.py immediately after the AnalysisManager releases the machine. Any tips are greatly appreciated on how that might be done. (Edit: This no longer applies. Now correctly deleting machines in such cases.)

If there are any ideas on how to better handle the issue with the semaphore, I would love to better apply a solution there. I am not entirely comfortable with what I have in place here. The main issues leading to deadlocking that I have noticed are:

1. In `update_limit` -- The `_limit_value` is only updated when there are machines, and the amount of machines is less than the `_upper_limit`. So no update for `_limit_value` occurs when we are at the upper limit.
2. In `check_for_starvation` -- The `available_count` is the number of unlocked machines. If machines are waiting at the semaphore, they are already locked. This makes updating the `_value` here impossible.

As a check for releasing the semaphore, I used the condition of `locked machines <=  configured machine limit`, but I think that should maybe be `total machines (locked or unlocked) <= configured machine limit`.

Thoughts?