### PR TITLE
Add **kwargs support to MongoDB utility functions

### DIFF
--- a/dev_utils/mongodb.py
+++ b/dev_utils/mongodb.py
@@ -114,11 +114,11 @@ def mongo_insert_one(collection: str, doc):
 
 
 @graceful_auto_reconnect
-def mongo_find(collection: str, query, projection=False, sort=None, limit=None):
+def mongo_find(collection: str, query, projection=False, sort=None, limit=None, **kwargs):
     if sort is None:
         sort = [("_id", -1)]
 
-    find_by = functools.partial(getattr(results_db, collection).find, query, sort=sort)
+    find_by = functools.partial(getattr(results_db, collection).find, query, sort=sort, **kwargs)
     if projection:
         find_by = functools.partial(find_by, projection=projection)
     if limit:
@@ -169,8 +169,8 @@ def mongo_update_one(collection: str, query, projection, bypass_document_validat
 
 
 @graceful_auto_reconnect
-def mongo_aggregate(collection: str, query):
-    return getattr(results_db, collection).aggregate(query)
+def mongo_aggregate(collection: str, query, **kwargs):
+    return getattr(results_db, collection).aggregate(query, **kwargs)
 
 
 @graceful_auto_reconnect

--- a/lib/cuckoo/common/web_utils.py
+++ b/lib/cuckoo/common/web_utils.py
@@ -1309,7 +1309,7 @@ normalized_int_terms = (
 
 
 def perform_search(
-    term: str, value: str, search_limit: int = 0, user_id: int = 0, privs: bool = False, web: bool = True, projection: dict = None
+    term: str, value: str, search_limit: int = 0, user_id: int = 0, privs: bool = False, web: bool = True, projection: dict = None, **kwargs
 ):
     """
     Perform a search based on the provided term and value.
@@ -1421,7 +1421,7 @@ def perform_search(
                 # Stage 9: Add your custom projection
                 {"$project": perform_search_filters},
             ]
-            retval = list(mongo_aggregate(FILES_COLL, pipeline))
+            retval = list(mongo_aggregate(FILES_COLL, pipeline, **kwargs))
             if not retval:
                 return []
         elif isinstance(search_term_map[term], str):
@@ -1441,7 +1441,7 @@ def perform_search(
                 projection[f"target.file.{FILE_REF_KEY}"] = 1
             if term in search_term_map_repetetive_blocks:
                 mongo_search_query = {"$or": [{path: condition} for path, condition in mongo_search_query.items()]}
-            retval = list(mongo_find("analysis", mongo_search_query, projection, limit=search_limit))
+            retval = list(mongo_find("analysis", mongo_search_query, projection, limit=search_limit, **kwargs))
 
         for doc in retval:
             target_file = doc.get("target", {}).get("file", {})


### PR DESCRIPTION
Extended mongo_find and mongo_aggregate in dev_utils/mongodb.py to accept arbitrary keyword arguments, allowing for greater flexibility in MongoDB queries. Updated perform_search in web_utils.py to pass through **kwargs to these functions, enabling advanced query options from the search interface.

 1 from lib.cuckoo.common.web_utils import perform_search
   2 results = perform_search("ip", "1.2.3.4", maxTimeMS=5000)