### PR TITLE
Count failures when running reporting modules

### DIFF
--- a/utils/process.py
+++ b/utils/process.py
@@ -32,13 +32,22 @@ log = logging.getLogger()
 sys.path.append(os.path.join(os.path.abspath(os.path.dirname(__file__)), ".."))
 from concurrent.futures import TimeoutError
 
+from atlas.imp_processing import ImpProcessing
 from lib.cuckoo.common.cleaners_utils import free_space_monitor
 from lib.cuckoo.common.colors import red
 from lib.cuckoo.common.config import Config
 from lib.cuckoo.common.constants import CUCKOO_ROOT
 from lib.cuckoo.common.path_utils import path_delete, path_exists, path_mkdir
 from lib.cuckoo.common.utils import get_options
-from lib.cuckoo.core.database import TASK_COMPLETED, TASK_FAILED_PROCESSING, TASK_REPORTED, Database, Task, init_database
+from lib.cuckoo.core.database import (
+    TASK_COMPLETED,
+    TASK_FAILED_PROCESSING,
+    TASK_FAILED_REPORTING,
+    TASK_REPORTED,
+    Database,
+    Task,
+    init_database,
+)
 from lib.cuckoo.core.plugins import RunProcessing, RunReporting, RunSignatures
 from lib.cuckoo.core.startup import ConsoleHandler, check_linux_dist, init_modules
 
@@ -137,9 +146,10 @@ def process(
         else:
             reprocess = report
 
-        RunReporting(task=task.to_dict(), results=results, reprocess=reprocess).run()
+        error_count = RunReporting(task=task.to_dict(), results=results, reprocess=reprocess).run()
+        status = TASK_REPORTED if error_count == 0 else TASK_FAILED_REPORTING
         with db.session.begin():
-            db.set_status(task_id, TASK_REPORTED)
+            db.set_status(task_id, status)
 
         if auto:
             # Is ok to delete original file, but we need to lookup on delete_bin_copy if no more pendings tasks


### PR DESCRIPTION
The status `TASK_FAILED_REPORTING` was never being set.

1. Reporting exceptions are now counted in `RunReporting.process()`.
2. `RunReporting.run()` now returns the number of exceptions caught.
3. When `utils/process.py` ran, it was always setting the status to `TASK_REPORTED`. 
   - Now, it checks the number of these exceptions, and if non-zero, sets the status to `TASK_FAILED_REPORTING` instead.