### PR TITLE
Add xdg-open package for generic graphical sample detonation on Linux

### DIFF
--- a/analyzer/linux/modules/packages/xdg_open.py
+++ b/analyzer/linux/modules/packages/xdg_open.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+
+from lib.core.packages import Package
+
+
+class Xdg_open(Package):
+    """Start file with xdg-open"""
+
+    summary = "Run via xdg-open"
+    description = "Generic package that uses xdg-open to run sample"
+
+    def prepare(self):
+        self.args = [self.target] + self.args
+        self.target = "/usr/bin/xdg-open"


### PR DESCRIPTION
[`xdg-open`](https://man.archlinux.org/man/xdg-open.1.en) is a generic way to open files on linux that respects users preferences, making detonation of documents like pdf files in system configured pdf reader possible