### PR TITLE
Fix demux

### DIFF
--- a/lib/cuckoo/common/demux.py
+++ b/lib/cuckoo/common/demux.py
@@ -217,7 +217,7 @@ def demux_sflock(filename: bytes, options: str, check_shellcode: bool = True):  
                     tmp_child = _sf_children(ch)
                     # check if path is not empty
                     if tmp_child and tmp_child[0]:
-                        retlist.extend(tmp_child)
+                        retlist.append(tmp_child)
 
                 # child is not available, the original file should be put into the list
                 if not retlist:


### PR DESCRIPTION
fixes

```
for filename, platform, magic_type, file_size in retlist:
ValueError: too many values to unpack (expected 4)
```