### PR TITLE
Ignore the data/ binaries that could be pulled in from the community repo.

### DIFF
--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,0 +1,6 @@
+# Ignore binaries use for self-extracting.
+UnAutoIt
+7zz
+innoextract
+procyon.jar
+NETReactorSlayer.CLI


### PR DESCRIPTION
I'm not sure exactly how people deploy these self-extraction binaries, but it seemed like if they get deployed to the places that are defined in conf/default/selfextract.conf.default but don't exist in this repo, then they should be in .gitignore.