### PR TITLE
Bump schema version to 4e000e02a409

### DIFF
--- a/lib/cuckoo/core/database.py
+++ b/lib/cuckoo/core/database.py
@@ -129,7 +129,7 @@ if repconf.elasticsearchdb.enabled:
 
     es = elastic_handler
 
-SCHEMA_VERSION = "c2bd0eb5e69d"
+SCHEMA_VERSION = "4e000e02a409"
 TASK_BANNED = "banned"
 TASK_PENDING = "pending"
 TASK_RUNNING = "running"


### PR DESCRIPTION
Follows on from https://github.com/kevoreilly/CAPEv2/pull/2560.

Updates the `SCHEMA_VERSION` constant in `database.py` to `4e000e02a409`