### PR TITLE
fix litereport failure due to invalid utf-8 byte string

### DIFF
--- a/modules/reporting/litereport.py
+++ b/modules/reporting/litereport.py
@@ -23,11 +23,11 @@ class LiteReport(Report):
 
     def default(self, obj):
         if isinstance(obj, bytes):
-            encoding = chardet.detect(obj)['encoding']
+            encoding = chardet.detect(obj)["encoding"]
             if encoding:
-                return obj.decode(encoding, errors='replace')
+                return obj.decode(encoding, errors="replace")
             else:
-                return (obj.decode("utf-8", errors='replace'))
+                return obj.decode("utf-8", errors="replace")
         raise TypeError
 
     def run(self, results):

--- a/modules/reporting/litereport.py
+++ b/modules/reporting/litereport.py
@@ -3,7 +3,7 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 import os
-
+import chardet
 from lib.cuckoo.common.abstracts import Report
 from lib.cuckoo.common.exceptions import CuckooReportError
 from lib.cuckoo.common.path_utils import path_write_file

--- a/modules/reporting/litereport.py
+++ b/modules/reporting/litereport.py
@@ -23,7 +23,10 @@ class LiteReport(Report):
 
     def default(self, obj):
         if isinstance(obj, bytes):
-            return obj.decode()
+            try:
+                return obj.decode()
+            except UnicodeDecodeError:
+                return obj.decode('latin1')
         raise TypeError
 
     def run(self, results):

--- a/modules/reporting/litereport.py
+++ b/modules/reporting/litereport.py
@@ -3,7 +3,9 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 import os
+
 import chardet
+
 from lib.cuckoo.common.abstracts import Report
 from lib.cuckoo.common.exceptions import CuckooReportError
 from lib.cuckoo.common.path_utils import path_write_file

--- a/modules/reporting/litereport.py
+++ b/modules/reporting/litereport.py
@@ -26,7 +26,7 @@ class LiteReport(Report):
             try:
                 return obj.decode()
             except UnicodeDecodeError:
-                return obj.decode('latin1')
+                return obj.decode("latin1")
         raise TypeError
 
     def run(self, results):

--- a/modules/reporting/litereport.py
+++ b/modules/reporting/litereport.py
@@ -23,10 +23,11 @@ class LiteReport(Report):
 
     def default(self, obj):
         if isinstance(obj, bytes):
-            try:
-                return obj.decode()
-            except UnicodeDecodeError:
-                return obj.decode("latin1")
+            encoding = chardet.detect(obj)['encoding']
+            if encoding:
+                return obj.decode(encoding, errors='replace')
+            else:
+                return (obj.decode("utf-8", errors='replace'))
         raise TypeError
 
     def run(self, results):


### PR DESCRIPTION
use chardet to avoid UnicodeDecodeError due to invalid utf-8 byte string.
Sample: 70524de53d60119c2913370232effaf1e551db9308909dba2cd1331bb0fa0f19