### PR TITLE
convert string type property data to ints where applicable

### DIFF
--- a/analyzer/windows/modules/auxiliary/amsi.py
+++ b/analyzer/windows/modules/auxiliary/amsi.py
@@ -1004,7 +1004,7 @@ class EventConsumer:
         # Convert the formatted data if necessary
         if isinstance(data, str):
             if out_type >= TDH_OUTTYPE_BYTE and out_type <= TDH_OUTTYPE_UNSIGNEDLONG:
-                with suppress(Exception)
+                with suppress(Exception):
                     data = int(data)
 
         if out_type in TDH_CONVERTER_LOOKUP and type(data) is TDH_CONVERTER_LOOKUP[out_type]:


### PR DESCRIPTION
I've been trying to get amsi_collector to work, but the processing module errors out:

> 2026-01-26 01:09:13,546 [Task 55] [modules.processing.amsi] ERROR: Failed to process line 1 of /opt/CAPEv2/storage/analyses/55/aux/amsi/amsi.jsonl.
> Traceback (most recent call last):
>   File "/opt/CAPEv2/utils/../modules/processing/amsi.py", line 24, in run
>     try:
> 
>   File "/opt/CAPEv2/utils/../modules/processing/amsi.py", line 49, in decode_event
>     "activity_id": header["ActivityId"],
>                    ^^^^^^^^^^^^^^^^^^^^^^
>   File "/opt/CAPEv2/utils/../modules/processing/amsi.py", line 65, in scan_result_to_str
>     return "detected"
>      ^^^^^^^^^^^^
> TypeError: unsupported operand type(s) for &: 'str' and 'int'
> 

The amsi.py processor expects scanResult to be an int, but in the actual AMSI data that gets written to aux/amsi/amsi.jsonl, the properties are all strings:

> Task Name: "MICROSOFT-ANTIMALWARE-SCAN-INTERFACE",
> session: "0x1433",
> scanStatus: "1",
> scanResult: "1",
> appname: "PowerShell_C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe_10.0.19041.1",
> contentname: "",
> contentsize: "432",
> originalsize: "432",
> hash: "0xEF81B3FB5660B563433FD2EBE1506055F320E69CD6CBE790365EE7741A842261",
> contentFiltered: "false",
> Description: "AmsiScanBuffer "

I could be wrong about the root cause, but it looks like back in the amsi.py analysis module, the 'formatted_data'  argument to TdhFormatProperty is set as ct.c_wchar_p.

This means that the python type comparison at the end of _unpackSimpleType always fails for non-string types:
```
        if out_type in TDH_CONVERTER_LOOKUP and type(data) is TDH_CONVERTER_LOOKUP[out_type]:
            data = TDH_CONVERTER_LOOKUP[out_type](data)
```

To fix this i've added a few lines to detect where the data is a string, and its supposed to be non-float numeric type, and does an integer conversion. It's wrapped in an exception so if that fails it just carries on as normal.

With this change, the "amsi" field in cape reports gets populated as expected:

> 
>   "amsi": [
>     {
>       "timestamp": "2026-01-26T14:06:54.232809+00:00",
>       "thread_id": 3644,
>       "process_id": 3676,
>       "provider_id": "{2A576B87-09A7-520E-C21A-4942F0271D67}",
>       "kernel_time": 6,
>       "user_time": 8,
>       "activity_id": "{AD128CFB-8D97-0002-B2A1-12AD978DDC01}",
>       "scan_result": "not_detected",
>       "app_name": "PowerShell_C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe_10.0.19041.1",
>       "content_name": "C:\\Program Files\\WindowsPowerShell\\Modules\\PSReadline\\2.0.0\\PSReadline.psd1",
>       "content_filtered": "false",
>       "hash": "4cf47c662b8c314fd781fa218da7c63e3a571bc462dcb2e90c4b754c16fc61c2"
>     },

I'd be interested to hear if amsi_collector has ever worked for anyone, or if its a recent change or just an issue with my system?