### PR TITLE
Enable protocol extended information to be generated without a TLS master secret

### DIFF
--- a/modules/processing/network.py
+++ b/modules/processing/network.py
@@ -1140,10 +1140,9 @@ class NetworkAnalysis(Processing):
 
         if HAVE_HTTPREPLAY:
             try:
-                p2 = {}
                 tls_master = self.get_tlsmaster()
                 p2 = Pcap2(self.pcap_path, tls_master, self.network_path).run()
-                if p2:
+                if any(p2.values()):
                     results.update(p2)
             except Exception:
                 log.exception("Error running httpreplay-based PCAP analysis")


### PR DESCRIPTION
The deleted if prevents obtaining protocol extended information, like http_ex, if the analyzed sample does not have a TLS master secret dumped. This information is useful regardless of whether the sample performs TLS communications or not. In my experimentation the `Pcap2` class works fine when `tls_master` is `{}`.