### PR TITLE
Make the logging and exception handling inside of `processing_finished` more succinct

### DIFF
--- a/utils/process.py
+++ b/utils/process.py
@@ -286,18 +286,11 @@ def processing_finished(future):
             _ = future.result()
             log.info("Reports generation completed for Task #%d", task_id)
         except TimeoutError as error:
-            exc_clsname = error.__class__.__name__
-            exc_message = str(error) or "unknown error"
-            log.error("[%d] Processing Timeout %s. Function: %s - %s", task_id, exc_message, error.args[1], exc_clsname)
-            Database().set_status(task_id, TASK_FAILED_PROCESSING)
-        except pebble.ProcessExpired as error:
-            exc_clsname = error.__class__.__name__
-            exc_message = str(error) or "unknown error"
-            log.error("[%d] Exception when processing task: %s - %s", task_id, exc_message, exc_clsname, exc_info=True)
-            Database().set_status(task_id, TASK_FAILED_PROCESSING)
-        except Exception as error:
+            log.error("[%d] Processing timeout: %s. Function: %s", task_id, error, error.args[1])
+            db.set_status(task_id, TASK_FAILED_PROCESSING)
+        except (pebble.ProcessExpired, Exception) as error:
             log.error("[%d] Exception when processing task: %s", task_id, error, exc_info=True)
-            Database().set_status(task_id, TASK_FAILED_PROCESSING)
+            db.set_status(task_id, TASK_FAILED_PROCESSING)
 
     pending_future_map.pop(future)
     pending_task_id_map.pop(task_id)


### PR DESCRIPTION
Makes the logging and exception handling inside of `processing_finished` more succinct

- Merges the `pebble.ProcessExpired` and generic `Exception` clauses as they are functionally identical. I've retained code-level visibility of `pebble.ProcessExpired`, despite it not being technically required.
- Removes the recently added `exc_classname` and `exc_message` variables, introduced in commit 1556340. The exception name is not required in the case of the `TimeoutError` clause, as the exception message provides enough insight.  In the second, generic clause, `exc_info` ensures the exception type, traceback and stack are contained in the log message.
- Replaces the `Database()` initialization calls in the exception handlers with a reference to the already initialized database, `db`, instead.