### PR TITLE
Apply DEBIAN_FRONTEND=noninteractive globally in install script

### DIFF
--- a/installer/cape2.sh
+++ b/installer/cape2.sh
@@ -6,7 +6,7 @@
 
 # Huge thanks to: @NaxoneZ @kevoreilly @ENZOK @wmetcalf @ClaudioWayne
 
-# Ensure non-interactive mode for apt commands globally
+# Ensure non-interactive mode for apt commands globally to prevent prompts during automated installations
 export DEBIAN_FRONTEND=noninteractive
 
 # Static values

--- a/installer/cape2.sh
+++ b/installer/cape2.sh
@@ -6,6 +6,9 @@
 
 # Huge thanks to: @NaxoneZ @kevoreilly @ENZOK @wmetcalf @ClaudioWayne
 
+# Ensure non-interactive mode for apt commands globally
+export DEBIAN_FRONTEND=noninteractive
+
 # Static values
 # Where to place everything
 # CAPE TcpDump will sniff this interface


### PR DESCRIPTION
### What Changed
Moved the `DEBIAN_FRONTEND=noninteractive` declaration to the top of the install script to ensure all `apt-get` operations run in non-interactive mode.

### Why
This improves consistency and prevents prompts from other packages in automated or CI environments. It also aligns with maintainer feedback from the previous PR.

### Related
Follow-up to the fix for Wireshark interactive installation.