### PR TITLE
Update poetry binary location. Fix pip errors for ubuntu 22.04.

### DIFF
--- a/extra/libvirt_installer.sh
+++ b/extra/libvirt_installer.sh
@@ -2,7 +2,7 @@
 set -ex
 
 # run this via...
-# cd /opt/CAPEv2/ ; sudo -u cape poetry run extra/libvirt_installer.sh
+# cd /opt/CAPEv2/ ; sudo -u cape /etc/poetry/bin/poetry run extra/libvirt_installer.sh
 
 LIB_VERSION=10.7.0
 cd /tmp || return

--- a/extra/yara_installer.sh
+++ b/extra/yara_installer.sh
@@ -2,7 +2,7 @@
 set -ex
 
 # run this via...
-# cd /opt/CAPEv2/ ; sudo -u cape poetry run extra/yara_installer.sh
+# cd /opt/CAPEv2/ ; sudo -u cape /etc/poetry/bin/poetry run extra/yara_installer.sh
 
 if [ ! -d /tmp/yara-python ]; then
     git clone --recursive https://github.com/VirusTotal/yara-python /tmp/yara-python
@@ -10,8 +10,8 @@ fi
 
 cd /tmp/yara-python
 
-poetry --directory /opt/CAPEv2 run python setup.py build --enable-cuckoo --enable-magic --enable-profiling
-poetry --directory /opt/CAPEv2 run pip install .
+/etc/poetry/bin/poetry --directory /opt/CAPEv2 run python setup.py build --enable-cuckoo --enable-magic --enable-profiling
+/etc/poetry/bin/poetry --directory /opt/CAPEv2 run pip install .
 
 cd ..
 

--- a/installer/kvm-qemu.sh
+++ b/installer/kvm-qemu.sh
@@ -597,7 +597,7 @@ EOH
 
     cd ..
     # Remove the $libvirt_version directory to permission errors when runing
-    # cd /opt/CAPEv2/ ; sudo -u cape poetry run extra/poetry_libvirt_installer.sh later
+    # cd /opt/CAPEv2/ ; sudo -u cape /etc/poetry/bin/poetry run extra/poetry_libvirt_installer.sh later
     rm -r libvirt-python-$libvirt_version
 
     if [ "$OS" = "Linux" ]; then


### PR DESCRIPTION
- Fixed all `poetry: command not found` errors.
- Kept the ubuntu 24.04 updates and fixed the pip errors with 22.04.

Likely a more graceful way of pointing to the Poetry binary than placing `/etc/poetry/bin/poetry` everywhere, but this fixes all of the install issues on ubuntu 22.04.