### PR TITLE
Reduce vivisect.base and vivisect.impemu cape-processor logs

### DIFF
--- a/lib/cuckoo/common/integrations/capa.py
+++ b/lib/cuckoo/common/integrations/capa.py
@@ -50,9 +50,12 @@ if integrations_conf.flare_capa.enabled:
             from pydantic_core._pydantic_core import ValidationError
 
             # Reduce vivisect logging verbosity
-            logging.getLogger("vivisect").setLevel(logging.CRITICAL)
+            logging.getLogger("vivisect").setLevel(logging.INFO)
             logging.getLogger("vivisect.base").setLevel(logging.CRITICAL)
             logging.getLogger("vivisect.impemu").setLevel(logging.CRITICAL)
+            logging.getLogger("vivisect.parsers").setLevel(logging.CRITICAL)
+            logging.getLogger("vivisect.tools").setLevel(logging.CRITICAL)
+            logging.getLogger("vivisect.analysis").setLevel(logging.CRITICAL)
 
             rules_path = os.path.join(CUCKOO_ROOT, "data", "capa-rules")
             if path_exists(rules_path):


### PR DESCRIPTION
Cape-processor logs are flooded with vivisect logs. These changes keep relevant `vivisect` logs and remove `vivisect.base` and `vivisect.impemu` logs below the `ERROR` level.