### PR TITLE
Adding fix for yara-python installation

### DIFF
--- a/installer/cape2.sh
+++ b/installer/cape2.sh
@@ -802,16 +802,14 @@ function install_yara_python() {
             --config-settings=\"--global-option=build\" \
             --config-settings=\"--global-option=--enable-cuckoo\" \
             --config-settings=\"--global-option=--enable-magic\" \
-            --config-settings=\"--global-option=--enable-profiling\" \
-            --config-settings=\"--global-option=--dynamic-linking\""
+            --config-settings=\"--global-option=--enable-profiling\""
     else
         sudo -u ${USER} $PYTHON_MGR --directory $CAPE_ROOT $PYTHON_MGR_CMD pip install yara-python \
             --no-binary :all: \
             --config-settings="--global-option=build" \
             --config-settings="--global-option=--enable-cuckoo" \
             --config-settings="--global-option=--enable-magic" \
-            --config-settings="--global-option=--enable-profiling" \
-            --config-settings="--global-option=--dynamic-linking"
+            --config-settings="--global-option=--enable-profiling"
     fi
 
     # Install from local source (commented out)


### PR DESCRIPTION
It looks like the recent changes to `capev2.sh` broke the `yara-python` installation: https://github.com/kevoreilly/CAPEv2/commit/a137ba7c143480d93bcf0b101097419d1eac7501#diff-5e02905676b1cd9a40b12f480c891109525037fc970e00cfbc4b8c6f01ff1d09R135-R814 this results in the following error:

```
Collecting yara-python

  Using cached yara_python-4.5.4.tar.gz (551 kB)

  Installing build dependencies: started

  Installing build dependencies: finished with status 'done'

  Getting requirements to build wheel: started

  Getting requirements to build wheel: finished with status 'error'

  **error**: **subprocess-exited-with-error**

  × Getting requirements to build wheel did not run successfully.

  │ exit code: **1**

  ╰─> [16 lines of output]

      /tmp/pip-build-env-bmuazwxz/overlay/lib/python3.12/site-packages/setuptools/dist.py:759: SetuptoolsDeprecationWarning: License classifiers are deprecated.

      !!

              ********************************************************************************

              Please consider removing the following classifiers in favor of a SPDX license expression:

              License :: OSI Approved :: Apache Software License

              See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.

              ********************************************************************************

      !!

        self._finalize_license_expression()

      running build

      running build_ext

      error: --enable-magic cant be used with --dynamic-linking

      [end of output]

  **note**: This error originates from a subprocess, and is likely not a problem with pip.

ERROR: Failed to build 'yara-python' when getting requirements to build wheel
```

This is due to the addition of `--dynamic-linking` that was not there before: https://github.com/kevoreilly/CAPEv2/commit/a137ba7c143480d93bcf0b101097419d1eac7501#diff-8cd4613e0f151de1760a153ac39223c7df621102f4e2fbb5cde4798cd650742cL11

This PR just removes this line in the new `capev2.sh`