### PR TITLE
Add .asd ext

### DIFF
--- a/analyzer/windows/lib/core/packages.py
+++ b/analyzer/windows/lib/core/packages.py
@@ -44,7 +44,7 @@ def choose_package(file_type, file_name, exports, target):
         or "Microsoft Office Word" in file_type
         or "Microsoft OOXML" in file_type
         or "MIME entity" in file_type
-        or file_name.endswith((".doc", ".dot", ".docx", ".dotx", ".docm", ".dotm", ".docb", ".rtf", ".mht", ".mso", ".wbk", ".wiz"))
+        or file_name.endswith((".asd", ".doc", ".dot", ".docx", ".dotx", ".docm", ".dotm", ".docb", ".rtf", ".mht", ".mso", ".wbk", ".wiz"))
     ):
         return "doc"
     elif (


### PR DESCRIPTION
... For auto-recovered Word files. These run as normal docs pretty much.