### PR TITLE
useragent switcher for firefox

### DIFF
--- a/analyzer/windows/modules/packages/firefox_ext.py
+++ b/analyzer/windows/modules/packages/firefox_ext.py
@@ -25,7 +25,6 @@ class Firefox_Ext(Package):
     """
 
     # set your current firefox profile path (about:profiles)
-    #profile_path = None
     profile_path = None
 
     def start(self, url):

--- a/analyzer/windows/modules/packages/firefox_ext.py
+++ b/analyzer/windows/modules/packages/firefox_ext.py
@@ -1,11 +1,15 @@
 # Copyright (C) 2024 fdiaz@virustotal.com
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
+import base64
+import logging
+import os
 import time
 import webbrowser
 
 from lib.common.abstracts import Package
 
+log = logging.getLogger(__name__)
 
 class Firefox_Ext(Package):
     """Firefox analysis package (with extension)."""
@@ -14,10 +18,32 @@ class Firefox_Ext(Package):
         ("ProgramFiles", "Mozilla Firefox", "firefox.exe"),
     ]
     summary = "Opens the URL in firefox."
-    description = """Spawns firefox.exe and opens the supplied URL."""
+    description = """Spawns firefox.exe and opens the supplied URL.
 
+    Allows setting a custom user-agent string via the 'user_agent' option.
+    The value should be provided base64-encoded.
+    """
+    
+    # set your current firefox profile path (about:profiles)
+    #profile_path = None
+    profile_path = None
+    
     def start(self, url):
-        webbrowser.register("firefox", None, webbrowser.BackgroundBrowser(self.get_path("firefox.exe")))
+        user_agent = self.options.get("user_agent")
+        log.debug("User agent option value: %s", user_agent)
+        if user_agent and self.profile_path:
+            config = os.path.join(self.profile_path, 'prefs.js')
+            ua_decoded = base64.b64decode(user_agent).decode('utf-8')
+            ua_config = f'user_pref("general.useragent.override", "{ua_decoded}");\n'
+            try:
+                os.makedirs(os.path.dirname(config), exist_ok=True)
+                with open(config, 'a') as file:
+                    file.write(ua_config)
+                log.info("Successfully appended user agent to prefs.js: %s", ua_decoded)
+            except Exception as e:
+                log.error("Failed to write user agent to prefs.js: %s", e, exc_info=True)
+        firefox_path = self.get_path("firefox.exe")
+        webbrowser.register("firefox", None, webbrowser.BackgroundBrowser(firefox_path))
         firefox = webbrowser.get("firefox")
         firefox.open("about:blank")
         time.sleep(7)  # Rough estimate, change based on your setup times.

--- a/analyzer/windows/modules/packages/firefox_ext.py
+++ b/analyzer/windows/modules/packages/firefox_ext.py
@@ -31,6 +31,11 @@ class Firefox_Ext(Package):
     def start(self, url):
         user_agent = self.options.get("user_agent")
         log.debug("User agent option value: %s", user_agent)
+        try:
+            base64.b64decode(user_agent)
+        except Exception:
+            log.error("Invalid base64 encoded user agent provided.")
+            user_agent = None
         if user_agent and self.profile_path:
             config = os.path.join(self.profile_path, 'prefs.js')
             ua_decoded = base64.b64decode(user_agent).decode('utf-8')
@@ -41,7 +46,7 @@ class Firefox_Ext(Package):
                     file.write(ua_config)
                 log.info("Successfully appended user agent to prefs.js: %s", ua_decoded)
             except Exception as e:
-                log.error("Failed to write user agent to prefs.js: %s", e, exc_info=True)
+                log.error("Failed to write user agent to prefs.js: %s", e)
         firefox_path = self.get_path("firefox.exe")
         webbrowser.register("firefox", None, webbrowser.BackgroundBrowser(firefox_path))
         firefox = webbrowser.get("firefox")

--- a/analyzer/windows/modules/packages/firefox_ext.py
+++ b/analyzer/windows/modules/packages/firefox_ext.py
@@ -23,11 +23,11 @@ class Firefox_Ext(Package):
     Allows setting a custom user-agent string via the 'user_agent' option.
     The value should be provided base64-encoded.
     """
-    
+
     # set your current firefox profile path (about:profiles)
     #profile_path = None
     profile_path = None
-    
+
     def start(self, url):
         user_agent = self.options.get("user_agent")
         log.debug("User agent option value: %s", user_agent)


### PR DESCRIPTION
Change the Firefox user agent for URL analysis.

The user agent must be sent as a base64-encoded string.
Provide the path to your current Firefox user profile, where the pref.js file is located.
