### PR TITLE
A couple of ruff %s fixes were missed

### DIFF
--- a/lib/cuckoo/common/cleaners_utils.py
+++ b/lib/cuckoo/common/cleaners_utils.py
@@ -185,7 +185,7 @@ def delete_bulk_tasks_n_folders(tids: list, delete_mongo: bool):
             for id in ids_tmp:
                 if db.delete_task(id):
                     try:
-                        path = os.path.join(CUCKOO_ROOT, "storage", "analyses", "%s", str(id))
+                        path = os.path.join(CUCKOO_ROOT, "storage", "analyses", str(id))
                         if path_is_dir(path):
                             delete_folder(path)
                     except Exception as e:
@@ -194,7 +194,7 @@ def delete_bulk_tasks_n_folders(tids: list, delete_mongo: bool):
             # If we don't remove from mongo we should keep in db to be able to show task in webgui
             for id in ids_tmp:
                 try:
-                    path = os.path.join(CUCKOO_ROOT, "storage", "analyses", "%s", str(id))
+                    path = os.path.join(CUCKOO_ROOT, "storage", "analyses", str(id))
                     if path_is_dir(path):
                         delete_folder(path)
                 except Exception as e:

--- a/modules/processing/CAPE.py
+++ b/modules/processing/CAPE.py
@@ -339,7 +339,7 @@ class CAPE(Processing):
         """
         self._set_dict_keys()
         meta = {}
-        # Required to control files extracted by selfextract.conf as we store them in dropped
+        # Required to control files extracted by integrations.conf as we store them in dropped
         duplicated: DuplicatesType = collections.defaultdict(set)
         if path_exists(self.files_metadata):
             for line in open(self.files_metadata, "rb"):


### PR DESCRIPTION
- The change was from `"%s" % str(id)` to `"%s", str(id)`
- Should have been just `str(id)`
- Follows on from f89c890143b59bdbcc9b9c8b5e15fbc5fd827afd
- also changed a comment re: integrations.conf renaming