### PR TITLE
fix Interactive desktop

### DIFF
--- a/web/guac/templates/guac/error.html
+++ b/web/guac/templates/guac/error.html
@@ -1,3 +1,4 @@
+{% load static %}
 <!DOCTYPE html>
 <html>
 <head>

--- a/web/submission/views.py
+++ b/web/submission/views.py
@@ -804,7 +804,7 @@ def remote_session(request, task_id):
     session_data = ""
 
     if task.status == "running":
-        machine = db.view_machine(task.machine)
+        machine = db.view_machine_by_label(task.machine)
         if not machine:
             return render(request, "error.html", {"error": "Machine is not set for this task."})
         guest_ip = machine.ip


### PR DESCRIPTION
Fixed guac error page.
Fixed submission, machine was always NONE so error page was shown. I changed db.view_machine to db.view_machine_by_label like here, and it worked again: https://github.com/kevoreilly/CAPEv2/blob/5d15ec1364f52eaa8b1e329e0aa3e3c5864925ef/web/submission/views.py#L787