### PR TITLE
Guac session auth, EVTX periodic snapshots, and web fixes

### DIFF
--- a/analyzer/windows/modules/auxiliary/evtx.py
+++ b/analyzer/windows/modules/auxiliary/evtx.py
@@ -2,6 +2,7 @@ import itertools
 import logging
 import os
 import subprocess
+import time
 import zipfile
 from threading import Thread
 
@@ -88,12 +89,17 @@ class Evtx(Thread, Auxiliary):
         "Microsoft-Windows-DriverFrameworks-UserMode/Operational",
     ]
 
+    # Interval in seconds between periodic snapshots
+    SNAPSHOT_INTERVAL = 30
+
     def __init__(self, options=None, config=None):
         if options is None:
             options = {}
         Thread.__init__(self)
         Auxiliary.__init__(self, options, config)
         self.enabled = config.evtx
+        self.do_run = True
+        self.snapshot_count = 0
         self.startupinfo = subprocess.STARTUPINFO()
         self.startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
 
@@ -181,27 +187,56 @@ class Evtx(Thread, Auxiliary):
             except Exception as err:
                 log.error("Cannot enable audit policy %s (%s) - %s", description, guid, err)
 
-    def collect_windows_logs(self):
-        """Collect selected evtx files, as specified in self.windows_logs."""
-        logs_folder = None
+    def export_windows_logs(self, output_zip):
+        """Export event logs using wevtutil epl (proper export, flushes buffers).
+
+        Unlike raw file copy, wevtutil epl ensures all buffered events are
+        written and the exported file is a consistent snapshot.
+
+        """
+        export_dir = os.path.join(os.environ.get("TEMP", "C:\\Windows\\Temp"), "evtx_export")
+        os.makedirs(export_dir, exist_ok=True)
+
+        exported = []
+        for channel in self.windows_logs:
+            safe_name = channel.replace("/", "%4") + ".evtx"
+            export_path = os.path.join(export_dir, safe_name)
+            try:
+                # Remove previous export if exists
+                if os.path.exists(export_path):
+                    os.unlink(export_path)
+                cmd = f'wevtutil epl "{channel}" "{export_path}" /ow:true'
+                result = subprocess.call(cmd, startupinfo=self.startupinfo,
+                                         timeout=30)
+                if result == 0 and os.path.exists(export_path):
+                    size = os.path.getsize(export_path)
+                    if size > 0:
+                        exported.append((export_path, safe_name))
+            except subprocess.TimeoutExpired:
+                log.debug("Timeout exporting %s", channel)
+            except Exception as err:
+                log.debug("Cannot export %s - %s", channel, err)
+
+        if not exported:
+            return
+
+        with zipfile.ZipFile(output_zip, "w", zipfile.ZIP_DEFLATED) as zip_obj:
+            for export_path, safe_name in exported:
+                try:
+                    zip_obj.write(export_path, safe_name)
+                except Exception as err:
+                    log.debug("Cannot add %s to zip - %s", safe_name, err)
+
+        # Clean up exported files
+        for export_path, _ in exported:
+            try:
+                os.unlink(export_path)
+            except Exception:
+                pass
         try:
-            logs_folder = "C:/windows/Sysnative/winevt/Logs"
-            os.listdir(logs_folder)
+            os.rmdir(export_dir)
         except Exception:
-            logs_folder = "C:/Windows/System32/winevt/Logs"
-
-        with zipfile.ZipFile(self.evtx_dump, "w", zipfile.ZIP_DEFLATED) as zip_obj:
-            for evtx_file_name, selected_evtx in itertools.product(os.listdir(logs_folder), self.windows_logs):
-                _selected_evtx = f"{selected_evtx}.evtx"
-                _selected_evtx = _selected_evtx.replace("/", "%4")
-                if _selected_evtx == evtx_file_name:
-                    full_path = os.path.join(logs_folder, evtx_file_name)
-                    if os.path.exists(full_path):
-                        log.debug("Adding %s to zip dump", full_path)
-                        zip_obj.write(full_path, evtx_file_name)
-
-        log.debug("Uploading %s to host", self.evtx_dump)
-        upload_to_host(self.evtx_dump, f"evtx/{self.evtx_dump}")
+            pass
 
     def wipe_windows_logs(self):
         """Wipe sequentially Windows logs."""
@@ -213,16 +248,100 @@ class Evtx(Thread, Auxiliary):
         except Exception as err:
             log.error("Module error - %s", err)
 
-    def run(self):
-        if self.enabled:
-            self.enable_cmdline_logging()
-            self.configure_log_sizes()
-            self.enable_advanced_logging()
+    def take_snapshot(self):
+        """Export current logs to a local snapshot dir, then wipe.
+
+        Snapshots are kept locally on the guest and merged into a single
+        evtx.zip at stop() time. This protects against malware clearing
+        logs — each snapshot captures events since the last wipe.
+        """
+        self.snapshot_count += 1
+        snapshot_dir = os.path.join(
+            os.environ.get("TEMP", "C:\\Windows\\Temp"),
+            "evtx_snapshots",
+            str(self.snapshot_count),
+        )
+        os.makedirs(snapshot_dir, exist_ok=True)
+
+        try:
+            for channel in self.windows_logs:
+                safe_name = channel.replace("/", "%4") + ".evtx"
+                export_path = os.path.join(snapshot_dir, safe_name)
+                try:
+                    cmd = f'wevtutil epl "{channel}" "{export_path}" /ow:true'
+                    subprocess.call(cmd, startupinfo=self.startupinfo, timeout=30)
+                except Exception:
+                    pass
+
             self.wipe_windows_logs()
-            return True
-        return False
+            log.debug("Took evtx snapshot %d", self.snapshot_count)
+        except Exception as err:
+            log.error("Failed to take evtx snapshot - %s", err)
+
+    def run(self):
+        if not self.enabled:
+            return False
+
+        self.enable_cmdline_logging()
+        self.configure_log_sizes()
+        self.enable_advanced_logging()
+        self.wipe_windows_logs()
+
+        # Periodic snapshot loop — captures events even if malware wipes logs
+        while self.do_run:
+            for _ in range(self.SNAPSHOT_INTERVAL):
+                if not self.do_run:
+                    break
+                time.sleep(1)
+            if self.do_run:
+                self.take_snapshot()
+
+        return True
 
     def stop(self):
-        if self.enabled:
-            self.collect_windows_logs()
+        self.do_run = False
+        if not self.enabled:
+            return True
+
+        # Take final snapshot of remaining events
+        self.take_snapshot()
+
+        # Merge all snapshots into a single evtx.zip.
+        # Each snapshot is incremental (logs wiped after each), so we
+        # include ALL snapshots. Since evtx files can't be concatenated,
+        # we add each snapshot's evtx with a unique name (channel_N.evtx).
+        snapshot_base = os.path.join(
+            os.environ.get("TEMP", "C:\\Windows\\Temp"),
+            "evtx_snapshots",
+        )
+
+        with zipfile.ZipFile(self.evtx_dump, "w", zipfile.ZIP_DEFLATED) as zip_obj:
+            if os.path.isdir(snapshot_base):
+                for snap_name in sorted(os.listdir(snapshot_base)):
+                    snap_dir = os.path.join(snapshot_base, snap_name)
+                    if not os.path.isdir(snap_dir):
+                        continue
+                    for evtx_file in os.listdir(snap_dir):
+                        if not evtx_file.lower().endswith(".evtx"):
+                            continue
+                        full_path = os.path.join(snap_dir, evtx_file)
+                        if os.path.getsize(full_path) == 0:
+                            continue
+                        # Add with snapshot number prefix to avoid name collisions
+                        arc_name = f"{snap_name}_{evtx_file}"
+                        try:
+                            zip_obj.write(full_path, arc_name)
+                        except Exception:
+                            pass
+
+        if os.path.exists(self.evtx_dump):
+            upload_to_host(self.evtx_dump, f"evtx/{self.evtx_dump}")
+
+        # Clean up
+        try:
+            import shutil
+            shutil.rmtree(snapshot_base, ignore_errors=True)
+        except Exception:
+            pass
+
         return True

--- a/analyzer/windows/modules/auxiliary/evtx.py
+++ b/analyzer/windows/modules/auxiliary/evtx.py
@@ -317,7 +317,7 @@ class Evtx(Thread, Auxiliary):
 
         with zipfile.ZipFile(self.evtx_dump, "w", zipfile.ZIP_DEFLATED) as zip_obj:
             if os.path.isdir(snapshot_base):
-                for snap_name in sorted(os.listdir(snapshot_base)):
+                for snap_name in sorted(os.listdir(snapshot_base), key=lambda x: int(x) if x.isdigit() else x):
                     snap_dir = os.path.join(snapshot_base, snap_name)
                     if not os.path.isdir(snap_dir):
                         continue

--- a/analyzer/windows/modules/auxiliary/evtx.py
+++ b/analyzer/windows/modules/auxiliary/evtx.py
@@ -1,4 +1,3 @@
-import itertools
 import logging
 import os
 import subprocess

--- a/lib/cuckoo/core/data/guac_session.py
+++ b/lib/cuckoo/core/data/guac_session.py
@@ -1,0 +1,34 @@
+"""Guacamole session tokens tied to CAPE task lifecycle."""
+
+from datetime import datetime
+
+from .db_common import Base, _utcnow_naive
+
+try:
+    from sqlalchemy import DateTime, Integer, String
+    from sqlalchemy.orm import Mapped, mapped_column
+except ImportError:
+    from lib.cuckoo.common.exceptions import CuckooDependencyError
+    raise CuckooDependencyError("Unable to import sqlalchemy")
+
+
+class GuacSession(Base):
+    """Ties a guacamole browser session to a CAPE task lifecycle.
+
+    A UUID token is generated when a user opens the guac view for a running
+    task.  The WebSocket consumer validates this token before proxying the
+    VNC connection.  The row is deleted when the task ends or the WebSocket
+    disconnects, preventing session camping.
+    """
+
+    __tablename__ = "guac_sessions"
+
+    id: Mapped[int] = mapped_column(Integer(), primary_key=True)
+    token: Mapped[str] = mapped_column(String(36), unique=True, index=True, nullable=False)
+    task_id: Mapped[int] = mapped_column(Integer(), index=True, nullable=False)
+    vm_label: Mapped[str] = mapped_column(String(128), nullable=False)
+    guest_ip: Mapped[str] = mapped_column(String(128), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(), default=_utcnow_naive, nullable=False)
+
+    def __repr__(self):
+        return f"<GuacSession task={self.task_id} vm={self.vm_label}>"

--- a/lib/cuckoo/core/database.py
+++ b/lib/cuckoo/core/database.py
@@ -24,6 +24,7 @@ from lib.cuckoo.common.path_utils import path_exists
 from lib.cuckoo.common.utils import create_folder
 
 from .data.db_common import Base
+from .data.guac_session import GuacSession  # noqa: F401 - must be imported before create_all()
 from .data.tasking import TasksMixIn
 from .data.machines import MachinesMixIn
 from .data.samples import SamplesMixIn
@@ -220,6 +221,54 @@ class _Database(TasksMixIn,
         except SQLAlchemyError as e:
             raise CuckooDatabaseError(f"Unable to create or connect to database: {e}")
 
+
+    # ---- Guac session helpers ----
+
+    def create_guac_session(self, token, task_id, vm_label, guest_ip):
+        """Create a new guac session for a task."""
+        from lib.cuckoo.core.data.guac_session import GuacSession
+        session = self.session()
+        try:
+            guac = GuacSession(token=str(token), task_id=task_id, vm_label=vm_label, guest_ip=guest_ip)
+            session.add(guac)
+            session.commit()
+            return guac
+        except Exception:
+            session.rollback()
+            raise
+
+    def get_guac_session(self, token):
+        """Look up a guac session by token. Returns dict or None."""
+        from lib.cuckoo.core.data.guac_session import GuacSession
+        session = self.session()
+        try:
+            row = session.query(GuacSession).filter_by(token=str(token)).first()
+            if row:
+                return {"task_id": row.task_id, "vm_label": row.vm_label, "guest_ip": getattr(row, "guest_ip", None)}
+            return None
+        except Exception:
+            return None
+
+    def delete_guac_session(self, token):
+        """Delete a guac session token."""
+        from lib.cuckoo.core.data.guac_session import GuacSession
+        session = self.session()
+        try:
+            session.query(GuacSession).filter_by(token=str(token)).delete()
+            session.commit()
+        except Exception:
+            session.rollback()
+
+    def delete_guac_sessions_for_task(self, task_id):
+        """Delete all guac sessions for a task."""
+        from lib.cuckoo.core.data.guac_session import GuacSession
+        session = self.session()
+        try:
+            session.query(GuacSession).filter_by(task_id=task_id).delete()
+            session.commit()
+        except Exception:
+            session.rollback()
+
 _DATABASE: Optional[_Database] = None
 
 
@@ -244,3 +293,4 @@ def reset_database_FOR_TESTING_ONLY():
     """Used for testing."""
     global _DATABASE
     _DATABASE = None
+

--- a/lib/cuckoo/core/database.py
+++ b/lib/cuckoo/core/database.py
@@ -226,7 +226,6 @@ class _Database(TasksMixIn,
 
     def create_guac_session(self, token, task_id, vm_label, guest_ip):
         """Create a new guac session for a task."""
-        from lib.cuckoo.core.data.guac_session import GuacSession
         session = self.session()
         try:
             guac = GuacSession(token=str(token), task_id=task_id, vm_label=vm_label, guest_ip=guest_ip)

--- a/web/analysis/views.py
+++ b/web/analysis/views.py
@@ -766,7 +766,6 @@ def _load_evtx_channel_page_cached(zip_path, member, page, page_size, mtime, sea
         ]
 
         # Chain records from all snapshot files
-        import itertools
         def _iter_all_records():
             for ep in evtx_paths:
                 try:

--- a/web/analysis/views.py
+++ b/web/analysis/views.py
@@ -590,7 +590,13 @@ EVTX_PAGE_SIZE = 100
 
 
 def _evtx_member_display_name(member):
-    return os.path.splitext(member)[0].replace("%4", "/")
+    name = os.path.splitext(member)[0].replace("%4", "/")
+    # Strip snapshot prefix (e.g., "1_Security" -> "Security")
+    if "_" in name:
+        parts = name.split("_", 1)
+        if parts[0].isdigit():
+            name = parts[1]
+    return name
 
 
 def _flatten_evtx_detail(detail, prefix=""):
@@ -612,9 +618,45 @@ def _flatten_evtx_detail(detail, prefix=""):
     return items
 
 
+def _compile_evtx_search_pattern(search_query):
+    search_query = (search_query or "").strip()
+    if not search_query:
+        return None, ""
+
+    try:
+        return re.compile(search_query, re.IGNORECASE), ""
+    except re.error as e:
+        return None, str(e)
+
+
+def _evtx_record_matches_search(search_pattern, raw_record):
+    if not search_pattern:
+        return True
+
+    if not isinstance(raw_record, str):
+        raw_record = str(raw_record)
+
+    return bool(search_pattern.search(raw_record))
+
+
+def _evtx_has_records(data):
+    """Check if raw evtx file data contains any records by reading the header.
+    EVTX header offset 24: NextRecordIdentifier (uint64). Starts at 1 for
+    empty files, so > 1 means records exist."""
+    if len(data) < 32 or data[:8] != b"ElfFile\x00":
+        return False
+    import struct
+    next_record = struct.unpack_from("<Q", data, 24)[0]
+    return next_record > 1
+
+
 def _list_evtx_members(zip_path):
-    """List safe EVTX members from an archive without extracting them."""
-    members = []
+    """List safe EVTX members from an archive, grouped by channel.
+    Snapshot-prefixed files (e.g., 1_Security.evtx, 2_Security.evtx) are
+    grouped under one channel entry. Channels where no file contains any
+    records are excluded."""
+    channel_members = {}
+    channel_has_records = {}
     try:
         with zipfile.ZipFile(zip_path, "r") as zf:
             for member in zf.namelist():
@@ -623,46 +665,166 @@ def _list_evtx_members(zip_path):
                     continue
                 if not normalized.lower().endswith(".evtx"):
                     continue
-                members.append({"member": normalized, "channel": _evtx_member_display_name(normalized)})
+                channel = _evtx_member_display_name(normalized)
+                if channel not in channel_members:
+                    channel_members[channel] = []
+                    channel_has_records[channel] = False
+                channel_members[channel].append(normalized)
+                if not channel_has_records[channel]:
+                    # Read just the first 32 bytes to check the header
+                    header = zf.read(member)[:32]
+                    if _evtx_has_records(header):
+                        channel_has_records[channel] = True
     except Exception:
         return []
 
-    members.sort(key=lambda item: item["channel"].lower())
+    members = []
+    for channel, member_list in sorted(channel_members.items()):
+        if not channel_has_records.get(channel, False):
+            continue
+        member_list.sort()
+        members.append({
+            "member": member_list[0],
+            "members": member_list,
+            "channel": channel,
+        })
     return members
 
 
 @lru_cache(maxsize=128)
-def _load_evtx_channel_page_cached(zip_path, member, page, page_size, mtime):
+def _load_evtx_channel_page_cached(zip_path, member, page, page_size, mtime, search_query=""):
     del mtime
     events = []
     total_events = 0
+    search_pattern, search_error = _compile_evtx_search_pattern(search_query)
+    if search_error:
+        return {
+            "member": member,
+            "channel": _evtx_member_display_name(member),
+            "events": [],
+            "page": 1,
+            "page_size": page_size,
+            "total_events": 0,
+            "total_pages": 0,
+            "search_query": search_query,
+            "error": f"Invalid regex: {search_error}",
+        }
 
     with tempfile.TemporaryDirectory() as tmpdir:
         with zipfile.ZipFile(zip_path, "r") as zf:
-            normalized = member.replace("\\", "/")
-            if normalized != os.path.basename(normalized) or normalized not in zf.namelist():
-                raise ValueError(f"Invalid EVTX member requested: {member}")
+            # Find all members for this channel (handles snapshot-prefixed names)
+            channel = _evtx_member_display_name(member)
+            members_to_extract = []
+            for m in zf.namelist():
+                if _evtx_member_display_name(m) == channel and m.lower().endswith(".evtx"):
+                    members_to_extract.append(m)
+            if not members_to_extract:
+                raise ValueError(f"No EVTX members found for channel: {channel}")
+            members_to_extract.sort()
 
             real_tmpdir = os.path.realpath(tmpdir)
-            target = os.path.realpath(os.path.join(tmpdir, normalized))
-            if not target.startswith(real_tmpdir + os.sep) and target != real_tmpdir:
-                raise ValueError(f"Zip slip attempt in evtx.zip: {member}")
+            for m in members_to_extract:
+                normalized = m.replace("\\", "/")
+                if normalized != os.path.basename(normalized):
+                    continue
+                target = os.path.realpath(os.path.join(tmpdir, normalized))
+                if not target.startswith(real_tmpdir + os.sep) and target != real_tmpdir:
+                    continue
+                zf.extract(normalized, tmpdir)
 
-            zf.extract(normalized, tmpdir)
+        # Parse all extracted evtx files for this channel in order
+        evtx_paths = sorted(
+            os.path.join(tmpdir, m) for m in members_to_extract
+            if os.path.exists(os.path.join(tmpdir, m))
+        )
 
-        evtx_path = os.path.join(tmpdir, normalized)
-        parser = PyEvtxParser(evtx_path)
+        # Chain records from all snapshot files
+        import itertools
+        def _iter_all_records():
+            for ep in evtx_paths:
+                try:
+                    p = PyEvtxParser(ep)
+                    yield from p.records_json()
+                except Exception:
+                    pass
+
+        parser_iter = _iter_all_records()
         start_index = max(page - 1, 0) * page_size
         end_index = start_index + page_size
 
-        for index, record in enumerate(parser.records_json()):
+        # Load analyzer noise filter from shared config
+        _ANALYZER_PARENTS = set()
+        _ANALYZER_IMAGES = set()
+        try:
+            import os as _os
+            _cape_root = _os.path.dirname(_os.path.dirname(_os.path.dirname(_os.path.abspath(__file__))))
+            for _fp in ["data/sigma/filters_local.json", "data/sigma/filters.json"]:
+                _full = _os.path.join(_cape_root, _fp)
+                if _os.path.exists(_full):
+                    with open(_full) as _f:
+                        _data = json.load(_f)
+                    _pf = _data.get("pre_filters", {})
+                    for _p in _pf.get("exclude_parent_processes", []):
+                        _ANALYZER_PARENTS.add(_p.lower())
+                    for _p in _pf.get("exclude_image_processes", []):
+                        _ANALYZER_IMAGES.add(_p.lower())
+            _ANALYZER_PATHS = set()
+            for _fp2 in ["data/sigma/filters_local.json", "data/sigma/filters.json"]:
+                _full2 = _os.path.join(_cape_root, _fp2)
+                if _os.path.exists(_full2):
+                    with open(_full2) as _f2:
+                        _data2 = json.load(_f2)
+                    for _p in _data2.get("pre_filters", {}).get("exclude_target_paths", []):
+                        _ANALYZER_PATHS.add(_p.lower())
+        except Exception:
+            pass
+        if not _ANALYZER_PARENTS:
+            _ANALYZER_PARENTS = {"icacls.exe", "python.exe", "wevtutil.exe"}
+        if not _ANALYZER_IMAGES:
+            _ANALYZER_IMAGES = {"wevtutil.exe", "conhost.exe"}
+
+        for record in parser_iter:
+            try:
+                evt = json.loads(record["data"])
+            except (json.JSONDecodeError, KeyError, TypeError):
+                total_events += 1
+                continue
+
+            event_data = evt.get("Event", {})
+
+            skip = False
+            # Skip events from the CAPE analyzer process
+            _ed = event_data.get("EventData", {})
+            if isinstance(_ed, dict):
+                _parent = _ed.get("ParentProcessName", "")
+                if isinstance(_parent, str):
+                    _pname = _parent.rsplit("\\", 1)[-1].lower()
+                    if _pname in _ANALYZER_PARENTS:
+                        continue
+                _image = _ed.get("Image", "")
+                if isinstance(_image, str):
+                    _iname = _image.rsplit("\\", 1)[-1].lower()
+                    if _iname in _ANALYZER_IMAGES:
+                        continue
+                _target = _ed.get("TargetFilename", _ed.get("TargetFileName", ""))
+                if isinstance(_target, str) and _target:
+                    _tlow = _target.lower()
+                    for _ep in _ANALYZER_PATHS:
+                        if _ep in _tlow:
+                            skip = True
+                            break
+                    if skip:
+                        continue
+
+            if not _evtx_record_matches_search(search_pattern, record.get("data", "")):
+                continue
+
             total_events += 1
+            index = total_events - 1
             if index < start_index or index >= end_index:
                 continue
 
             try:
-                evt = json.loads(record["data"])
-                event_data = evt.get("Event", {})
                 system = event_data.get("System", {})
 
                 event_id_raw = system.get("EventID", "")
@@ -716,38 +878,101 @@ def _load_evtx_channel_page_cached(zip_path, member, page, page_size, mtime):
         "page_size": page_size,
         "total_events": total_events,
         "total_pages": (total_events + page_size - 1) // page_size,
+        "search_query": search_query,
     }
 
 
 @lru_cache(maxsize=256)
 def _count_evtx_channel_events_cached(zip_path, member, mtime):
+    """Count events for a channel, applying the same noise filters as the page loader."""
     del mtime
     if not HAVE_EVTX:
         return None
 
+    # Load the same noise filters used by the page loader
+    _ANALYZER_PARENTS = set()
+    _ANALYZER_IMAGES = set()
+    _ANALYZER_PATHS = set()
+    try:
+        _cape_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+        for _fp in ["data/sigma/filters_local.json", "data/sigma/filters.json"]:
+            _full = os.path.join(_cape_root, _fp)
+            if os.path.exists(_full):
+                with open(_full) as _f:
+                    _data = json.load(_f)
+                _pf = _data.get("pre_filters", {})
+                for _p in _pf.get("exclude_parent_processes", []):
+                    _ANALYZER_PARENTS.add(_p.lower())
+                for _p in _pf.get("exclude_image_processes", []):
+                    _ANALYZER_IMAGES.add(_p.lower())
+                for _p in _pf.get("exclude_target_paths", []):
+                    _ANALYZER_PATHS.add(_p.lower())
+    except Exception:
+        pass
+    if not _ANALYZER_PARENTS:
+        _ANALYZER_PARENTS = {"icacls.exe", "python.exe", "wevtutil.exe"}
+    if not _ANALYZER_IMAGES:
+        _ANALYZER_IMAGES = {"wevtutil.exe", "conhost.exe"}
+
     count = 0
     with tempfile.TemporaryDirectory() as tmpdir:
         with zipfile.ZipFile(zip_path, "r") as zf:
-            normalized = member.replace("\\", "/")
-            if normalized != os.path.basename(normalized) or normalized not in zf.namelist():
-                raise ValueError(f"Invalid EVTX member requested: {member}")
+            channel = _evtx_member_display_name(member)
+            members_to_extract = []
+            for m in zf.namelist():
+                if _evtx_member_display_name(m) == channel and m.lower().endswith(".evtx"):
+                    members_to_extract.append(m)
+            if not members_to_extract:
+                raise ValueError(f"No EVTX members found for channel: {channel}")
+            members_to_extract.sort()
 
             real_tmpdir = os.path.realpath(tmpdir)
-            target = os.path.realpath(os.path.join(tmpdir, normalized))
-            if not target.startswith(real_tmpdir + os.sep) and target != real_tmpdir:
-                raise ValueError(f"Zip slip attempt in evtx.zip: {member}")
+            for m in members_to_extract:
+                normalized = m.replace("\\", "/")
+                if normalized != os.path.basename(normalized):
+                    continue
+                target = os.path.realpath(os.path.join(tmpdir, normalized))
+                if not target.startswith(real_tmpdir + os.sep) and target != real_tmpdir:
+                    continue
+                zf.extract(normalized, tmpdir)
 
-            zf.extract(normalized, tmpdir)
+        evtx_paths = sorted(
+            os.path.join(tmpdir, m) for m in members_to_extract
+            if os.path.exists(os.path.join(tmpdir, m))
+        )
 
-        evtx_path = os.path.join(tmpdir, normalized)
-        parser = PyEvtxParser(evtx_path)
-        for _ in parser.records_json():
-            count += 1
+        for ep in evtx_paths:
+            try:
+                p = PyEvtxParser(ep)
+                for record in p.records_json():
+                    try:
+                        evt = json.loads(record["data"])
+                    except (json.JSONDecodeError, KeyError, TypeError):
+                        count += 1
+                        continue
+
+                    event_data = evt.get("Event", {})
+                    _ed = event_data.get("EventData", {})
+                    if isinstance(_ed, dict):
+                        _parent = _ed.get("ParentProcessName", "")
+                        if isinstance(_parent, str) and _parent.rsplit("\\", 1)[-1].lower() in _ANALYZER_PARENTS:
+                            continue
+                        _image = _ed.get("Image", "")
+                        if isinstance(_image, str) and _image.rsplit("\\", 1)[-1].lower() in _ANALYZER_IMAGES:
+                            continue
+                        _target = _ed.get("TargetFilename", _ed.get("TargetFileName", ""))
+                        if isinstance(_target, str) and _target:
+                            _tlow = _target.lower()
+                            if any(_ep in _tlow for _ep in _ANALYZER_PATHS):
+                                continue
+                    count += 1
+            except Exception:
+                pass
 
     return count
 
 
-def _load_evtx_channel_page(zip_path, member, page, page_size=EVTX_PAGE_SIZE):
+def _load_evtx_channel_page(zip_path, member, page, page_size=EVTX_PAGE_SIZE, search_query=""):
     if not HAVE_EVTX:
         return {"member": member, "channel": _evtx_member_display_name(member), "error": "EVTX parser is not installed on the web node."}
 
@@ -758,7 +983,7 @@ def _load_evtx_channel_page(zip_path, member, page, page_size=EVTX_PAGE_SIZE):
 
     try:
         mtime = os.path.getmtime(zip_path)
-        return _load_evtx_channel_page_cached(zip_path, member, page, page_size, mtime)
+        return _load_evtx_channel_page_cached(zip_path, member, page, page_size, mtime, search_query)
     except Exception:
         return None
 
@@ -1955,13 +2180,19 @@ def load_evtx_channel(request, task_id):
 
     member = request.GET.get("member", "")
     page = request.GET.get("page", "1")
+    search_query = request.GET.get("search", "")
     evtx_zip = os.path.join(CUCKOO_ROOT, "storage", "analyses", str(task_id), "evtx", "evtx.zip")
     if not path_exists(evtx_zip):
         raise PermissionDenied
 
-    evtx_page = _load_evtx_channel_page(evtx_zip, member, page)
+    evtx_page = _load_evtx_channel_page(evtx_zip, member, page, search_query=search_query)
     if not evtx_page:
-        evtx_page = {"member": member, "channel": _evtx_member_display_name(member), "error": "Failed to load EVTX channel."}
+        evtx_page = {
+            "member": member,
+            "channel": _evtx_member_display_name(member),
+            "search_query": search_query,
+            "error": "Failed to load EVTX channel.",
+        }
 
     return render(request, "analysis/eventlogs/_evtx_channel.html", {"evtx_page": evtx_page})
 

--- a/web/analysis/views.py
+++ b/web/analysis/views.py
@@ -692,6 +692,33 @@ def _list_evtx_members(zip_path):
 
 
 @lru_cache(maxsize=128)
+def _load_evtx_noise_filters():
+    """Load analyzer noise filter sets from sigma filters config."""
+    parents = set()
+    images = set()
+    paths = set()
+    try:
+        for fp in ["data/sigma/filters_local.json", "data/sigma/filters.json"]:
+            full = os.path.join(CUCKOO_ROOT, fp)
+            if os.path.exists(full):
+                with open(full) as f:
+                    data = json.load(f)
+                pf = data.get("pre_filters", {})
+                for p in pf.get("exclude_parent_processes", []):
+                    parents.add(p.lower())
+                for p in pf.get("exclude_image_processes", []):
+                    images.add(p.lower())
+                for p in pf.get("exclude_target_paths", []):
+                    paths.add(p.lower())
+    except Exception:
+        pass
+    if not parents:
+        parents = {"icacls.exe", "python.exe", "wevtutil.exe"}
+    if not images:
+        images = {"wevtutil.exe", "conhost.exe"}
+    return parents, images, paths
+
+
 def _load_evtx_channel_page_cached(zip_path, member, page, page_size, mtime, search_query=""):
     del mtime
     events = []
@@ -720,7 +747,7 @@ def _load_evtx_channel_page_cached(zip_path, member, page, page_size, mtime, sea
                     members_to_extract.append(m)
             if not members_to_extract:
                 raise ValueError(f"No EVTX members found for channel: {channel}")
-            members_to_extract.sort()
+            members_to_extract.sort(key=lambda x: int(x.split("_")[0]) if "_" in x and x.split("_")[0].isdigit() else x)
 
             real_tmpdir = os.path.realpath(tmpdir)
             for m in members_to_extract:
@@ -732,11 +759,11 @@ def _load_evtx_channel_page_cached(zip_path, member, page, page_size, mtime, sea
                     continue
                 zf.extract(normalized, tmpdir)
 
-        # Parse all extracted evtx files for this channel in order
-        evtx_paths = sorted(
+        # Parse all extracted evtx files for this channel in order (preserving numeric sort)
+        evtx_paths = [
             os.path.join(tmpdir, m) for m in members_to_extract
             if os.path.exists(os.path.join(tmpdir, m))
-        )
+        ]
 
         # Chain records from all snapshot files
         import itertools
@@ -752,36 +779,7 @@ def _load_evtx_channel_page_cached(zip_path, member, page, page_size, mtime, sea
         start_index = max(page - 1, 0) * page_size
         end_index = start_index + page_size
 
-        # Load analyzer noise filter from shared config
-        _ANALYZER_PARENTS = set()
-        _ANALYZER_IMAGES = set()
-        try:
-            import os as _os
-            _cape_root = _os.path.dirname(_os.path.dirname(_os.path.dirname(_os.path.abspath(__file__))))
-            for _fp in ["data/sigma/filters_local.json", "data/sigma/filters.json"]:
-                _full = _os.path.join(_cape_root, _fp)
-                if _os.path.exists(_full):
-                    with open(_full) as _f:
-                        _data = json.load(_f)
-                    _pf = _data.get("pre_filters", {})
-                    for _p in _pf.get("exclude_parent_processes", []):
-                        _ANALYZER_PARENTS.add(_p.lower())
-                    for _p in _pf.get("exclude_image_processes", []):
-                        _ANALYZER_IMAGES.add(_p.lower())
-            _ANALYZER_PATHS = set()
-            for _fp2 in ["data/sigma/filters_local.json", "data/sigma/filters.json"]:
-                _full2 = _os.path.join(_cape_root, _fp2)
-                if _os.path.exists(_full2):
-                    with open(_full2) as _f2:
-                        _data2 = json.load(_f2)
-                    for _p in _data2.get("pre_filters", {}).get("exclude_target_paths", []):
-                        _ANALYZER_PATHS.add(_p.lower())
-        except Exception:
-            pass
-        if not _ANALYZER_PARENTS:
-            _ANALYZER_PARENTS = {"icacls.exe", "python.exe", "wevtutil.exe"}
-        if not _ANALYZER_IMAGES:
-            _ANALYZER_IMAGES = {"wevtutil.exe", "conhost.exe"}
+        _ANALYZER_PARENTS, _ANALYZER_IMAGES, _ANALYZER_PATHS = _load_evtx_noise_filters()
 
         for record in parser_iter:
             try:
@@ -889,30 +887,7 @@ def _count_evtx_channel_events_cached(zip_path, member, mtime):
     if not HAVE_EVTX:
         return None
 
-    # Load the same noise filters used by the page loader
-    _ANALYZER_PARENTS = set()
-    _ANALYZER_IMAGES = set()
-    _ANALYZER_PATHS = set()
-    try:
-        _cape_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-        for _fp in ["data/sigma/filters_local.json", "data/sigma/filters.json"]:
-            _full = os.path.join(_cape_root, _fp)
-            if os.path.exists(_full):
-                with open(_full) as _f:
-                    _data = json.load(_f)
-                _pf = _data.get("pre_filters", {})
-                for _p in _pf.get("exclude_parent_processes", []):
-                    _ANALYZER_PARENTS.add(_p.lower())
-                for _p in _pf.get("exclude_image_processes", []):
-                    _ANALYZER_IMAGES.add(_p.lower())
-                for _p in _pf.get("exclude_target_paths", []):
-                    _ANALYZER_PATHS.add(_p.lower())
-    except Exception:
-        pass
-    if not _ANALYZER_PARENTS:
-        _ANALYZER_PARENTS = {"icacls.exe", "python.exe", "wevtutil.exe"}
-    if not _ANALYZER_IMAGES:
-        _ANALYZER_IMAGES = {"wevtutil.exe", "conhost.exe"}
+    _ANALYZER_PARENTS, _ANALYZER_IMAGES, _ANALYZER_PATHS = _load_evtx_noise_filters()
 
     count = 0
     with tempfile.TemporaryDirectory() as tmpdir:

--- a/web/guac/consumers.py
+++ b/web/guac/consumers.py
@@ -1,36 +1,126 @@
 import asyncio
 import logging
+import uuid
 import urllib.parse
+from xml.etree import ElementTree as ET
 
 from asgiref.sync import sync_to_async
 from channels.generic.websocket import AsyncWebsocketConsumer
 from guacamole.client import GuacamoleClient
 
-# Ensure this import path matches your project structure
 from lib.cuckoo.common.config import Config
+from lib.cuckoo.core.database import Database
+
+try:
+    import libvirt
+    LIBVIRT_AVAILABLE = True
+except ImportError:
+    LIBVIRT_AVAILABLE = False
 
 logger = logging.getLogger("guac-session")
 web_cfg = Config("web")
 
+machinery = Config().cuckoo.machinery
+machinery_dsn = getattr(Config(machinery), machinery).get("dsn", "qemu:///system")
+
+TASK_POLL_INTERVAL = 10
+
+
+def _get_vnc_port(vm_label):
+    """Look up VNC port for a VM from libvirt. Must be called from sync context."""
+    if not LIBVIRT_AVAILABLE:
+        return None
+    conn = None
+    try:
+        conn = libvirt.open(machinery_dsn)
+        if not conn:
+            return None
+        dom = conn.lookupByName(vm_label)
+        if not dom:
+            return None
+        state = dom.state(flags=0)
+        if not state or state[0] != 1:
+            return None
+        xml_desc = dom.XMLDesc(0)
+        root = ET.fromstring(xml_desc)
+        graphics = root.find('./devices/graphics[@type="vnc"]')
+        if graphics is not None:
+            return int(graphics.get("port"))
+        return None
+    except Exception as e:
+        logger.error("Failed to get VNC port for %s: %s", vm_label, e)
+        return None
+    finally:
+        if conn:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+
 class GuacamoleWebSocketConsumer(AsyncWebsocketConsumer):
-    # Channels 4: Explicitly declare supported subprotocols
     subprotocols = ["guacamole"]
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.client = None
         self.task = None
+        self.monitor_task = None
+        self.guac_token = None
+        self.guac_task_id = None
 
     async def connect(self):
-        """
-        Initiate the GuacamoleClient and create a connection to it.
-        """
+        """Validate session token, look up VNC server-side, connect to guacd."""
         try:
-            # Capture session_id from URL route for logging context
-            session_id = self.scope["url_route"]["kwargs"].get("session_id", "unknown")
+            # 1. Read and validate the session cookie
+            cookies = self.scope.get("cookies", {})
+            token_str = cookies.get("guac_session")
 
-            # 1. Parse Configuration & Parameters inside a try block
-            # This prevents 500 errors from reaching the client as HTML
+            if not token_str:
+                logger.warning("WebSocket rejected: no guac_session cookie")
+                await self.close()
+                return
+
+            try:
+                token = uuid.UUID(token_str)
+            except ValueError:
+                logger.warning("WebSocket rejected: invalid token format")
+                await self.close()
+                return
+
+            # 2. Look up session in DB
+            db = Database()
+            session_data = await sync_to_async(db.get_guac_session)(token)
+
+            if not session_data:
+                logger.warning("WebSocket rejected: token not found in DB")
+                await self.close()
+                return
+
+            self.guac_token = str(token)
+            self.guac_task_id = session_data["task_id"]
+            vm_label = session_data["vm_label"]
+
+            # 3. Verify task is still running
+            task = await sync_to_async(db.view_task)(self.guac_task_id)
+            if not task or task.status != "running":
+                logger.warning(
+                    "WebSocket rejected: task %s is not running", self.guac_task_id
+                )
+                await sync_to_async(db.delete_guac_session)(token)
+                await self.close()
+                return
+
+            # 4. Look up VNC port server-side from libvirt
+            vnc_port = await sync_to_async(_get_vnc_port)(vm_label)
+            if not vnc_port:
+                logger.warning(
+                    "WebSocket rejected: no VNC port for VM %s", vm_label
+                )
+                await self.close()
+                return
+
+            # 5. Parse config
             guacd_hostname = web_cfg.guacamole.guacd_host or "localhost"
             guacd_port = int(web_cfg.guacamole.guacd_port) or 4822
             guacd_recording_path = web_cfg.guacamole.guacd_recording_path or ""
@@ -40,55 +130,41 @@ class GuacamoleWebSocketConsumer(AsyncWebsocketConsumer):
             guest_username = web_cfg.guacamole.username or ""
             guest_password = web_cfg.guacamole.password or ""
 
-            # Safe decoding of query string
             query_string = self.scope.get("query_string", b"").decode()
             params = urllib.parse.parse_qs(query_string)
+            # Sanitize recording name — only allow alphanumeric, dash, underscore
+            import re
+            raw_recording = params.get("recording_name", ["task-recording"])[0]
+            guacd_recording_name = re.sub(r"[^a-zA-Z0-9_-]", "", raw_recording)
 
             if "rdp" in guest_protocol:
-                hosts = params.get("guest_ip", [""])
-                guest_host = hosts[0]
+                guest_host = session_data.get("guest_ip", vm_label)
+                if not guest_host:
+                    guest_host = vm_label
                 guest_port = int(web_cfg.guacamole.guest_rdp_port) or 3389
-                ignore_cert = "true" if web_cfg.guacamole.ignore_rdp_cert is True else "false"
-
-                # RDP Performance Optimizations
-                # Default to safe/fast values if not present in config
-                disable_wallpaper = "true" if getattr(web_cfg.guacamole, "rdp_disable_wallpaper", "yes") == "yes" else "false"
-                disable_theming = "true" if getattr(web_cfg.guacamole, "rdp_disable_theming", "yes") == "yes" else "false"
-                enable_font_smoothing = "true" if getattr(web_cfg.guacamole, "rdp_enable_font_smoothing", "no") == "yes" else "false"
-                enable_full_window_drag = "true" if getattr(web_cfg.guacamole, "rdp_enable_full_window_drag", "no") == "yes" else "false"
-                enable_desktop_composition = "true" if getattr(web_cfg.guacamole, "rdp_enable_desktop_composition", "no") == "yes" else "false"
-                enable_menu_animations = "true" if getattr(web_cfg.guacamole, "rdp_enable_menu_animations", "no") == "yes" else "false"
-                enable_audio = "audio" if getattr(web_cfg.guacamole, "enable_audio", "no") == "yes" else None
-
+                ignore_cert = (
+                    "true"
+                    if web_cfg.guacamole.ignore_rdp_cert is True
+                    else "false"
+                )
                 extra_args = {
-                    "disable-wallpaper": disable_wallpaper,
-                    "disable-theming": disable_theming,
-                    "enable-font-smoothing": enable_font_smoothing,
-                    "enable-full-window-drag": enable_full_window_drag,
-                    "enable-desktop-composition": enable_desktop_composition,
-                    "enable-menu-animations": enable_menu_animations,
+                    "disable-wallpaper": "true",
+                    "disable-theming": "true",
                 }
-                if enable_audio:
-                    extra_args["enable-audio"] = "true"
-
             else:
                 guest_host = web_cfg.guacamole.vnc_host or "localhost"
-                ports = params.get("vncport", ["5900"])
-                guest_port = int(ports[0])
+                guest_port = vnc_port
                 ignore_cert = "false"
-
-                # VNC Performance Optimizations
-                vnc_color_depth = str(getattr(web_cfg.guacamole, "vnc_color_depth", 16))
+                vnc_color_depth = str(
+                    getattr(web_cfg.guacamole, "vnc_color_depth", 16)
+                )
                 vnc_cursor = getattr(web_cfg.guacamole, "vnc_cursor", "local")
-
                 extra_args = {
                     "color-depth": vnc_color_depth,
                     "cursor": vnc_cursor,
                 }
 
-            guacd_recording_name = params.get("recording_name", ["task-recording"])[0]
-
-            # 2. Connect to Guacamole Daemon (guacd)
+            # 6. Connect to guacd
             self.client = GuacamoleClient(guacd_hostname, guacd_port)
 
             await sync_to_async(self.client.handshake)(
@@ -102,31 +178,58 @@ class GuacamoleWebSocketConsumer(AsyncWebsocketConsumer):
                 recording_path=guacd_recording_path,
                 recording_name=guacd_recording_name,
                 ignore_cert=ignore_cert,
-                **extra_args
+                **extra_args,
             )
 
             if self.client.connected:
-                # 3. Accept the WebSocket connection specifically for 'guacamole'
-                # Accept first to ensure the channel is open before sending data
                 await self.accept(subprotocol="guacamole")
-                logger.info("Guacamole connection accepted for session %s.", session_id)
-
-                # 4. Start the background reader task
-                # Use asyncio.create_task instead of get_event_loop()
+                logger.info(
+                    "Guacamole session accepted: task=%s vm=%s",
+                    self.guac_task_id,
+                    vm_label,
+                )
                 self.task = asyncio.create_task(self.read_guacd())
+                self.monitor_task = asyncio.create_task(self.monitor_task_status())
             else:
-                logger.warning("Guacamole handshake failed. Closing connection.")
+                logger.warning("Guacamole handshake failed.")
                 await self.close()
 
         except Exception as e:
             logger.error("Error during Guacamole connect: %s", str(e))
             await self.close()
 
+    async def monitor_task_status(self):
+        """Periodically check if the CAPE task is still running. Disconnect if not."""
+        try:
+            while True:
+                await asyncio.sleep(TASK_POLL_INTERVAL)
+                if not self.guac_task_id:
+                    break
+                db = Database()
+                task = await sync_to_async(db.view_task)(self.guac_task_id)
+                if not task or task.status != "running":
+                    logger.info(
+                        "Task %s no longer running, disconnecting guac session",
+                        self.guac_task_id,
+                    )
+                    if self.guac_token:
+                        await sync_to_async(db.delete_guac_session)(self.guac_token)
+                    await self.close()
+                    break
+        except asyncio.CancelledError:
+            pass
+        except Exception as e:
+            logger.error("Error in task monitor: %s", e)
+
     async def disconnect(self, code):
-        """
-        Close the GuacamoleClient connection on WebSocket disconnect.
-        """
-        # Cancel the reader task if it exists
+        """Clean up on WebSocket disconnect."""
+        if self.monitor_task:
+            self.monitor_task.cancel()
+            try:
+                await self.monitor_task
+            except asyncio.CancelledError:
+                pass
+
         if self.task:
             self.task.cancel()
             try:
@@ -134,42 +237,41 @@ class GuacamoleWebSocketConsumer(AsyncWebsocketConsumer):
             except asyncio.CancelledError:
                 pass
 
-        # Close the client safely
         if self.client:
             try:
                 await sync_to_async(self.client.close)()
             except Exception as e:
                 logger.error("Error closing guacamole client: %s", str(e))
 
+        if self.guac_token:
+            try:
+                db = Database()
+                await sync_to_async(db.delete_guac_session)(self.guac_token)
+            except Exception:
+                pass
+
     async def receive(self, text_data=None, bytes_data=None):
-        """
-        Handle data received in the WebSocket, send to GuacamoleClient.
-        """
+        """Forward data from browser to guacd."""
         if text_data and self.client:
-            # logger.debug("To server: %s", text_data) # Verbose logging can slow down RDP
             try:
                 await sync_to_async(self.client.send)(text_data)
             except Exception as e:
                 logger.error("Failed to send data to guacd: %s", str(e))
 
     async def read_guacd(self):
-        """
-        Receive data from GuacamoleClient and pass it to the WebSocket
-        """
+        """Forward data from guacd to browser."""
         try:
             while True:
-                # This blocks in a thread, releasing the async loop
-                # thread_sensitive=False allows this to run in a separate thread pool, not blocking the main thread
-                content = await sync_to_async(self.client.receive, thread_sensitive=False)()
+                content = await sync_to_async(
+                    self.client.receive, thread_sensitive=False
+                )()
                 if content:
-                    # logger.debug("From server: %s", content)
                     await self.send(text_data=content)
                 else:
                     break
         except asyncio.CancelledError:
-            pass  # Task cancellation is normal on disconnect
+            pass
         except Exception as e:
             logger.error("Exception in Guacamole message loop: %s", e)
         finally:
-            # Ensure we close the websocket if the guacd connection dies
             await self.close()

--- a/web/guac/templates/guac/index.html
+++ b/web/guac/templates/guac/index.html
@@ -35,7 +35,7 @@
             document.getElementById("taskStatus").addEventListener("click", function() {
                 location.replace(task_url);
             }, false);
-	        GuacMe("html", "{{guest_ip}}","{{vncport}}", "{{session_id}}", "{{recording_name}}");
+	        GuacMe("html", "{{session_id}}", "{{recording_name}}");
         </script>
     </div>
 </body>

--- a/web/guac/views.py
+++ b/web/guac/views.py
@@ -1,85 +1,107 @@
+import uuid
 from base64 import urlsafe_b64decode
 from xml.etree import ElementTree as ET
+
+from django.conf import settings
+from django.contrib.auth.decorators import login_required
 from django.shortcuts import render
+
 from lib.cuckoo.common.config import Config
+from lib.cuckoo.core.database import Database
+
+
+class conditional_login_required:
+    def __init__(self, decorator, condition):
+        self.decorator = decorator
+        self.condition = condition
+
+    def __call__(self, func):
+        if not self.condition:
+            return func
+        return self.decorator(func)
 
 try:
     import libvirt
-
     LIBVIRT_AVAILABLE = True
 except ImportError:
-    print("Unable to import python-libvirt. Check that the CAPE python environment has it installed.")
     LIBVIRT_AVAILABLE = False
 
 machinery = Config().cuckoo.machinery
 machinery_available = ["kvm", "qemu"]
 machinery_dsn = getattr(Config(machinery), machinery).get("dsn", "qemu:///system")
+db = Database()
 
 
+def _error(request, task_id, msg):
+    return render(request, "guac/error.html", {
+        "error_msg": msg, "error": "remote session", "task_id": task_id,
+    })
+
+
+@conditional_login_required(login_required, settings.WEB_AUTHENTICATION)
 def index(request, task_id, session_data):
     if not LIBVIRT_AVAILABLE:
-        return render(
-            request,
-            "guac/error.html",
-            {"error_msg": "Libvirt not available", "error": "remote session", "task_id": task_id},
-        )
+        return _error(request, task_id, "Libvirt not available")
 
     if machinery not in machinery_available:
-        return render(
-            request,
-            "guac/error.html",
-            {"error_msg": f"Machinery type '{machinery}' is not supported", "error": "remote session", "task_id": task_id},
-        )
+        return _error(request, task_id, f"Machinery type '{machinery}' is not supported")
 
     conn = None
-    state = None
-    recording_name = ""
-
     try:
         conn = libvirt.open(machinery_dsn)
-        if conn:
-            try:
-                session_id, label, guest_ip = urlsafe_b64decode(session_data).decode("utf8").split("|")
-                recording_name = f"{task_id}_{session_id}"
-                dom = conn.lookupByName(label)
-                if dom:
-                    state = dom.state(flags=0)
-            except Exception as e:
-                return render(
-                    request,
-                    "guac/error.html",
-                    {"error_msg": f"{e}", "error": "remote session", "task_id": task_id},
-                )
+        if not conn:
+            return _error(request, task_id, "Could not connect to hypervisor")
 
-            if state:
-                if state[0] == 1:
-                    vmXml = dom.XMLDesc(0)
-                    root = ET.fromstring(vmXml)
-                    graphics = root.find('./devices/graphics[@type="vnc"]')
-                    vncport = graphics.get("port") if graphics else None
-                    return render(
-                        request,
-                        "guac/index.html",
-                        {
-                            "vncport": vncport,
-                            "session_id": session_id,
-                            "task_id": task_id,
-                            "recording_name": recording_name,
-                            "guest_ip": guest_ip,
-                        },
-                    )
-                else:
-                    return render(request, "guac/wait.html", {"task_id": task_id})
+        try:
+            session_id, label, guest_ip = (
+                urlsafe_b64decode(session_data).decode("utf8").split("|")
+            )
+        except Exception as e:
+            return _error(request, task_id, str(e))
+
+        try:
+            dom = conn.lookupByName(label)
+        except Exception as e:
+            return _error(request, task_id, str(e))
+
+        if not dom:
+            return _error(request, task_id, f"VM {label} not found")
+
+        state = dom.state(flags=0)
+        if not state or state[0] != 1:
+            return render(request, "guac/wait.html", {"task_id": task_id})
+
+        # VM is running — get or create a session token
+        recording_name = f"{task_id}_{session_id}"
+        token = uuid.uuid4()
+
+        guac_session = db.create_guac_session(
+            token=token,
+            task_id=int(task_id),
+            vm_label=label,
+            guest_ip=guest_ip,
+        )
+
+        response = render(request, "guac/index.html", {
+            "session_id": session_id,
+            "task_id": task_id,
+            "recording_name": recording_name,
+        })
+
+        response.set_cookie(
+            "guac_session",
+            str(guac_session.token),
+            httponly=True,
+            secure=request.is_secure(),
+            samesite="Lax",
+            path="/guac/",
+        )
+
+        return response
+
     finally:
         if conn:
             try:
                 conn.close()
             except Exception:
                 pass
-
-    # Fallback return if something went wrong before rendering
-    return render(
-        request,
-        "guac/error.html",
-        {"error_msg": "Could not connect to hypervisor", "error": "remote session", "task_id": task_id},
-    )

--- a/web/guac/views.py
+++ b/web/guac/views.py
@@ -1,6 +1,5 @@
 import uuid
 from base64 import urlsafe_b64decode
-from xml.etree import ElementTree as ET
 
 from django.conf import settings
 from django.contrib.auth.decorators import login_required

--- a/web/static/js/guac-main.js
+++ b/web/static/js/guac-main.js
@@ -1,4 +1,4 @@
-function GuacMe(element, guest_ip, vncport, session_id, recording_name) {
+function GuacMe(element, session_id, recording_name) {
     "use strict";
 
     var terminal_connected = false;
@@ -7,24 +7,18 @@ function GuacMe(element, guest_ip, vncport, session_id, recording_name) {
     var dialog_container;
 
     var init = function() {
-        /* Process terminal URL. */
-
         dialog_container = $(element).find('.guaconsole')[0];
-        
-        /* Build websocket url based on protocol */
+
         var terminal_ws_url = location.origin.replace(/^http(s?):/, function(match, p1) {
             return (p1 ? 'wss:' : 'ws:');
         });
 
-        /* Initialize Guacamole Client */
         terminal_client = new Guacamole.Client(
             new Guacamole.WebSocketTunnel(terminal_ws_url + '/guac/websocket-tunnel/' + session_id)
         );
-        terminal_connect(guest_ip, vncport, recording_name);
+        terminal_connect(recording_name);
 
         terminal_element = terminal_client.getDisplay().getElement();
-
-        /* Show the terminal.  */
         $('#terminal').append(terminal_element);
 
         /* Scale display to fit the browser window. */
@@ -72,35 +66,23 @@ function GuacMe(element, guest_ip, vncport, session_id, recording_name) {
             terminal_client.sendMouseState(mouseState, true);
         };
 
-        /* Keyboard handling.  */
         var keyboard = new Guacamole.Keyboard(terminal_element);
         var ctrl, shift = false;
 
         keyboard.onkeydown = function (keysym) {
             var cancel_event = true;
 
-            /* Don't cancel event on paste shortcuts. */
-            if (keysym == 0xFFE1 /* shift */
-                || keysym == 0xFFE3 /* ctrl */
-                || keysym == 0xFF63 /* insert */
-                || keysym == 0x0056 /* V */
-                || keysym == 0x0076 /* v */
-            ) {
+            if (keysym == 0xFFE1 || keysym == 0xFFE3 || keysym == 0xFF63
+                || keysym == 0x0056 || keysym == 0x0076) {
                 cancel_event = false;
             }
 
-            /* Remember when ctrl or shift are down. */
-            if (keysym == 0xFFE1) {
-                shift = true;
-            } else if (keysym == 0xFFE3) {
-                ctrl = true;
-            }
+            if (keysym == 0xFFE1) { shift = true; }
+            else if (keysym == 0xFFE3) { ctrl = true; }
 
-            /* Delay sending final stroke until clipboard is updated. */
-            if ((ctrl && shift && keysym == 0x0056) /* ctrl-shift-V */
-                || (ctrl && keysym == 0x0076) /* ctrl-v */
-                || (shift && keysym == 0xFF63) /* shift-insert */
-            ) {
+            if ((ctrl && shift && keysym == 0x0056)
+                || (ctrl && keysym == 0x0076)
+                || (shift && keysym == 0xFF63)) {
                 window.setTimeout(function() {
                     terminal_client.sendKeyEvent(1, keysym);
                 }, 50);
@@ -112,18 +94,12 @@ function GuacMe(element, guest_ip, vncport, session_id, recording_name) {
         };
 
         keyboard.onkeyup = function (keysym) {
-            /* Remember when ctrl or shift are released. */
-            if (keysym == 0xFFE1) {
-                shift = false;
-            } else if (keysym == 0xFFE3) {
-                ctrl = false;
-            }
+            if (keysym == 0xFFE1) { shift = false; }
+            else if (keysym == 0xFFE3) { ctrl = false; }
 
-            /* Delay sending final stroke until clipboard is updated. */
-            if ((ctrl && shift && keysym == 0x0056) /* ctrl-shift-v */
-                || (ctrl && keysym == 0x0076) /* ctrl-v */
-                || (shift && keysym == 0xFF63) /* shift-insert */
-            ) {
+            if ((ctrl && shift && keysym == 0x0056)
+                || (ctrl && keysym == 0x0076)
+                || (shift && keysym == 0xFF63)) {
                 window.setTimeout(function() {
                     terminal_client.sendKeyEvent(0, keysym);
                 }, 50);
@@ -133,26 +109,17 @@ function GuacMe(element, guest_ip, vncport, session_id, recording_name) {
         };
 
         $(terminal_element)
-            /* Set tabindex so that element can be focused.  Otherwise, no
-            * keyboard events will be registered for it. */
             .attr('tabindex', 1)
-            /* Focus on the element based on mouse movement.  Simply
-            * letting the user click on it doesn't work. */
             .hover(
                 function() {
-                var x = window.scrollX, y = window.scrollY;
-                $(this).focus();
-                window.scrollTo(x, y);
-                }, function() {
-                $(this).blur();
-                }
+                    var x = window.scrollX, y = window.scrollY;
+                    $(this).focus();
+                    window.scrollTo(x, y);
+                },
+                function() { $(this).blur(); }
             )
-            /* Release all keys when the element loses focus. */
-            .blur(function() {
-                keyboard.reset();
-            });
+            .blur(function() { keyboard.reset(); });
 
-        /* Handle paste events when the element is in focus. */
         $(document).on('paste', function(e) {
             var text = e.originalEvent.clipboardData.getData('text/plain');
             if ($(terminal_element).is(":focus")) {
@@ -160,9 +127,7 @@ function GuacMe(element, guest_ip, vncport, session_id, recording_name) {
             }
         });
 
-        /* Error handling. */
         terminal_client.onerror = function(guac_error) {
-            /* Reset and disconnect. */
             terminal_client.disconnect();
 
             var dialog = $('#launch_error');
@@ -173,7 +138,7 @@ function GuacMe(element, guest_ip, vncport, session_id, recording_name) {
             var error_message = guac_error.message;
 
             if (guac_error.message.toLowerCase().startsWith('aborted')) {
-                dialog_message = "Remote session terminated."
+                dialog_message = "Remote session terminated.";
                 error_message = "Close tab.";
             }
             dialog.find('.message').html(dialog_message);
@@ -181,20 +146,16 @@ function GuacMe(element, guest_ip, vncport, session_id, recording_name) {
             dialog.dialog({dialogClass: 'no-close'});
             dialog.dialog(dialog_container);
         };
-
-
     };
 
-    var terminal_connect = function(guest_ip, vncport, recording_name) {
+    var terminal_connect = function(recording_name) {
         if (terminal_connected) {
-            terminal_client.disconnect()
+            terminal_client.disconnect();
             terminal_connected = false;
         }
 
         try {
             terminal_client.connect($.param({
-                'guest_ip': guest_ip,
-                'vncport': vncport,
                 'recording_name': recording_name,
             }));
             terminal_connected = true;
@@ -211,22 +172,12 @@ function GuacMe(element, guest_ip, vncport, session_id, recording_name) {
 function stopTask(taskId) {
     var apiUrl = location.origin + "/apiv2/tasks/status/" + taskId + "/";
 
-    var postData = {
-        status: 'finish',
-    };
-
     fetch(apiUrl, {
         method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(postData),
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'finish' }),
     })
     .then(response => response.json())
-    .then(data => {
-        console.log('Response:', data);
-    })
-    .catch(error => {
-        console.error('Error:', error);
-    });
+    .then(data => console.log('Response:', data))
+    .catch(error => console.error('Error:', error));
 }

--- a/web/submission/views.py
+++ b/web/submission/views.py
@@ -491,7 +491,15 @@ def index(request, task_id=None, resubmit_hash=None):
                 if opt_filename:
                     filename = base_dir + "/" + opt_filename
                 else:
-                    filename = base_dir + "/" + sanitize_filename(hash)
+                    # Try to recover the original filename from the task
+                    original_filename = ""
+                    if task_id:
+                        resubmit_tasks = db.find_sample(task_id=task_id)
+                        if resubmit_tasks:
+                            original_target = resubmit_tasks[0].to_dict().get("target", "")
+                            if original_target:
+                                original_filename = sanitize_filename(os.path.basename(original_target))
+                    filename = base_dir + "/" + (original_filename or sanitize_filename(hash))
                 path = store_temp_file(content, filename)
                 list_of_tasks.append((content, path, hash))
 

--- a/web/submission/views.py
+++ b/web/submission/views.py
@@ -494,11 +494,9 @@ def index(request, task_id=None, resubmit_hash=None):
                     # Try to recover the original filename from the task
                     original_filename = ""
                     if task_id:
-                        resubmit_tasks = db.find_sample(task_id=task_id)
-                        if resubmit_tasks:
-                            original_target = resubmit_tasks[0].to_dict().get("target", "")
-                            if original_target:
-                                original_filename = sanitize_filename(os.path.basename(original_target))
+                        task = db.view_task(task_id)
+                        if task and task.target:
+                            original_filename = sanitize_filename(os.path.basename(task.target))
                     filename = base_dir + "/" + (original_filename or sanitize_filename(hash))
                 path = store_temp_file(content, filename)
                 list_of_tasks.append((content, path, hash))

--- a/web/templates/account/email.html
+++ b/web/templates/account/email.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 
 {% load i18n %}
+{% load crispy_forms_tags %}
 
 {% block head_title %}{% trans "E-mail Addresses" %}{% endblock %}
 

--- a/web/templates/account/password_change.html
+++ b/web/templates/account/password_change.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% load i18n %}
+{% load crispy_forms_tags %}
 
 {% block head_title %}{% trans "Change Password" %}{% endblock %}
 

--- a/web/templates/account/password_reset.html
+++ b/web/templates/account/password_reset.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
 
 {% load i18n %}
+{% load crispy_forms_tags %}
 {% load account %}
 
 {% block head_title %}{% trans "Password Reset" %}{% endblock %}

--- a/web/templates/account/password_reset_from_key.html
+++ b/web/templates/account/password_reset_from_key.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% load i18n %}
+{% load crispy_forms_tags %}
 {% block head_title %}{% trans "Change Password" %}{% endblock %}
 
 {% block content %}

--- a/web/templates/analysis/eventlogs/_evtx_channel.html
+++ b/web/templates/analysis/eventlogs/_evtx_channel.html
@@ -4,6 +4,7 @@
 <div class="mb-2">
     <small class="text-muted">
         {{ evtx_page.channel }} - {{ evtx_page.total_events }} event{{ evtx_page.total_events|pluralize }} - page {{ evtx_page.page }} of {{ evtx_page.total_pages|default:1 }}
+        {% if evtx_page.search_query %}<br>Regex filter: <code>{{ evtx_page.search_query }}</code>{% endif %}
     </small>
 </div>
 

--- a/web/templates/analysis/eventlogs/index.html
+++ b/web/templates/analysis/eventlogs/index.html
@@ -330,6 +330,13 @@
             <small class="text-muted">Channels load on demand and each fetched page is cached in the browser for this report view.</small>
         </div>
 
+        <div class="input-group input-group-sm mb-3">
+            <span class="input-group-text">Regex Search</span>
+            <input type="text" class="form-control" id="evtx_regex_search" placeholder="Applies to the selected EVTX channel">
+            <button class="btn btn-outline-primary" type="button" id="evtx_regex_search_btn">Search</button>
+            <button class="btn btn-outline-secondary" type="button" id="evtx_regex_clear_btn">Clear</button>
+        </div>
+
         <script>
         (function() {
             function escapeHtml(str) {
@@ -357,11 +364,18 @@
 
                 var pageCache = {};
                 var countCache = {};
+                var activeMember = null;
+
+                function getActiveSearch() {
+                    return ($("#evtx_regex_search").val() || "").trim();
+                }
 
                 function loadChannelPage(member, page, paneId, listItem) {
-                    var cacheKey = member + "::" + page;
+                    var search = getActiveSearch();
+                    var cacheKey = member + "::" + page + "::" + search;
                     var pane = $("#" + paneId);
                     if (!pane.length) return;
+                    activeMember = member;
                     $(".evtx-channel-list .list-group-item").removeClass("active");
                     if (listItem) {
                         listItem.addClass("active");
@@ -377,7 +391,7 @@
                     pane.html('<div class="text-center p-3"><i class="fas fa-spinner fa-spin"></i> Loading EVTX events...</div>');
                     $.ajax({
                         url: "{% url 'load_evtx_channel' id %}",
-                        data: {member: member, page: page},
+                        data: {member: member, page: page, search: search},
                         headers: {"X-Requested-With": "XMLHttpRequest"},
                         success: function(html) {
                             pageCache[cacheKey] = html;
@@ -440,6 +454,28 @@
                 container.on("click", ".evtx-channel-list .list-group-item", function() {
                     var listItem = $(this);
                     loadChannelPage(listItem.data("member"), 1, "evtx_channel_content", listItem);
+                });
+
+                $("#evtx_regex_search_btn").on("click", function() {
+                    var member = activeMember || container.find('.evtx-channel-list .list-group-item').first().data("member");
+                    if (!member) return;
+                    var listItem = container.find('.evtx-channel-list .list-group-item[data-member="' + member.replace(/"/g, '&quot;') + '"]');
+                    loadChannelPage(member, 1, "evtx_channel_content", listItem);
+                });
+
+                $("#evtx_regex_search").on("keydown", function(e) {
+                    if (e.key === "Enter") {
+                        e.preventDefault();
+                        $("#evtx_regex_search_btn").trigger("click");
+                    }
+                });
+
+                $("#evtx_regex_clear_btn").on("click", function() {
+                    $("#evtx_regex_search").val("");
+                    var member = activeMember || container.find('.evtx-channel-list .list-group-item').first().data("member");
+                    if (!member) return;
+                    var listItem = container.find('.evtx-channel-list .list-group-item[data-member="' + member.replace(/"/g, '&quot;') + '"]');
+                    loadChannelPage(member, 1, "evtx_channel_content", listItem);
                 });
 
                 container.on("click", ".evtx-pagination .page-link", function(e) {

--- a/web/web/guac_settings.py
+++ b/web/web/guac_settings.py
@@ -168,3 +168,15 @@ logging.config.dictConfig(
         },
     }
 )
+
+from lib.cuckoo.core.database import init_database
+from lib.cuckoo.common.config import Config as _CapeConfig
+
+_db = init_database(exists_ok=True)
+
+# Create guac_sessions table if guacamole is enabled
+if _CapeConfig('web').guacamole.get('enabled', False):
+    from lib.cuckoo.core.data.guac_session import GuacSession  # noqa: F401
+    from lib.cuckoo.core.data.db_common import Base
+    Base.metadata.create_all(_db.engine)
+

--- a/web/web/settings.py
+++ b/web/web/settings.py
@@ -236,6 +236,8 @@ ASGI_APPLICATION = "web.asgi.application"
 
 INSTALLED_APPS = [
     "daphne",
+    "channels",
+    "guac",
     "django.contrib.auth",
     "django.contrib.contenttypes",
     "django.contrib.sessions",

--- a/web/web/urls.py
+++ b/web/web/urls.py
@@ -35,6 +35,7 @@ handler403 = "web.views.handler403"
 handler404 = "web.views.handler404"
 
 urlpatterns = [
+    re_path(r"^guac/", include("guac.urls")),
     path("accounts/", include("allauth.urls")),
     path("robots.txt", TemplateView.as_view(template_name="robots.txt", content_type="text/plain")),
     re_path(r"^$", dashboard_views.index, name="dashboard"),


### PR DESCRIPTION
## Summary
- **Guac session security**: Replace client-side VNC port/IP with server-side libvirt lookup and database-backed session tokens. WebSocket consumer validates session cookie, verifies task is running, and auto-disconnects on task completion. VNC display scales to fit browser viewport.
- **EVTX periodic snapshots**: Collect EVTX snapshots every 30s during analysis to protect against malware clearing event logs. Web viewer groups snapshots by channel with regex search filtering and analyzer noise removal.
- **Web fixes**: Add missing `crispy_forms_tags` to account templates; recover original filename on task resubmit.

## New files
- `lib/cuckoo/core/data/guac_session.py` — GuacSession SQLAlchemy model (table auto-created on startup via `create_all`)

## Test plan
- [ ] Open interactive desktop session — verify VNC connects with no IP/port in browser URL or JS
- [ ] Confirm VNC auto-disconnects when task completes
- [ ] Submit malware that clears event logs — verify snapshots preserve pre-cleared events
- [ ] Test event log search filtering in web UI
- [ ] Verify account pages (password change/reset, email) render without template errors
- [ ] Resubmit a task and confirm original filename is preserved

## Note
The companion `modules/processing/sigma.py` changes for multi-snapshot EVTX support will be submitted as a separate PR against [CAPEsandbox/community](https://github.com/CAPEsandbox/community).