### PR TITLE
analyzer/linux: Fix get_proc_status parsing

### DIFF
--- a/analyzer/linux/lib/api/process.py
+++ b/analyzer/linux/lib/api/process.py
@@ -30,7 +30,7 @@ class Process:
         return True
 
     def get_parent_pid(self):
-        return self.get_proc_status().get("PPid")
+        return int(self.get_proc_status().get("PPid"))
 
     def get_proc_status(self):
         try:


### PR DESCRIPTION
When parsing the `/proc/<id>/status` file some fields are empty which made the dict() conversion fail because the list length was 1.

With this change, we are splitting on the ":" character and striping the key and the value so we can get the key without the ":" at the end and the value without any "\t" at the beginning or "\n" at the end.