### PR TITLE
Fix platform None

### DIFF
--- a/lib/cuckoo/core/plugins.py
+++ b/lib/cuckoo/core/plugins.py
@@ -562,7 +562,7 @@ class RunSignatures:
 
     def _check_signature_platform(self, signature):
         module = inspect.getmodule(signature).__name__
-        platform = self.task.get("platform", "")
+        platform = self.task.get("platform") or ""
 
         if platform in module:
             return True


### PR DESCRIPTION
Fix  edge case `{"platform": None}`

```
if platform in module:
TypeError: 'in <string>' requires string as left operand, not NoneType
```