### PR TITLE
fix for interactive desktop analysis using rdp

### DIFF
--- a/conf/default/web.conf.default
+++ b/conf/default/web.conf.default
@@ -194,6 +194,7 @@ guest_width = 1280
 guest_height = 1024
 # rdp settings
 guest_rdp_port = 3389
+ignore_rdp_cert = false
 
 [packages]
 # VM tags may be used to specify on which guest machines a sample should be run

--- a/web/guac/consumers.py
+++ b/web/guac/consumers.py
@@ -35,7 +35,7 @@ class GuacamoleWebSocketConsumer(AsyncWebsocketConsumer):
             hosts = params.get("guest_ip", "")
             guest_host = hosts[0]
             guest_port = int(web_cfg.guacamole.guest_rdp_port) or 3389
-            ignore_cert = "true" if web_cfg.guacamole.ignore_rdp_cert == True else "false"
+            ignore_cert = "true" if web_cfg.guacamole.ignore_rdp_cert is True else "false"
         else:
             guest_host = web_cfg.guacamole.vnc_host or "localhost"
             ports = params.get("vncport", ["5900"])

--- a/web/guac/consumers.py
+++ b/web/guac/consumers.py
@@ -32,12 +32,15 @@ class GuacamoleWebSocketConsumer(AsyncWebsocketConsumer):
         params = urllib.parse.parse_qs(self.scope["query_string"].decode())
 
         if "rdp" in guest_protocol:
-            guest_host = params.get("guest_ip", "")
+            hosts = params.get("guest_ip", "")
+            guest_host = hosts[0]
             guest_port = int(web_cfg.guacamole.guest_rdp_port) or 3389
+            ignore_cert = "true" if web_cfg.guacamole.ignore_rdp_cert == True else "false"
         else:
             guest_host = web_cfg.guacamole.vnc_host or "localhost"
             ports = params.get("vncport", ["5900"])
             guest_port = int(ports[0])
+            ignore_cert = "false"
 
         guacd_recording_name = params.get("recording_name", ["task-recording"])[0]
 
@@ -53,6 +56,7 @@ class GuacamoleWebSocketConsumer(AsyncWebsocketConsumer):
             password=guest_password,
             recording_path=guacd_recording_path,
             recording_name=guacd_recording_name,
+            ignore_cert=ignore_cert
         )
 
         if self.client.connected:


### PR DESCRIPTION
This PR is a fix for using RDP for interactive desktop analyses. Without this change, I was unable to get RDP working.

There is also a new config for indicating if certificate verification of the remote desktop should be ignored. The cert verification only applies to connections over RDP; it is ignored for VNC.