### PR TITLE
Fix for bash script kvm-qemu.sh when installing libvmi

### DIFF
--- a/installer/kvm-qemu.sh
+++ b/installer/kvm-qemu.sh
@@ -294,7 +294,7 @@ function install_libvmi() {
     fi
     mkdir -p /tmp/libvmi_builded/DEBIAN
     echo -e "Package: libvmi\nVersion: 1.0-0\nArchitecture: $ARCH\nMaintainer: $MAINTAINER\nDescription: libvmi" > /tmp/libvmi_builded/DEBIAN/control
-    cd "libvmi-v0.14.0" || return
+    cd "libvmi-0.14.0" || return
 
     # install deps
     aptitude install -f -y cmake flex bison libglib2.0-dev libjson-c-dev libyajl-dev doxygen


### PR DESCRIPTION
Hello everyone!
Please review a small fix to the file `installer/kvm-qemu.sh` for the libvmi installation script.

When installing KVM/QEMU twice using this script I received such the error every time:
```bash
bash: cd: libvmi-v0.14.0: No such file or directory
```
### How to reproduce
```bash
cd /tmp
wget -q https://github.com/libvmi/libvmi/archive/refs/tags/v0.14.0.zip -O libvmi-v0.14.0.zip
unzip libvmi-v0.14.0.zip
cd "libvmi-v0.14.0"
```
### Expected result
```bash
user@ubuntu24:/tmp/libvmi-v0.14.0$
```
### The actual result
```bash
bash: cd: libvmi-v0.14.0: No such file or directory
```
### Description
The downloaded file `libvmi-v0.14.0.zip` has the `libvmi-0.14.0` directory inside, not the `libvmi-v0.14.0`.

### What to be changed
This string:
```bash
cd "libvmi-v0.14.0" || return
```
is changing to this:
```bash
cd "libvmi-0.14.0" || return
```