### PR TITLE
Improve exception handling in Guacamole view & Vpshere

### DIFF
--- a/modules/machinery/vsphere.py
+++ b/modules/machinery/vsphere.py
@@ -113,8 +113,8 @@ class vSphere(Machinery):
                         raise CuckooCriticalError(
                             f"Snapshot for machine {machine.label} not in powered-on state, please create one"
                         )
-        except Exception:
-            raise CuckooCriticalError("Couldn't connect to vSphere host")
+        except Exception as e
+            raise CuckooCriticalError(f"Couldn't connect to vSphere host: {e}")
 
         super(vSphere, self)._initialize_check()
 

--- a/modules/machinery/vsphere.py
+++ b/modules/machinery/vsphere.py
@@ -113,7 +113,8 @@ class vSphere(Machinery):
                         raise CuckooCriticalError(
                             f"Snapshot for machine {machine.label} not in powered-on state, please create one"
                         )
-        except Exception as e
+        except Exception as e:
+            logging.exception("Couldn't connect to vSphere host")
             raise CuckooCriticalError(f"Couldn't connect to vSphere host: {e}")
 
         super(vSphere, self)._initialize_check()

--- a/web/guac/templates/guac/error.html
+++ b/web/guac/templates/guac/error.html
@@ -1,3 +1,4 @@
+{% load static %}
 <!DOCTYPE html>
 <html>
 <head>

--- a/web/guac/views.py
+++ b/web/guac/views.py
@@ -1,22 +1,39 @@
 from base64 import urlsafe_b64decode
 from xml.etree import ElementTree as ET
-
 from django.shortcuts import render
-
 from lib.cuckoo.common.config import Config
 
 try:
     import libvirt
+    LIBVIRT_AVAILABLE = True
 except ImportError:
     print("Missed python-libvirt. Use extra/libvirt_installer.sh")
+    LIBVIRT_AVAILABLE = False
 
 machinery = Config().cuckoo.machinery
+machinery_available = ["kvm", "qemu"]
 machinery_dsn = getattr(Config(machinery), machinery).get("dsn", "qemu:///system")
 
-
 def index(request, task_id, session_data):
-    conn = libvirt.open(machinery_dsn)
+    if not LIBVIRT_AVAILABLE:
+        return render(
+            request,
+            "guac/error.html",
+            {"error_msg": "Libvirt not available", "error": "remote session", "task_id": task_id},
+        )
+    
+    if machinery not in machinery_available:
+        return render(
+            request,
+            "guac/error.html",
+            {"error_msg": f"Machinery type '{machinery}' is not supported", "error": "remote session", "task_id": task_id},
+        )
+    
+    conn = None
+    state = None
     recording_name = ""
+    
+    conn = libvirt.open(machinery_dsn)
     if conn:
         try:
             session_id, label, guest_ip = urlsafe_b64decode(session_data).decode("utf8").split("|")
@@ -30,7 +47,7 @@ def index(request, task_id, session_data):
                 "guac/error.html",
                 {"error_msg": f"{e}", "error": "remote session", "task_id": task_id},
             )
-
+    
     if state:
         if state[0] == 1:
             vmXml = dom.XMLDesc(0)

--- a/web/guac/views.py
+++ b/web/guac/views.py
@@ -5,6 +5,7 @@ from lib.cuckoo.common.config import Config
 
 try:
     import libvirt
+
     LIBVIRT_AVAILABLE = True
 except ImportError:
     print("Missed python-libvirt. Use extra/libvirt_installer.sh")
@@ -14,6 +15,7 @@ machinery = Config().cuckoo.machinery
 machinery_available = ["kvm", "qemu"]
 machinery_dsn = getattr(Config(machinery), machinery).get("dsn", "qemu:///system")
 
+
 def index(request, task_id, session_data):
     if not LIBVIRT_AVAILABLE:
         return render(
@@ -21,18 +23,18 @@ def index(request, task_id, session_data):
             "guac/error.html",
             {"error_msg": "Libvirt not available", "error": "remote session", "task_id": task_id},
         )
-    
+
     if machinery not in machinery_available:
         return render(
             request,
             "guac/error.html",
             {"error_msg": f"Machinery type '{machinery}' is not supported", "error": "remote session", "task_id": task_id},
         )
-    
+
     conn = None
     state = None
     recording_name = ""
-    
+
     conn = libvirt.open(machinery_dsn)
     if conn:
         try:
@@ -47,7 +49,7 @@ def index(request, task_id, session_data):
                 "guac/error.html",
                 {"error_msg": f"{e}", "error": "remote session", "task_id": task_id},
             )
-    
+
     if state:
         if state[0] == 1:
             vmXml = dom.XMLDesc(0)


### PR DESCRIPTION
### Summary

Improved exception handling in `vsphere.py` and the Guacamole view:

- In `vsphere.py`, added error details to the `CuckooCriticalError` message for better debugging.
- In `guac/views.py`, added proper checks to:
  - Ensure `libvirt` is available before using it
  - Restrict Guacamole usage to compatible machinery types (`kvm`, `qemu`)
- Updated the error page template to load static files if needed

These changes help avoid unexpected crashes or misleading behavior when using unsupported backends like `vsphere`, and improve feedback to the user.

---

This is my first contribution to the project — happy to get any feedback.