### PR TITLE
restore behavior defaults to a dictionary

### DIFF
--- a/modules/processing/behavior.py
+++ b/modules/processing/behavior.py
@@ -1182,7 +1182,7 @@ class BehaviorAnalysis(Processing):
         @return: results dict.
         """
 
-        behavior = []
+        behavior = {"processes": []}
         if path_exists(self.logs_path) and len(os.listdir(self.logs_path)) != 0:
             behavior = {"processes": Processes(self.logs_path, self.task, self.options).run()}
 


### PR DESCRIPTION
Prior to PR #2454, behavioral data defaulted to a dictionary pointing to a list. The PR changed it to an empty list. This is expected to be a dictionary everywhere, and most code expects the "processes" key to exist and either be empty or have process data in it.

The specific commit this changed in is https://github.com/kevoreilly/CAPEv2/commit/11fb7b1964ae0836e1a69ec3734c346594b08a2e.