### PR TITLE
agent spawn child subprocess not grandchild

### DIFF
--- a/agent/agent.py
+++ b/agent/agent.py
@@ -378,7 +378,7 @@ def get_subprocess_status():
     """Return the subprocess status."""
     async_subprocess = state.get("async_subprocess")
     message = "Analysis status"
-    exitcode = async_subprocess.exitcode
+    exitcode = async_subprocess.poll()
     if exitcode is None or (sys.platform == "win32" and exitcode == 259):
         # Process is still running.
         state["status"] = Status.RUNNING
@@ -713,9 +713,7 @@ def background_subprocess(command_args, cwd, base64_encode, shell=False):
 
 def spawn(args, cwd, base64_encode, shell=False):
     """Kick off a subprocess in the background."""
-    run_subprocess_args = [args, cwd, base64_encode, shell]
-    proc = multiprocessing.Process(target=background_subprocess, name=f"child process {args[1]}", args=run_subprocess_args)
-    proc.start()
+    proc = subprocess.Popen(args, cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=shell)
     state["status"] = Status.RUNNING
     state["description"] = ""
     state["async_subprocess"] = proc

--- a/agent/test_agent.py
+++ b/agent/test_agent.py
@@ -9,6 +9,7 @@ import os
 import pathlib
 import random
 import shutil
+import subprocess
 import sys
 import tempfile
 import time
@@ -39,8 +40,8 @@ class TestAgentFunctions:
     @mock.patch("sys.platform", "win32")
     def test_get_subprocess_259(self):
         mock_process_id = 999998
-        mock_subprocess = mock.Mock(spec=multiprocessing.Process)
-        mock_subprocess.exitcode = 259
+        mock_subprocess = mock.Mock(spec=subprocess.Popen)
+        mock_subprocess.poll = mock.Mock(return_value=259)
         mock_subprocess.pid = mock_process_id
         with mock.patch.dict(agent.state, {"async_subprocess": mock_subprocess}):
             actual = agent.get_subprocess_status()


### PR DESCRIPTION
The agent is creating the analyzer as a grandchild process rather than just a child.

The analyzer protects its own pid and its parent. 

Use `subprocess.Popen()` instead of `multiprocessing.Process()`