### PR TITLE
Fix the issue of network ports being empty in the report

### DIFF
--- a/modules/processing/network.py
+++ b/modules/processing/network.py
@@ -776,8 +776,6 @@ class Pcap:
                     offset = file.tell()
                     continue
 
-                self._add_hosts(connection)
-
                 if ip.p == dpkt.ip.IP_PROTO_TCP:
                     tcp = ip.data
                     if not isinstance(tcp, dpkt.tcp.TCP):
@@ -843,6 +841,7 @@ class Pcap:
                     self._icmp_dissect(connection, icmp)
 
                 offset = file.tell()
+                self._add_hosts(connection)
             except AttributeError:
                 continue
             except dpkt.dpkt.NeedData:


### PR DESCRIPTION
The original location network port has not been obtained, which will cause the port information to remain empty.

After modification:
<img width="841" height="400" alt="image" src="https://github.com/user-attachments/assets/dae817f1-1218-43f2-87ef-df4a4c8af0e0" />
