### PR TITLE
Only process PCAPs with httpreplay when tlsdump.log exists

### DIFF
--- a/utils/profiling.py
+++ b/utils/profiling.py
@@ -1,0 +1,29 @@
+import time
+from dataclasses import dataclass, field
+
+
+@dataclass
+class Counter:
+    """Profiler that counts real and CPU time."""
+    real: float = field(default_factory=time.perf_counter)
+    cpu: float = field(default_factory=time.process_time)
+
+    def __sub__(self, other):
+        real = self.real - other.real
+        cpu = self.cpu - other.cpu
+        return Counter(real, cpu)
+
+    def __add__(self, other):
+        real = self.real + other.real
+        cpu = self.cpu + other.cpu
+        return Counter(real, cpu)
+
+    def __str__(self) -> str:
+        return f"{self.real:.2f}s (cpu {self.cpu:.2f}s)".format(self.real, self.cpu)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_tb):
+        elapsed = (Counter() - self)
+        self.__dict__.update(**elapsed.__dict__)


### PR DESCRIPTION
These changes prevent PCAPs from being processed by httpreplay (Pcap2 processing module) when there are no TLS keys available. This is because httpreplay processing is very time intensive due to its pure-python implementation.

Httpreplay's core use is to decrypt TLS traffic so it can be processed by Suricata. If there are no TLS keys available, there is no requirement to use it for processing.

For context, when CAPE attempted to process a ~250MB PCAP with httpreplay, it took ~960 seconds. Without httpreplay, it took ~16 seconds.

Related to https://github.com/kevoreilly/CAPEv2/issues/2314