### PR TITLE
Disable analysis log truncation if buffer is configured to 0

### DIFF
--- a/lib/cuckoo/common/utils.py
+++ b/lib/cuckoo/common/utils.py
@@ -342,6 +342,18 @@ def convert_to_printable_and_truncate(s: str, buf: int, cache=None):
     return convert_to_printable(f"{s[:buf]} <truncated>" if len(s) > buf else s, cache=cache)
 
 
+def truncate_str(s: str, max_length: int, marker=" <truncated>"):
+     """Truncate a string if its length exceeds the configured `max_length`.
+
+     If `max_length` is less than or equal to 0, the string is not modified.
+     If the string is truncated, `marker` is added to the end."""
+     truncate_size = min(max_length, len(s))
+     if truncate_size > 0 and truncate_size < len(s):
+             return f"{s[:truncate_size]}{marker}"
+     else:
+             return s
+
+
 def convert_filename_char(c):
     """Escapes filename characters.
     @param c: dirty char.

--- a/modules/processing/debug.py
+++ b/modules/processing/debug.py
@@ -7,6 +7,7 @@ import codecs
 from lib.cuckoo.common.abstracts import Processing
 from lib.cuckoo.common.exceptions import CuckooProcessingError
 from lib.cuckoo.common.path_utils import path_exists
+from lib.cuckoo.common.utils import truncate_str
 from lib.cuckoo.core.database import Database
 
 
@@ -24,7 +25,7 @@ class Debug(Processing):
             try:
                 buf_size = self.options.get("buffer", 8192)
                 content = codecs.open(self.log_path, "rb", "utf-8").read()
-                debug["log"] = content[:buf_size] + " <truncated>" if len(content) > buf_size else content
+                debug["log"] = truncate_str(content, buf_size)
             except ValueError as e:
                 raise CuckooProcessingError(f"Error decoding {self.log_path}: {e}") from e
             except (IOError, OSError) as e:


### PR DESCRIPTION
Follows on from the changes to modules.processing.debug.Debug in https://github.com/kevoreilly/CAPEv2/commit/944d0e2d771038a1e24aaf6164fe6afa511dcbee.

Allows log truncation to be disabled if the configured buffer parameter is set to '0'.