### PR TITLE
Fix clock handling for API submissions

### DIFF
--- a/lib/cuckoo/common/web_utils.py
+++ b/lib/cuckoo/common/web_utils.py
@@ -1535,7 +1535,7 @@ def parse_request_arguments(request, keyword="POST"):
     tags = getattr(request, keyword).get("tags")
     custom = getattr(request, keyword).get("custom", "")
     memory = force_bool(getattr(request, keyword).get("memory", False))
-    clock = getattr(request, keyword).get("clock", datetime.now().strftime("%m-%d-%Y %H:%M:%S"))
+    clock = getattr(request, keyword).get("clock", "")
     if not clock:
         clock = datetime.utcfromtimestamp(0)
     elif "1970" in clock:


### PR DESCRIPTION
When submitting a sample through the API without specifying the clock, the `parse_request_arguments()` function automatically [sets the clock to the submission time](https://github.com/kevoreilly/CAPEv2/blob/master/lib/cuckoo/common/web_utils.py#L1539-L1540). Later, the [analysis manager](https://github.com/kevoreilly/CAPEv2/blob/master/lib/cuckoo/core/analysis_manager.py#L422) tries to update the clock before running the task. However, the clock update only works correctly if the timestamp is set to 0 ([database.py](https://github.com/kevoreilly/CAPEv2/blob/master/lib/cuckoo/core/database.py#L820))

This behavior can cause problems in large-scale analyses, where there can be a significant delay (even days) between submission and execution. In such cases, if the sample makes network requests, they can fail due to the large discrepancy between the submission time and the actual task execution time.

Setting the clock to 0 instead of the submission time ensures that the clock update in the analysis manager works correctly, preventing this issue