### PR TITLE
Adds private auxiliary module configuration option

### DIFF
--- a/analyzer/windows/analyzer.py
+++ b/analyzer/windows/analyzer.py
@@ -509,6 +509,21 @@ class Analyzer:
             except ImportError as e:
                 log.warning('Unable to import the auxiliary module "%s": %s', name, e)
 
+        def configure_aux_from_data(instance):
+        # Do auxiliary module configuration stored in 'data/auxiliary/<package_name>'
+            _class = type(instance)
+            try:
+                log.debug("attempting to configure '%s' from data", _class.__name__)
+                instance.configure_from_data()
+            except ModuleNotFoundError:
+                # let it go, not every module is configurable from data
+                log.debug("module %s does not support data configuration, ignoring", _class.__name__)
+            except ImportError as iexc:
+                # let it go but emit a warning; assume a dependency is missing
+                log.warning("configuration error for module %s: %s", _class.__name__, iexc)
+            except Exception as exc:
+                log.error("error configuring module %s: %s", _class.__name__, exc)
+
         # Walk through the available auxiliary modules.
         aux_modules = []
 
@@ -517,6 +532,7 @@ class Analyzer:
                 aux = module(self.options, self.config)
                 log.debug('Initialized auxiliary module "%s"', module.__name__)
                 aux_modules.append(aux)
+                configure_aux_from_data(aux)
                 log.debug('Trying to start auxiliary module "%s"...', module.__module__)
                 aux.start()
             except (NotImplementedError, AttributeError) as e:

--- a/docs/book/src/customization/auxiliary.rst
+++ b/docs/book/src/customization/auxiliary.rst
@@ -27,3 +27,52 @@ very end of the analysis process, before launching the processing and reporting 
 
 For example, an auxiliary module provided by default in CAPE is called *sniffer.py* and
 takes care of executing **tcpdump** in order to dump the generated network traffic.
+
+Auxiliary Module Configuration
+==============================
+
+Auxiliary modules can be "configured" before being started. This allows data to be added
+at runtime, whilst also allowing for the configuration to be stored separately from the
+CAPE python code.
+
+Private Auxiliary Module Configuration
+--------------------------------------
+
+Private auxiliary module configuration is stored outside the auxiliary class, in a module
+under the same name as the auxiliary module. This is useful when managing configuration
+of auxiliary modules separately if desired, for privacy reasons or otherwise.
+
+Here is a configuration module example that installs some software prior to the auxiliary
+module starting:
+
+    .. code-block:: python
+        :linenos:
+
+        # data/auxiliary/example.py
+        import subprocess
+        import logging
+        from pathlib import Path
+
+        log = logging.getLogger(__name__)
+        BIN_PATH = Path.cwd() / "bin"
+
+
+        def configure(aux_instance):
+            # here "example" refers to modules.auxiliary.example.Example
+            if not aux_instance.enabled:
+                return
+            msi = aux_instance.options.get("example_msi")
+            if not msi:
+                return
+            msi_path = BIN_PATH / msi
+            if not msi_path.exists():
+                log.warning("missing MSI %s", msi_path)
+                return
+            cmd = ["msiexec", "/i", msi_path, "/quiet"]
+            try:
+                log.info("Executing msi package...")
+                subprocess.check_output(cmd)
+                log.info("Installation succesful")
+            except subprocess.CalledProcessError as exc:
+                log.error("Installation failed: %s", exc)
+                return


### PR DESCRIPTION
This adds a new `configure_from_data` method to analyzer.windows.lib.common.abstracts.Auxiliary.

This optional method provides the ability to run private auxiliary-specific configuration code from `data.packages.<module_name>`.

If an auxiliary module doesn't provide a `configure_from_data` method, it's logged but ignored.