### PR TITLE
Disable Signatures Module if Benign File

### DIFF
--- a/lib/cuckoo/core/plugins.py
+++ b/lib/cuckoo/core/plugins.py
@@ -661,9 +661,14 @@ class RunSignatures:
 
         malscore, malstatus = calc_scoring(self.results, matched)
 
-        self.results["malscore"] = malscore
-        self.results["ttps"] = mapTTP(self.ttps, self.mbcs)
         self.results["malstatus"] = malstatus
+        self.results["malscore"] = malscore
+
+        if malscore == 0:
+            self.results["signatures"] = []
+            return
+
+        self.results["ttps"] = mapTTP(self.ttps)
 
         # Make a best effort detection of malware family name (can be updated later by re-processing the analysis)
         if (


### PR DESCRIPTION
Related to PR #1941, If the file is benign, I think we don't need to get any triggered signature to avoid false-positive detections.