### PR TITLE
Use ZIP_DEFLATE instead of ZIP_LZMA

### DIFF
--- a/lib/cuckoo/common/utils.py
+++ b/lib/cuckoo/common/utils.py
@@ -153,7 +153,7 @@ def create_zip(files=False, folder=False, encrypted=False):
 
     mem_zip = BytesIO()
     if encrypted and HAVE_PYZIPPER:
-        zipper = pyzipper.AESZipFile(mem_zip, "w", compression=pyzipper.ZIP_LZMA, encryption=pyzipper.WZ_AES)
+        zipper = pyzipper.AESZipFile(mem_zip, "w", compression=pyzipper.ZIP_DEFLATED, encryption=pyzipper.WZ_AES)
     else:
         zipper = zipfile.ZipFile(mem_zip, "a", zipfile.ZIP_DEFLATED, False)
     with zipper as zf:

--- a/web/analysis/views.py
+++ b/web/analysis/views.py
@@ -1964,7 +1964,7 @@ def file(request, category, task_id, dlfile):
                 return resp
             else:
                 mem_zip = BytesIO()
-                with pyzipper.AESZipFile(mem_zip, "w", compression=pyzipper.ZIP_LZMA, encryption=pyzipper.WZ_AES) as zf:
+                with pyzipper.AESZipFile(mem_zip, "w", compression=pyzipper.ZIP_DEFLATED, encryption=pyzipper.WZ_AES) as zf:
                     zf.setpassword(settings.ZIP_PWD)
                     if not isinstance(path, list):
                         path = [path]
@@ -2032,7 +2032,7 @@ def procdump(request, task_id, process_id, start, end, zipped=False):
                 s.seek(0)
                 if zipped and HAVE_PYZIPPER:
                     mem_zip = BytesIO()
-                    with pyzipper.AESZipFile(mem_zip, "w", compression=pyzipper.ZIP_LZMA, encryption=pyzipper.WZ_AES) as zf:
+                    with pyzipper.AESZipFile(mem_zip, "w", compression=pyzipper.ZIP_DEFLATED, encryption=pyzipper.WZ_AES) as zf:
                         zf.setpassword(settings.ZIP_PWD)
                         zf.writestr(file_name, s.getvalue())
                     file_name += ".zip"


### PR DESCRIPTION
This makes archives easier to decompress/decrypt as ZIP_DEFLATE is supported by all standard ZIP libraries. ZIP_LZMA requires third-party tools like 7Zip.