### PR TITLE
Fix 'machines' vars on Azure

### DIFF
--- a/modules/machinery/az.py
+++ b/modules/machinery/az.py
@@ -618,7 +618,7 @@ class Azure(Machinery):
 
         machines = self.db.session.query(Machine).options(sqlalchemy.orm.joinedload(Machine.tags))
         filter_kwargs = {
-            "machines": machines,
+            "statement": machines,
             "label": task.machine,
             "tags": task_tags,
             "archs": task_archs,


### PR DESCRIPTION
It seems that commit ba590a7dd5834ffc1a7945afe253708baaa66b31 introducing modification to database.py broke az.py filter_kwargs dict :

[lib.cuckoo.core.scheduler] ERROR: Failed to find next serviceable task
Traceback (most recent call last):
  File "/opt/CAPEv2/lib/cuckoo/core/scheduler.py", line 119, in do_main_loop_work
    task, machine = self.find_next_serviceable_task(max_machines_reached)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/CAPEv2/lib/cuckoo/core/scheduler.py", line 154, in find_next_serviceable_task
    task, machine = self.find_pending_task_to_service()
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/CAPEv2/lib/cuckoo/core/scheduler.py", line 196, in find_pending_task_to_service
    machine = self.machinery_manager.find_machine_to_service_task(task_candidate)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/CAPEv2/lib/cuckoo/core/machinery_manager.py", line 209, in find_machine_to_service_task
    machine = self.machinery.find_machine_to_service_task(task)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/CAPEv2/modules/machinery/az.py", line 627, in find_machine_to_service_task
    filtered_machines = self.db.filter_machines_to_task(include_reserved=False, **filter_kwargs)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: _Database.filter_machines_to_task() got an unexpected keyword argument 'machines'

As 'machines' was replaced with 'statement' in filter_machines_to_task()

I did not review and understood all changes which resulted from this commit, but it corrected the issue on my tests.