### PR TITLE
start libvirt VM in case snapshot was taken in shut-off mode

### DIFF
--- a/lib/cuckoo/common/abstracts.py
+++ b/lib/cuckoo/common/abstracts.py
@@ -453,7 +453,7 @@ class LibVirtMachinery(Machinery):
                 self.vms[label].revertToSnapshot(snapshot, flags=0)
                 _start_vm_if_necessary(snapshot, vm)
             except libvirt.libvirtError as e:
-                msg = f"Unable to restore snapshot {vm_info.snapshot} on virtual machine {label}. Your snapshot MUST BE in running state!"
+                msg = f"Unable to restore snapshot {vm_info.snapshot} on virtual machine {label}. Please ensure the snapshot is valid."
                 raise CuckooMachineError(msg) from e
             finally:
                 self._disconnect(conn)


### PR DESCRIPTION
If the Libvirt VM Snapshot was not taken while the VM was running (shutoff) then the VM will not be automatically started which causes the job to timeout.

This PR checks the snapshot state and will start the VM if needed.

Newer libvirt specs (e.g. Windows 11 machine with pflash) do not support live snapshots, therefore this is particularly useful for these configuration where snapshots in shutoff state are required.