### PR TITLE
Resolve "The Poetry configuration is invalid"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,6 @@ description = "CAPE: Malware Configuration And Payload Extraction"
 authors = ["Kevin O'Reilly <kev@capesandbox.com>", "doomedraven <doomedraven@capesandbox.com>"]
 license = "MIT"
 package-mode = false
-requires-poetry = ">=2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.10, <4.0"
@@ -139,6 +138,7 @@ asyncio_mode = "auto"
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
+requires-poetry = ">=2.0"
 
 [tool.ruff]
 line-length = 132


### PR DESCRIPTION
This commit fixes the following error when poetry install is run to install dependencies inside /opt/CAPEv2:

```
The Poetry configuration is invalid:
  - Additional properties are not allowed ('requires-poetry' was unexpected)
```