### PR TITLE
Wireshark installation fails in non-interactive environments

### DIFF
--- a/installer/cape2.sh
+++ b/installer/cape2.sh
@@ -963,7 +963,7 @@ function dependencies() {
     sudo apt-get install -y python3-pip build-essential libssl-dev libssl3 python3-dev cmake nfs-common crudini
     sudo apt-get install -y innoextract msitools iptables psmisc jq sqlite3 tmux net-tools checkinstall graphviz python3-pydot git numactl python3 python3-dev python3-pip libjpeg-dev zlib1g-dev
     sudo apt-get install -y zpaq upx-ucl wget zip unzip lzip rar unrar unace-nonfree cabextract geoip-database libgeoip-dev libjpeg-dev mono-utils ssdeep libfuzzy-dev exiftool
-    sudo apt-get install -y uthash-dev libconfig-dev libarchive-dev libtool autoconf automake privoxy software-properties-common wkhtmltopdf xvfb xfonts-100dpi tcpdump libcap2-bin wireshark-common
+    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y uthash-dev libconfig-dev libarchive-dev libtool autoconf automake privoxy software-properties-common wkhtmltopdf xvfb xfonts-100dpi tcpdump libcap2-bin wireshark-common
     sudo apt-get install -y python3-pil subversion uwsgi uwsgi-plugin-python3 python3-pyelftools git curl
     sudo apt-get install -y openvpn wireguard
     # for bingraph


### PR DESCRIPTION
### Problem
When running the installer script, the terminal exits unexpectedly during the Wireshark package installation. This is because wireshark-common prompts for user input (e.g., permission to allow non-superusers to capture packets), which requires an interactive terminal.

This breaks automated installations or any environment (like CI/CD pipelines or Docker builds) where user interaction is not possible.

### Solution
Set the environment variable DEBIAN_FRONTEND=noninteractive before installing Wireshark to suppress the interactive prompt:

```bash
DEBIAN_FRONTEND=noninteractive apt-get install -y wireshark
```

This ensures the script runs smoothly in non-interactive sessions.

### Additional Notes

- The script could optionally pre-answer debconf selections if needed.

- Tested on Debian/Ubuntu systems.

- Does not impact systems where interaction is possible — only improves automation compatibility.