### PR TITLE
Don't overwrite the 'target' key for every detonation.

### DIFF
--- a/modules/processing/url_analysis.py
+++ b/modules/processing/url_analysis.py
@@ -35,5 +35,5 @@ class UrlAnalysis(Processing):
                 if vt_details:
                     self.results["url"].setdefault("virustotal", vt_details)
 
-        self.results["target"] = {"category": "url"}
+            self.results["target"] = {"category": "url"}
         return target_info


### PR DESCRIPTION
This fixes a regression introduced in https://github.com/kevoreilly/CAPEv2/commit/d896e8d50f70216ab9847b2880f63eff6828fab1 where every file detonation now has {"category": "url"} as the entire content of the "target" key. This removes all of the information about the target file.