### PR TITLE
feat: clean up cuckoo-sflock tmp folder

### DIFF
--- a/lib/cuckoo/common/cleaners_utils.py
+++ b/lib/cuckoo/common/cleaners_utils.py
@@ -426,7 +426,7 @@ def tmp_clean_before_day(days: int):
     today = datetime.today()
     tmp_folder_path = config.cuckoo.get("tmppath")
 
-    for folder in ("cuckoo-tmp", "cape-external"):
+    for folder in ("cuckoo-tmp", "cape-external", "cuckoo-sflock"):
         for root, directories, files in os.walk(os.path.join(tmp_folder_path, folder), topdown=True):
             for name in files + directories:
                 path = os.path.join(root, name)


### PR DESCRIPTION
This PR adds `cuckoo-sflock` to the list of tmp folders for cleanup. I noticed it wasn’t included in when this function was changed a few months ago, and ran into issues on my CAPE instance, so thought it’d be helpful to add.

Thanks!