### PR TITLE
Improve Azure VMSS error handling and logging

### DIFF
--- a/modules/machinery/az.py
+++ b/modules/machinery/az.py
@@ -1589,7 +1589,7 @@ class Azure(Machinery):
                 with current_operations_lock:
                     current_vmss_operations -= 1
                 log.debug(
-                    "%successfully deleting instances %s in %s took %ss", 'S' if deleted else 'Uns', str(instance_ids), str(vmss_to_delete_from), str(round(timeit.default_timer() - start_time))
+                    "%ssuccessfully deleting instances %s in %s took %ss", 'S' if deleted else 'Un', str(instance_ids), str(vmss_to_delete_from), str(round(timeit.default_timer() - start_time))
                 )
             except Exception as e:
                 log.error("Exception occurred in the delete thread: %s. Trying again...", str(e))


### PR DESCRIPTION
Adds handling for ResourceNotFoundError when listing VMSS VMs and NICs, preventing exceptions when VMSS capacity is zero. Improves logging for VMSS deletion conditions and corrects log formatting in reimage and delete threads. Also wraps VMSS creation logic in a broader exception handler for robustness.

✦ Here is the summary of changes specifically for the Azure machinery module (`modules/machinery/az.py`):

  Azure Machinery (`az.py`) Enhancements

   * Zero-Scale Compatibility: * Added handling for ResourceNotFoundError in _add_machines_to_db and _delete_machines_from_db_if_missing. This prevents the module from crashing when a Virtual Machine Scale Set (VMSS) has a capacity of 0, enabling the "scale from zero" cost-saving feature.
   * External Management Support:
       * Updated _process_pre_existing_vmsss to honor the just_start parameter. This prevents CAPE from automatically deleting VMSSs that don't match its internal tags/names if they are managed by external tools like Terraform or Ansible.
   * Robust Connection Logic: * Refactored _thr_wait_for_ready_machine to use an explicit socket creation and getaddrinfo iteration loop. This fixes potential thread hangs, improves reliability on busy systems, and adds full support for DNS hostnames and IPv6 addresses.
   * Thread Stability & Error Handling:
       * Wrapped the _thr_create_vmss background thread in a top-level exception handler to ensure that failures during VMSS creation (e.g., subnet issues or API errors) are logged instead of failing silently.
   * Bug Fixes & Logging: * Fixed malformed logging strings in the batch reimage and delete list readers (previously using incorrect set literal syntax and missing format arguments). * Added detailed debug logging for VMSS deletion and zero-capacity scenarios to improve troubleshooting. * Ensured proper import of ResourceNotFoundError from azure.core.exceptions.