### PR TITLE
Only show interactive options and infos when enabled and used (AI imp…

### DIFF
--- a/web/submission/views.py
+++ b/web/submission/views.py
@@ -653,6 +653,7 @@ def index(request, task_id=None, resubmit_hash=None):
         enabledconf["pre_script"] = web_conf.pre_script.enabled
         enabledconf["during_script"] = web_conf.during_script.enabled
         enabledconf["downloading_service"] = bool(downloader_services.downloaders)
+        enabledconf["interactive_desktop"] = web_conf.guacamole.enabled
 
         all_vms_tags = load_vms_tags()
 
@@ -775,7 +776,7 @@ def status(request, task_id):
         "session_data": "",
         "target": task.sample.sha256 if getattr(task, "sample") else task.target,
     }
-    if settings.REMOTE_SESSION:
+    if web_conf.guacamole.enabled and get_options(task.options).get("interactive") == "1":
         machine = db.view_machine_by_label(task.machine)
         if machine:
             guest_ip = machine.ip

--- a/web/templates/submission/index.html
+++ b/web/templates/submission/index.html
@@ -674,16 +674,18 @@ $(document).ready( function() {
                                         <input type="checkbox" name="nohuman" /> Disable automated interaction
                                     </label>
                                 </div>
+                                {% if config.interactive_desktop %}
                                 <div class="form-check">
                                     <label>
-                                        <input type="checkbox" name="interactive" /> Interactive desktop
+                                        <input type="checkbox" id="interactive" name="interactive" /> Interactive desktop
                                     </label>
                                 </div>
                                 <div class="form-check">
                                     <label>
-                                        <input type="checkbox" name="manual" /> Manual detonation. Must be used with Interactive desktop
+                                        <input type="checkbox" id="manual" name="manual" disabled /> Manual detonation <span class="text-muted"><small>(Must be used with Interactive desktop!)</small></span>
                                     </label>
                                 </div>
+                                {% endif %}
                                 {% if config.kernel %}
                                 <div class="form-check">
                                     <label>
@@ -711,4 +713,22 @@ $(document).ready( function() {
         </form>
     </div>
 </div>
+<script>
+document.addEventListener("DOMContentLoaded", function() {
+    const interactive = document.getElementById("interactive");
+    const manual = document.getElementById("manual");
+
+    if (interactive && manual) {
+        const syncManualCheckbox = () => {
+            manual.disabled = !interactive.checked;
+            if (!interactive.checked) {
+                manual.checked = false;
+            }
+        };
+
+        syncManualCheckbox();
+        interactive.addEventListener("change", syncManualCheckbox);
+    }
+});
+</script>
 {% endblock %}

--- a/web/templates/submission/status.html
+++ b/web/templates/submission/status.html
@@ -15,10 +15,10 @@
         <p>The analysis is not finished yet, it's still <b>{{status}}</b>. This page will refresh every 30 seconds.</p>
         {% if session_data %}
             <p>To view the Remote Session - click <a href='javascript:window.open(window.location.origin + "/guac/{{task_id}}/{{session_data}}", "_blank");'>here.</a></p>
-            <div class="progress progress-striped active" style="margin-top: 10px;">
-                <div class="progress-bar progress-bar-striped progress-bar-animated" style="width:100%"></div>
-            </div>
         {% endif %}
+        <div class="progress progress-striped active" style="margin-top: 10px;">
+                <div class="progress-bar progress-bar-striped progress-bar-animated" style="width:100%"></div>
+        </div>
     </div>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
…rovements)
- Show interactive and manual check boxes depending on whether they are configured on submit page
- Display remote session information on the task status website only if it has been configured and activated.
- Disable Manual checkbox on submit page when interactive checkbox is unchecked
- AI improvements included