### PR TITLE
Improve logging

### DIFF
--- a/cuckoo.py
+++ b/cuckoo.py
@@ -7,7 +7,6 @@ import argparse
 import logging
 import os
 import sys
-import traceback
 from pathlib import Path
 
 from lib.cuckoo.core.database import Database, init_database
@@ -145,7 +144,7 @@ if __name__ == "__main__":
         except CuckooCriticalError as e:
             message = "{0}: {1}".format(e.__class__.__name__, e)
             if any(filter(lambda hdlr: not isinstance(hdlr, logging.NullHandler), log.handlers)):
-                log.critical(traceback.format_exc(e))
+                log.critical(message, exc_info=True)
             else:
                 sys.stderr.write("{0}\n".format(message))
 

--- a/cuckoo.py
+++ b/cuckoo.py
@@ -7,6 +7,7 @@ import argparse
 import logging
 import os
 import sys
+import traceback
 from pathlib import Path
 
 from lib.cuckoo.core.database import Database, init_database
@@ -144,7 +145,7 @@ if __name__ == "__main__":
         except CuckooCriticalError as e:
             message = "{0}: {1}".format(e.__class__.__name__, e)
             if any(filter(lambda hdlr: not isinstance(hdlr, logging.NullHandler), log.handlers)):
-                log.critical(message)
+                log.critical(traceback.format_exc(e))
             else:
                 sys.stderr.write("{0}\n".format(message))
 


### PR DESCRIPTION
Print full traceback instead of only the last occuring error (which is often caused by previous ones)
As an example, errors thrown by machineries are stripped of their details before being printed to the user (as seen on #2682).