### PR TITLE
Fix the break on sniffer section in auxiliary.conf.default

### DIFF
--- a/conf/default/auxiliary.conf.default
+++ b/conf/default/auxiliary.conf.default
@@ -49,11 +49,6 @@ enabled = no
 # Enable or disable the use of an external sniffer (tcpdump) [yes/no].
 enabled = yes
 
-[QemuScreenshots]
-# Enable or disable the use of QEMU as screenshot capture [yes/no].
-# screenshots_linux and screenshots_windows must be disabled
-enabled = no
-
 # enable remote tcpdump support
 remote = no
 host = root@192.168.122.1
@@ -75,4 +70,9 @@ bpf = not arp
 #INETSIM = 192.168.1.2
 
 [tracee]
+enabled = no
+
+[QemuScreenshots]
+# Enable or disable the use of QEMU as screenshot capture [yes/no].
+# screenshots_linux and screenshots_windows must be disabled
 enabled = no


### PR DESCRIPTION
The pr (kevoreilly#2255) breaks the sniffer section, the screenshot section should be put at the end of the configuration file.