### PR TITLE
Optimize Remcos config extractor - get version string

### DIFF
--- a/modules/processing/parsers/CAPE/Remcos.py
+++ b/modules/processing/parsers/CAPE/Remcos.py
@@ -145,7 +145,7 @@ def check_version(filedata):
 
     # find and extract version string e.g. "2.0.5 Pro", "1.7 Free" or "1.7 Light"
     for s in slist:
-        if bool(re.search(r"^\d+\.\d+\.\d+\s+\w+$", s)):
+        if bool(re.search(r"^\d+\.\d+(\.\d+)?\s+\w+$", s)):
             return s
     return ""
 


### PR DESCRIPTION
RegEx misses versions x.x e.g. 1.7 pro

![Fix_Version_String_1](https://github.com/user-attachments/assets/02850f4b-d7c7-494b-845f-b2a7b68c0370)
---->
![Fix_Version_String_2](https://github.com/user-attachments/assets/87aa257d-62a7-49b2-a2cc-5276f4c0e674)

Sample to reproduce: 
[c42c37c46206d1beab2ca15b75af8b1f8b9c0ace15155f8ce934749ca05ea250](https://www.virustotal.com/gui/file/c42c37c46206d1beab2ca15b75af8b1f8b9c0ace15155f8ce934749ca05ea250)
