### PR TITLE
Improve cleaners

### DIFF
--- a/lib/cuckoo/common/cleaners_utils.py
+++ b/lib/cuckoo/common/cleaners_utils.py
@@ -56,7 +56,6 @@ if repconf.mongodb.enabled:
         mongo_update_one,
         mongo_update_many,
         mongo_delete_calls_by_task_id_in_range,
-        mongo_delete_data_range,
     )
 elif repconf.elasticsearchdb.enabled:
     from dev_utils.elasticsearchdb import all_docs, delete_analysis_and_related_calls, get_analysis_index
@@ -470,9 +469,9 @@ def tmp_clean_before(timerange: str):
 
 
 def cuckoo_clean_before(args: dict):
-    """Clean up failed tasks
+    """Clean up old tasks
     It deletes all stored data from file system and configured databases (SQL
-    and MongoDB for tasks completed before now - time range.
+    and optionally MongoDB) for tasks completed before now - time range.
     """
     # Init logging.
     # This need to init a console logger handler, because the standard
@@ -498,7 +497,12 @@ def cuckoo_clean_before(args: dict):
         log.info("url filter applied")
         category = "url"
 
-    old_tasks = db.list_tasks(added_before=added_before, category=category, not_status=TASK_PENDING)
+    tags_tasks_like = args.get("tags_tasks_filter", False)
+
+    old_tasks = db.list_tasks(added_before=added_before,
+                              category=category,
+                              not_status=TASK_PENDING,
+                              tags_tasks_like=tags_tasks_like)
 
     # We need this to cleanup file system and MongoDB calls collection
     id_arr = [e.id for e in old_tasks]
@@ -537,7 +541,9 @@ def cuckoo_clean_before(args: dict):
                 sys.exit()
         mongo_delete_data(id_arr)
 
-    db.delete_tasks(added_before=added_before, category=category)
+    db.delete_tasks(added_before=added_before,
+                    category=category,
+                    tags_tasks_like=tags_tasks_like)
 
 
 def cuckoo_clean_sorted_pcap_dump():

--- a/utils/cleaners.py
+++ b/utils/cleaners.py
@@ -30,18 +30,21 @@ if __name__ == "__main__":
     parser.add_argument("--pcap-sorted-clean", help="Remove sorted pcap from jobs", action="store_true", required=False)
     parser.add_argument(
         "--suricata-zero-alert-filter",
-        help="only remove events with zero suri alerts DELETE AFTER ONLY",
+        help="only remove events with zero suri alerts (DELETE-OLDER-THAN ONLY)",
         action="store_true",
         required=False,
     )
     parser.add_argument(
-        "--urls-only-filter", help="only remove url events filter DELETE AFTER ONLY", action="store_true", required=False
+        "--urls-only-filter", help="only remove url events filter (DELETE-OLDER-THAN ONLY)", action="store_true", required=False
     )
     parser.add_argument(
-        "--files-only-filter", help="only remove files events filter DELETE AFTER ONLY", action="store_true", required=False
+        "--files-only-filter", help="only remove files events filter (DELETE-OLDER-THAN ONLY)", action="store_true", required=False
     )
     parser.add_argument(
-        "--custom-include-filter", help="Only include jobs that match the custom field DELETE AFTER ONLY", required=False
+        "--custom-include-filter", help="Only include jobs that match the custom field (DELETE-OLDER-THAN ONLY)", required=False
+    )
+    parser.add_argument(
+        "--tags-tasks-filter", help="Only include jobs whose tags_tasks contains this string (DELETE-OLDER-THAN ONLY)", required=False
     )
     parser.add_argument(
         "--bson-suri-logs-clean", help="clean bson and suri logs from analysis dirs", required=False, action="store_true"


### PR DESCRIPTION
We have a use case where we need to delete tasks with a specific tags_tasks on a different schedule than other tasks. The DB code already supported this, I basically only had to add a CLI option for it.

While doing that, I discovered a critical bug with `--delete-mongo`. It disregarded all filter options and rendered analyses unusable that you actually didn't want to delete.