### PR TITLE
Fix a bug that prevents terminal status from being reported by the agent

### DIFF
--- a/agent/agent.py
+++ b/agent/agent.py
@@ -92,6 +92,8 @@ class Status(enum.IntEnum):
         return None
 
 
+TERMINAL_STATUSES = [Status.COMPLETE, Status.FAILED, Status.EXCEPTION]
+
 AGENT_BROWSER_EXT_PATH = ""
 AGENT_BROWSER_LOCK = Lock()
 ANALYZER_FOLDER = ""
@@ -493,6 +495,11 @@ def put_status():
         status = Status(request.form.get("status"))
     except ValueError:
         return json_error(400, "No valid status has been provided")
+
+    # If the new status is terminal, unset the async subprocess so /status reports
+    # the final analysis state rather than the child process state.
+    if status in TERMINAL_STATUSES:
+        state["async_subprocess"] = None
 
     state["status"] = status
     state["description"] = request.form.get("description")


### PR DESCRIPTION
Updates the POST /status endpoint to unset the async subprocess if the new status is terminal. This makes GET /status report the final analysis state, rather than the child process state.

See https://github.com/kevoreilly/CAPEv2/compare/master...josh-feather:CAPEv2:agent-terminal-status-update?expand=1#diff-14871e8d8c7b1cfa74aec39f46895f82101d3e070dc811eed3a6d1dd3e70e65dL446 for context