### PR TITLE
Improve libvirt based machinery handling

### DIFF
--- a/lib/cuckoo/common/abstracts.py
+++ b/lib/cuckoo/common/abstracts.py
@@ -696,7 +696,7 @@ class LibVirtMachinery(Machinery):
             if hasattr(conn, "listAllDomains"):
                 # flags=0 returns all domains (active and inactive)
                 return [dom.name() for dom in conn.listAllDomains(0)]
-            
+
             # Fallback for older libvirt versions
             names = conn.listDefinedDomains()
             for vid in conn.listDomainsID():


### PR DESCRIPTION
  1. Removal of Stale Object Caching (self.vms)
   * The Problem: The original code cached libvirt VM objects in self.vms during initialization. If the connection dropped or the objects became stale, subsequent operations would fail.
   * The Fix: Removed the self.vms attribute and the _fetch_machines method. All operations (start, stop, _status, etc.) now retrieve a fresh VM object from the active connection locally, ensuring the object is
     always valid.

  2. Implementation of Persistent Connections
   * Initialization: Added self.conn (to store the persistent connection) and self.conn_lock (a threading.Lock) to the __init__ method.
   * Thread-Safe Reconnection Logic: Refactored _connect to:
       * Check if an existing connection exists.
       * Validate if the connection is still alive using isAlive().
       * Gracefully close and reset the connection if it is dead.
       * Reuse the existing connection if it's healthy, significantly reducing overhead.
       * Use locking to prevent race conditions during connection establishment.
   * Connection Reuse: Modified _disconnect to be a no-op (pass), allowing the connection to persist across multiple calls instead of closing and reopening for every VM check.

  3. Improved VM Listing (_list)
   * The Problem: The previous _list implementation often only returned inactive domains or missed active ones depending on the libvirt version and state.
   * The Fix: Updated _list to return both active and inactive domains. It now uses the modern listAllDomains(0) method if available, with a robust fallback that combines listDefinedDomains and listDomainsID for
     older environments.

  4. Connection Lifecycle Management
   * Cleanup: Updated the shutdown method to explicitly close self.conn under lock. This ensures that when CAPE stops or the machinery module is destroyed, the libvirt connection is cleanly terminated, preventing
     resource leaks.

  5. Architectural Compatibility
   * Subclass Support: Maintained the _lookup method used by subclasses (like KVM and ESX). This ensures that specific machinery implementations can still perform targeted lookups while benefiting from the new
     underlying connection management and stale-object prevention logic.

  These changes collectively make the libvirt-based machinery much more robust, faster (due to connection reuse), and reliable in long-running production environments.
