### PR TITLE
Optional url splitter

### DIFF
--- a/conf/default/web.conf.default
+++ b/conf/default/web.conf.default
@@ -66,8 +66,8 @@ expose_process_log = no
 reprocess_tasks = no
 # Allow to reprocess failed processing tasks
 reprocess_failed_processing = no
-# Allows you to define URL splitter, "," is default
-url_splitter = ,
+# Allows you to define URL splitter (for example comma). Empty value disables splitting
+url_splitter =
 # Limit number of files extracted from archive in demux.py
 demux_files_limit = 10
 

--- a/web/submission/views.py
+++ b/web/submission/views.py
@@ -426,7 +426,7 @@ def index(request, task_id=None, resubmit_hash=None):
         if task_category in ("url", "dlnexec"):
             if not samples:
                 return render(request, "error.html", {"error": "You specified an invalid URL!"})
-            urls = samples.split(web_conf.general.url_splitter) if web_conf.general.url_splitter else [samples]
+            urls = [u.strip() for u in samples.split(web_conf.general.url_splitter) if u.strip()] if web_conf.general.url_splitter else [samples]
             for url in urls:
                 url = url.replace("hxxps://", "https://").replace("hxxp://", "http://").replace("[.]", ".")
                 if task_category == "dlnexec":

--- a/web/submission/views.py
+++ b/web/submission/views.py
@@ -426,7 +426,8 @@ def index(request, task_id=None, resubmit_hash=None):
         if task_category in ("url", "dlnexec"):
             if not samples:
                 return render(request, "error.html", {"error": "You specified an invalid URL!"})
-            for url in samples.split(web_conf.general.url_splitter):
+            urls = samples.split(web_conf.general.url_splitter) if web_conf.general.url_splitter else [samples]
+            for url in urls:
                 url = url.replace("hxxps://", "https://").replace("hxxp://", "http://").replace("[.]", ".")
                 if task_category == "dlnexec":
                     path, content, sha256 = process_new_dlnexec_task(url, route, options, custom)


### PR DESCRIPTION
Summary
This PR allows disabling URL splitting during submission by leaving the url_splitter configuration value empty and handling such value in the code. It also changes the default behavior to not split URLs, addressing issues where valid URLs containing commas (the previous default) were incorrectly fragmented.

Argument for Change
The previous default splitter was a comma (","). However, commas are valid characters in URLs (e.g., in query parameters or certain path structures). Using a comma as a mandatory default splitter caused many legitimate URLs to be incorrectly broken into invalid fragments during submission. This change ensures that by default, URLs are preserved exactly as entered, while still allowing users to opt-in to multi-URL submission by configuring a specific delimiter.

Configuration Limitation
Due to how configuration values are parsed and stripped, setting url_splitter to a space is effectively treated as an empty value (disabling splitting).  If space-delimited splitting is required in the future, a more complex solution may be necessary, such as implementing a specific placeholder like "whitespace" in the config that the code would then interpret as a command to split by whitespace.