### PR TITLE
Allow disabling linux strace update_file_descriptors

### DIFF
--- a/conf/default/processing.conf.default
+++ b/conf/default/processing.conf.default
@@ -63,6 +63,7 @@ enabled = no
 processtree = no
 # Platform specific
 platform = linux
+update_file_descriptors = yes
 
 [debug]
 enabled = yes

--- a/modules/processing/strace.py
+++ b/modules/processing/strace.py
@@ -229,6 +229,8 @@ class Processes:
         Returns an updated process list where file-access related calls have
         the matching file descriptor at the time of it being opened.
         """
+        if not self.options.get("update_file_descriptors"):
+            return
         # Default file descriptors
         fd_lookup = {
             "0": [{


### PR DESCRIPTION
Some samples open too many fd and we just get `failed_processing` due to timeout

- 3232cd3755228abce71af80c6e978eeace441b2cf76c2e2322eff07d2b5bde90