### PR TITLE
Package summary/description in UI

### DIFF
--- a/analyzer/windows/lib/common/constants.py
+++ b/analyzer/windows/lib/common/constants.py
@@ -52,6 +52,7 @@ OPT_UNPACKER = "unpacker"
 
 ARCHIVE_OPTIONS = (OPT_FILE, OPT_PASSWORD)
 DLL_OPTIONS = (OPT_ARGUMENTS, OPT_DLLLOADER, OPT_FUNCTION)
+SERVICE_OPTIONS = (OPT_SERVICENAME, OPT_SERVICEDESC, OPT_ARGUMENTS)
 
 
 """ Excel, Word, and Powerpoint won't have macros enabled without interaction for
@@ -65,3 +66,11 @@ MSOFFICE_TRUSTED_PATH = os.path.join("%SystemDrive%", "Program Files", "Microsof
 TRUSTED_PATH_TEXT = (
     f"Use MS Office Trusted Path location {MSOFFICE_TRUSTED_PATH} unless the user has provided a '{OPT_CURDIR}' option."
 )
+
+DLL_OPTION_TEXT = f"""\
+Use the '{OPT_DLLLOADER}' option to set the name of the process loading the DLL (defaults to rundll32.exe).
+Use the '{OPT_ARGUMENTS}' option to set the arguments to be passed to the exported function(s).
+Use the '{OPT_FUNCTION}' option to set the name of the exported function/ordinal to execute.
+The default function is '#1'.
+Can be multiple function/ordinals split by colon. Ex: function=#1:#3 or #2-4
+"""

--- a/analyzer/windows/modules/packages/Unpacker_dll.py
+++ b/analyzer/windows/modules/packages/Unpacker_dll.py
@@ -7,8 +7,15 @@ import shutil
 
 from lib.common.abstracts import Package
 from lib.common.common import check_file_extension
-from lib.common.constants import OPT_ARGUMENTS, OPT_DLLLOADER, OPT_FUNCTION, OPT_INJECTION, OPT_UNPACKER
-from modules.packages.dll import DLL_OPTION_TEXT, DLL_OPTIONS
+from lib.common.constants import (
+    DLL_OPTION_TEXT,
+    DLL_OPTIONS,
+    OPT_ARGUMENTS,
+    OPT_DLLLOADER,
+    OPT_FUNCTION,
+    OPT_INJECTION,
+    OPT_UNPACKER,
+)
 
 
 class Unpacker_dll(Package):

--- a/analyzer/windows/modules/packages/dll.py
+++ b/analyzer/windows/modules/packages/dll.py
@@ -9,7 +9,7 @@ import shutil
 
 from lib.common.abstracts import Package
 from lib.common.common import check_file_extension
-from lib.common.constants import DLL_OPTIONS, OPT_ARGUMENTS, OPT_DLLLOADER, OPT_FUNCTION
+from lib.common.constants import DLL_OPTION_TEXT, DLL_OPTIONS, OPT_ARGUMENTS, OPT_DLLLOADER, OPT_FUNCTION
 
 log = logging.getLogger(__name__)
 
@@ -17,14 +17,6 @@ _OPT_ENABLE_MULTI = "enable_multi"
 _OPT_MAX_DLL_EXPORTS = "max_dll_exports"
 _OPT_USE_EXPORT_NAME = "use_export_name"
 MAX_DLL_EXPORTS_DEFAULT = 8
-
-DLL_OPTION_TEXT = f"""
-Use the '{OPT_DLLLOADER}' option to set the name of the process loading the DLL (defaults to rundll32.exe).
-Use the '{OPT_ARGUMENTS}' option to set the arguments to be passed to the exported function(s).
-Use the '{OPT_FUNCTION}' option to set the name of the exported function/ordinal to execute.
-The default function is '#1'.
-Can be multiple function/ordinals split by colon. Ex: function=#1:#3 or #2-4
-"""
 
 
 class Dll(Package):

--- a/analyzer/windows/modules/packages/exe.py
+++ b/analyzer/windows/modules/packages/exe.py
@@ -15,7 +15,8 @@ class Exe(Package):
     """EXE analysis package."""
 
     summary = "Runs the supplied executable."
-    description = f"""Executes the given sample, passing '{OPT_ARGUMENTS}' if specified.
+    description = f"""\
+    Executes the given sample, passing '{OPT_ARGUMENTS}' if specified.
     Use the '{OPT_APPDATA}' option to run the executable from the APPDATA directory.
     Use the '{OPT_RUNASX86}' option to set the 32BITREQUIRED flag in the PE header,
     using 'CorFlags.exe /32bit+'.

--- a/analyzer/windows/modules/packages/service.py
+++ b/analyzer/windows/modules/packages/service.py
@@ -9,7 +9,7 @@ import sys
 from lib.api.process import Process
 from lib.common.abstracts import Package
 from lib.common.common import check_file_extension
-from lib.common.constants import OPT_ARGUMENTS, OPT_SERVICEDESC, OPT_SERVICENAME
+from lib.common.constants import OPT_ARGUMENTS, OPT_SERVICEDESC, OPT_SERVICENAME, SERVICE_OPTIONS
 from lib.common.defines import ADVAPI32, KERNEL32
 
 INJECT_CREATEREMOTETHREAD = 0
@@ -53,8 +53,6 @@ SERVICE_INTERACTIVE_PROCESS = 0x0100
 SERVICE_DEMAND_START = 0x0003
 SERVICE_ERROR_IGNORE = 0x0000
 log = logging.getLogger(__name__)
-
-SERVICE_OPTIONS = (OPT_SERVICENAME, OPT_SERVICEDESC, OPT_ARGUMENTS)
 
 
 class Service(Package):

--- a/analyzer/windows/modules/packages/service_dll.py
+++ b/analyzer/windows/modules/packages/service_dll.py
@@ -16,10 +16,8 @@ from winreg import (
 from lib.api.process import Process
 from lib.common.abstracts import Package
 from lib.common.common import check_file_extension, disable_wow64_redirection
-from lib.common.constants import OPT_ARGUMENTS, OPT_SERVICEDESC, OPT_SERVICENAME
+from lib.common.constants import OPT_ARGUMENTS, OPT_SERVICEDESC, OPT_SERVICENAME, SERVICE_OPTIONS
 from lib.common.defines import ADVAPI32, KERNEL32
-
-from .service import SERVICE_OPTIONS
 
 SC_MANAGER_CONNECT = 0x0001
 SC_MANAGER_CREATE_SERVICE = 0x0002

--- a/tests/web/test_submission_views.py
+++ b/tests/web/test_submission_views.py
@@ -1,0 +1,245 @@
+import ast
+import os
+import re
+import textwrap
+
+import pytest
+from django.test import SimpleTestCase
+from submission.views import (
+    correlate_platform_packages,
+    get_form_data,
+    get_lib_common_constants,
+    get_package_info,
+    parse_ast,
+    web_conf,
+)
+
+
+@pytest.mark.usefixtures("db")
+class TestSubmissionViews(SimpleTestCase):
+    maxDiff = None
+
+    def setUp(self):
+        self.linux_enabled = web_conf.linux.enabled
+        self.excluded_packages = web_conf.package_exclusion.packages
+        self.linux_package_dir = os.path.join(
+            os.path.abspath(os.path.dirname(__file__)), "..", "..", "analyzer", "linux", "modules", "packages"
+        )
+        self.windows_package_dir = os.path.join(
+            os.path.abspath(os.path.dirname(__file__)), "..", "..", "analyzer", "windows", "modules", "packages"
+        )
+        web_conf.linux.enabled = True
+
+    def tearDown(self):
+        web_conf.linux.enabled = self.linux_enabled
+        web_conf.package_exclusion.packages = self.excluded_packages
+
+    def find_in_list(self, regex, list_of_strings):
+        """Test if the regex matches any string in the list."""
+        pattern = re.compile(regex, flags=re.DOTALL)
+        for string in list_of_strings:
+            if pattern.match(string):
+                return True
+        return False
+
+    def one_should_match(self, regex, list_of_strings):
+        """One of the strings should match."""
+        found = self.find_in_list(regex, list_of_strings)
+        self.assertTrue(found, f"No string matched <{regex}>")
+
+    def none_should_match(self, regex, list_of_strings):
+        """None of the strings should match."""
+        found = self.find_in_list(regex, list_of_strings)
+        self.assertFalse(found, f"One or more strings matched <{regex}>")
+
+    def test_submission_page(self):
+        """The submission page should have a package selection form.
+
+        The form should have a list of at least 10 options.
+        """
+        submission_page = self.client.get("/submit/#file")
+        self.assertIsNotNone(submission_page.content)
+        self.assertIn("Analysis Package", submission_page.content.decode())
+        pattern = re.compile(r'select class="form-control" id="form_package" name="package">(.*?)</select>', flags=re.DOTALL)
+        matches = re.findall(pattern, submission_page.content.decode())
+        self.assertEqual(len(matches), 1)
+        group0 = matches[0].strip()
+        self.assertTrue(group0.startswith("<option value"))
+        self.assertTrue(group0.endswith("</option>"))
+        option_pattern = re.compile(r"<option (.*?)</option>", flags=re.DOTALL)
+        options = re.findall(option_pattern, group0)
+        self.assertEqual('value="" title="">Detect Automatically', options[0])
+
+        self.one_should_match('value="exe" title=".*">exe - .*', options)
+        self.one_should_match('value="Unpacker" title="[^"]*">Unpacker', options)
+        self.one_should_match(".*ichitaro.*", options)
+        self.one_should_match(".*chromium.*", options)
+        self.assertGreater(len(options), 10)
+        for opt in options:
+            self.assertTrue(opt.startswith("value="))
+
+    def test_package_exclusion(self):
+        """Pick a couple of packages to exclude, to test exclusion"""
+        web_conf.package_exclusion.packages = "chromium,ichitaro,Shellcode"
+        submission_page = self.client.get("/submit/#file")
+        self.assertIsNotNone(submission_page.content)
+        self.assertIn("Analysis Package", submission_page.content.decode())
+        option_pattern = re.compile(r"<option (.*?)</option>", flags=re.DOTALL)
+        options = re.findall(option_pattern, submission_page.content.decode())
+        self.assertGreater(len(options), 10)
+        # excluded packages should not be listed
+        self.none_should_match(".*ichitaro.*", options)
+        self.none_should_match(".*chromium.*", options)
+        # Package 'Shellcode' was excluded, but not 'Shellcode-Unpacker'.
+        self.none_should_match('.*"Shellcode".*', options)
+        self.one_should_match('.*"Shellcode-Unpacker".*', options)
+
+    def test_get_package_exe_info(self):
+        """Get the package info from exe.py."""
+        expected_options = ("str1", "str2", "str3")
+        context = {
+            "OPT_ARGUMENTS": expected_options[0],
+            "OPT_APPDATA": expected_options[1],
+            "OPT_RUNASX86": expected_options[2],
+            "ARCHIVE_OPTIONS": (1, 2),
+            "DLL_OPTIONS": (3, 4),
+        }
+        actual = get_package_info(self.windows_package_dir, "exe.py", "windows", context)
+        self.assertEqual("exe", actual["name"])
+        self.assertEqual("Exe", actual["classname"])
+        self.assertIn("summary", actual)
+        self.assertIn("description", actual)
+        self.assertEqual("Runs the supplied executable.", actual["summary"])
+        expected_description = textwrap.dedent(
+            f"""\
+        Executes the given sample, passing '{context["OPT_ARGUMENTS"]}' if specified.
+        Use the '{context["OPT_APPDATA"]}' option to run the executable from the APPDATA directory.
+        Use the '{context["OPT_RUNASX86"]}' option to set the 32BITREQUIRED flag in the PE header,
+        using 'CorFlags.exe /32bit+'.
+        The .exe extension will be added automatically.
+        OPTIONS: {expected_options}"""
+        )
+        actual_description = actual["description"]
+        self.assertEqual(expected_description, actual_description)
+        self.assertEqual(expected_options, actual["option_names"])
+
+    def test_get_package_rar_info(self):
+        """Get the package info from rar.py."""
+        context = {
+            "ARCHIVE_OPTIONS": (2, 5, 1, 3),
+            "DLL_OPTIONS": (3, 4, 2, 5),
+        }
+        actual = get_package_info(self.windows_package_dir, "rar.py", "windows", context)
+        self.assertIn("name", actual)
+        self.assertEqual("rar", actual["name"])
+        self.assertIn("summary", actual)
+        self.assertIn("description", actual)
+        self.assertIn("option_names", actual)
+        self.assertEqual([1, 2, 3, 4, 5], actual["option_names"])
+
+    def test_get_package_one(self):
+        """Get the package info from one.py."""
+        context = dict()
+        actual = get_package_info(self.windows_package_dir, "one.py", "windows", context)
+        self.assertEqual("one", actual["name"])
+        self.assertNotIn("_OPT_YARASCAN", actual["description"])
+        self.assertIn("'yarascan'", actual["description"])
+
+    def test_get_package_bash(self):
+        """Get the package info from bash.py."""
+        context = {
+            "summary": "should not be preserved",
+            "description": "should not be preserved",
+            "option_names": ("opt1", "opt2", "opt3"),
+        }
+        actual = get_package_info(self.linux_package_dir, "bash.py", "linux", context)
+        self.assertEqual("bash", actual["name"])
+        self.assertEqual("linux", actual["platform"])
+        self.assertNotEqual("should not be preserved", actual["summary"])
+        self.assertNotEqual("should not be preserved", actual["description"])
+        # The bash package does not have a summary, description, or option_names.
+        self.assertIn(" has no summary", actual["summary"])
+        self.assertIn(" has no description", actual["description"])
+        self.assertFalse(actual["option_names"])
+
+    def test_get_form_data(self):
+        """Use get_form_data() and check the values returned."""
+        packages, machines = get_form_data()
+        self.assertIsInstance(packages, list)
+        self.assertIsInstance(machines, list)
+        self.assertGreater(len(packages), 10)
+        self.assertGreater(len(machines), 0)
+        platforms = {package["platform"] for package in packages}
+        self.assertIn("windows", platforms)
+        self.assertIn("linux", platforms)
+        package_names = {package["name"] for package in packages}
+        self.assertIn("bash (linux only)", package_names)
+
+    def test_get_lib_common_constants(self):
+        """Ensure we get the constants from lib/common/constants.py"""
+        actual = get_lib_common_constants(platform="windows")
+        self.assertIsInstance(actual, dict)
+        self.assertEqual("runasx86", actual["OPT_RUNASX86"])
+        self.assertCountEqual(("file", "password"), actual["ARCHIVE_OPTIONS"])
+        self.assertCountEqual(("arguments", "dllloader", "function"), actual["DLL_OPTIONS"])
+        self.assertIn("SystemDrive", actual["TRUSTED_PATH_TEXT"])
+        self.assertIn("SystemDrive", actual["MSOFFICE_TRUSTED_PATH"])
+
+    def test_parse_ast(self):
+        """Test some of the parse_ast functionality."""
+        var1 = "x"
+        val1 = "value-of-x"
+
+        # Test ast.BinOp
+        code1 = f"{var1} = 'value-of-' + 'x'"
+        tree = ast.parse(code1)
+        actual = parse_ast(tree.body)
+        self.assertEqual(val1, actual[var1])
+
+        # Test ast.Name lookup from context
+        var2 = "y"
+        code2 = f"{var1} = '{val1}'\n{var2} = f'{{x}}'"
+        tree = ast.parse(code2)
+        actual = parse_ast(tree.body)
+        self.assertEqual(val1, actual[var1])
+        self.assertEqual(val1, actual[var2])
+
+        # Test ast.Tuple handling.
+        code3 = f"{var1} = (1, 2)"
+        tree = ast.parse(code3)
+        actual = parse_ast(tree.body)
+        self.assertEqual((1, 2), actual[var1])
+
+    def test_correlate_platform_packages(self):
+        """Test the correlate_platform_packages function."""
+        win_packages = [
+            {
+                "name": "firefox",
+                "summary": "opens a url with firefox",
+                "platform": "windows",
+            },
+            {
+                "name": "autoit",
+                "summary": "opens a file with autoit",
+                "platform": "windows",
+            },
+        ]
+        linux_packages = [
+            {
+                "name": "firefox",
+                "platform": "linux",
+            },
+            {
+                "name": "bash",
+                "platform": "linux",
+            },
+        ]
+        package_dict = {
+            "windows": win_packages,
+            "linux": linux_packages,
+        }
+        actual = correlate_platform_packages(package_dict)
+        self.assertEqual(3, len(actual))
+        names = [item["name"] for item in actual]
+        self.assertIn("firefox", names)
+        self.assertIn("bash (linux only)", names)

--- a/web/submission/views.py
+++ b/web/submission/views.py
@@ -3,11 +3,13 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
+import ast
 import logging
 import os
 import random
 import sys
 import tempfile
+import textwrap
 from base64 import urlsafe_b64encode
 from contextlib import suppress
 
@@ -55,22 +57,164 @@ disable_warnings()
 logger = logging.getLogger(__name__)
 
 
-def get_form_data():
+def parse_expr(expr, context):
+    """Return the value from a python AST expression.
+
+    Recursive! the initial call is the right hand side of an assignment.
+    Recursion is necessary because the expression is made up of a variable number
+    of subexpressions, sub-subexpressions, etc.
+    """
+    if isinstance(expr, str):
+        return expr
+    if isinstance(expr, ast.Constant):
+        return expr.value
+    if isinstance(expr, ast.Name):
+        # To get the value associated with the variable name, look up name (expr.id) in context.
+        # If lookup fails (we do not know the value of the variable), return the name.
+        return context.get(expr.id, str(expr.id))
+    if isinstance(expr, ast.List):
+        return [parse_expr(item, context) for item in expr.elts]
+    if isinstance(expr, ast.Tuple):
+        return tuple([parse_expr(item, context) for item in expr.elts])
+    if isinstance(expr, ast.JoinedStr):
+        # JoinedStr - coerce each item to string, and join them.
+        return "".join([str(parse_expr(item, context)) for item in expr.values])
+    if isinstance(expr, ast.FormattedValue):
+        return parse_expr(expr.value, context)
+    if isinstance(expr, ast.Attribute):
+        # Join expr.value to expr.attr with a "." between. Example: os.path.join
+        return parse_expr(expr.value, context) + "." + parse_expr(expr.attr, context)
+    if isinstance(expr, ast.Call):
+        # Figure out what function is being called, with what arguments.
+        func = parse_expr(expr.func, context)
+        args = tuple([parse_expr(item, context) for item in expr.args])
+        # We deem these functions safe to use with "eval".
+        allowed_functions = ("sorted", "set", "os.path.join")
+        if func in allowed_functions:
+            # Actually call the function, passing the args, and return the result.
+            return eval(f"{func}{args}")
+        # Don't execute the call, but instead, give back a string representation.
+        return f"<{func}{args}>"
+    if isinstance(expr, ast.BinOp) and isinstance(expr.op, ast.Add):
+        left = parse_expr(expr.left, context)
+        right = parse_expr(expr.right, context)
+        try:
+            ans = left + right
+        except TypeError:
+            # Expected behavior during unit tests
+            ans = str(left) + str(right)
+        return ans
+    # Not expected to reach this, but should aid in debugging if found.
+    return f"?? Unexpected type({type(expr)}) in parse_expr()"
+
+
+def parse_ast(items, context=None):
+    """Look at each item in a list of ast elements.
+
+    Item type ast.Assign signifies a statement of the form 'name = value'.
+    Work out the value using parse_expr.
+    Add an entry of the form 'name' = value to the context dictionary.
+    """
+    if not context:
+        context = dict()
+    for item in items:
+        if isinstance(item, ast.Assign):
+            key = item.targets[0].id
+            context[key] = parse_expr(item.value, context)
+    return context
+
+
+def get_lib_common_constants(platform):
+    """Extract constants from lib.common.constants into a dict"""
+    constant_file = os.path.join(settings.CUCKOO_PATH, "analyzer", platform, "lib", "common", "constants.py")
+    with open(constant_file, "r") as f:
+        contents = f.read()
+    tr = ast.parse(contents)
+    the_dict = parse_ast(tr.body)
+    return the_dict
+
+
+def get_package_info(dir_name, filename, platform, common_context):
+    """Find out everything we can about the package."""
+    default_summary = f"Package {filename} has no summary"
+    default_description = f"Package {filename} has no description"
+    # Clear out previous package description etc.
+    to_delete = ("summary", "description", "option_names")
+    for item in to_delete:
+        if item in common_context:
+            del common_context[item]
+    with open(os.path.join(dir_name, filename), "r") as f:
+        contents = f.read()
+    tr = ast.parse(contents)
+    expanded_context = parse_ast(tr.body, common_context)
+    classes = [item for item in tr.body if isinstance(item, ast.ClassDef) and item.bases and item.bases[0].id == "Package"]
+    if classes:
+        classname = classes[0].name
+        assignments = parse_ast(classes[0].body, expanded_context)
+    else:
+        # No class inherited from 'Package'
+        classname = "unknown classname"
+        assignments = dict()
+    summary = assignments.get("summary", default_summary)
+    description = textwrap.dedent(assignments.get("description", default_description))
+    option_names = assignments.get("option_names", ())
+    if option_names:
+        description = description + f"\nOPTIONS: {option_names}"
+    result = {
+        "name": os.path.splitext(filename)[0],
+        "value": os.path.splitext(filename)[0],
+        "classname": classname,
+        "platform": platform,
+        "summary": summary,
+        "description": description,
+        "option_names": option_names,
+    }
+    return result
+
+
+def get_enabled_platforms():
+    """Return a list of enabled platforms.
+
+    We are going to assume that the windows platform is first in the list."""
     platforms = ["windows"]
     if web_conf.linux.enabled:
         platforms.append("linux")
+    return platforms
 
-    packages = set()
+
+def correlate_platform_packages(platform_package_dict):
+    """Given a per-platform dictionary, return a single list of all packages"""
+    package_names = set()
+    result = []
+    for platform in get_enabled_platforms():
+        for package in platform_package_dict.get(platform, []):
+            package_name = package["name"].lower()
+            if package_name not in package_names:
+                package_names.add(package_name)
+                if platform != "windows":
+                    # The windows analyzer package list did not contain this package name.
+                    package["name"] = package["name"] + f" ({platform} only)"
+                result.append(package)
+    return result
+
+
+def get_form_data():
+    """Return data about packages and machines to help build the submission form."""
+    platforms = get_enabled_platforms()
+
+    platform_packages = dict()
     for platform in platforms:
-        files = os.listdir(os.path.join(settings.CUCKOO_PATH, "analyzer", platform, "modules", "packages"))
-        exclusions = [package.strip() for package in web_conf.package_exclusion.packages.split(",")]
+        common_context = get_lib_common_constants(platform)
+        package_root = os.path.join(settings.CUCKOO_PATH, "analyzer", platform, "modules", "packages")
+        files = [item.name for item in os.scandir(package_root) if item.is_file() and not item.name.startswith(".")]
+        exclusions = [package.strip() + ".py" for package in web_conf.package_exclusion.packages.split(",")]
 
-        for name in files:
-            name = os.path.splitext(name)[0]
-            if name == "__init__":
-                continue
-            if name not in exclusions:
-                packages.add(name)
+        exclusions.append("__init__.py")
+
+        platform_packages[platform] = [
+            get_package_info(package_root, name, platform, common_context) for name in files if name not in exclusions
+        ]
+    packages = correlate_platform_packages(platform_packages)
 
     # Prepare a list of VM names, description label based on tags.
     machines = []
@@ -608,7 +752,7 @@ def index(request, task_id=None, resubmit_hash=None):
             request,
             "submission/index.html",
             {
-                "packages": sorted(packages),
+                "packages": sorted(packages, key=lambda i: i["name"].lower()),
                 "machines": machines,
                 "vpns": vpns_data,
                 "random_route": random_route,

--- a/web/templates/submission/index.html
+++ b/web/templates/submission/index.html
@@ -56,6 +56,10 @@ $(document).ready( function() {
             document.getElementById('non-pcap-2').style.display = "block";
         }
     });
+    $('#form_package').change(function () {
+        let title = $('option:selected', this).attr('title');
+        $("#package_description").text(title);
+    });
 });
 </script>
 <div class="row">
@@ -177,8 +181,8 @@ $(document).ready( function() {
                                 {% endif %}
                                 {% if resubmit %}
                                     <div class="form-group">
-                                        <label for="form_package">Task Category</label>
-                                        <select class="form-control" id="form_package" name="job_category">
+                                        <label for="form_job_category">Task Category</label>
+                                        <select class="form-control" id="form_job_category" name="job_category">
                                             <option value="hash" checked>Resubmit</option>
                                             <option value="sample">Files</option>
                                             <option value="static">Static analysis</option>
@@ -190,13 +194,14 @@ $(document).ready( function() {
                                     </div>
                                 {% endif %}
                                 <div class="form-group">
-                                    <label for="form_package">Analysis Package</label>
+                                    <label for="form_package">Analysis Package (hover for more info)</label>
                                     <select class="form-control" id="form_package" name="package">
-                                        <option value="" active>Detect Automatically</option>
+                                        <option value="" title="">Detect Automatically</option>
                                         {% for package in packages %}
-                                        <option value="{{package}}">{{package}}</option>
+                                        <option value="{{package.value}}" title="{{ package.description }}">{{package.name}} - {{ package.summary }}</option>
                                         {% endfor %}
                                     </select>
+                                    <small id="package_description"></small>
                                 </div>
                                 {% if not config.dist_master_storage_only %}
                                     <div class="form-group">

--- a/web/web/settings.py
+++ b/web/web/settings.py
@@ -10,7 +10,7 @@ if os.geteuid() == 0 and os.getenv("CAPE_AS_ROOT", "0") != "1":
     sys.exit("Root is not allowed. You gonna break permission and other parts of CAPE. RTM!")
 
 # Cuckoo path.
-CUCKOO_PATH = os.path.join(Path.cwd(), "..")
+CUCKOO_PATH = os.path.join(os.path.abspath(os.path.dirname(__file__)), "..", "..")
 sys.path.append(CUCKOO_PATH)
 
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -181,7 +181,7 @@ TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
         "DIRS": [
-            "templates",
+            os.path.join(CUCKOO_PATH, "web", "templates"),
         ],
         "OPTIONS": {
             "debug": True,


### PR DESCRIPTION
- Following on from #2220 now we display the package summary and description in the UI
- In views.py:
  - Added code to parse the python analysis package modules, pulling out summary and description
  - Updated `get_form_data()` to return list of dicts, not list of strings
  - When sorting the package names, no longer be case sensitive
- Updated the `submission/index.html` template to expect a dict per package
- Added some tests
- Tweak to `web/settings.py` so it can find the templates, even during test execution

Screenshots:
![Screenshot from 2024-09-09 15-27-14](https://github.com/user-attachments/assets/1f45ae75-91b1-4249-b8b0-a61cc0873c02)
![Screenshot from 2024-09-09 15-27-36](https://github.com/user-attachments/assets/c9712636-f99d-45ea-bab2-ec273ffde520)
![Screenshot from 2024-09-09 15-26-57](https://github.com/user-attachments/assets/bde4d634-f08e-4dd5-bcab-aedd7fd45773)


