### PR TITLE
qickfix for  "false" route handling

### DIFF
--- a/lib/cuckoo/core/analysis_manager.py
+++ b/lib/cuckoo/core/analysis_manager.py
@@ -606,7 +606,7 @@ class AnalysisManager(threading.Thread):
             )
             self.rooter_response = rooter("libvirt_fwo_enable", self.machine.interface, self.machine.ip)
 
-        elif self.route in ("none", "None", "drop"):
+        elif self.route in ("none", "None", "drop", "false"):
             self.rooter_response = rooter("drop_enable", self.machine.ip, str(self.machine.resultserver_port))
         elif self.route[:3] == "tun" and is_network_interface(self.route):
             self.log.info("Network interface %s is tunnel", self.interface)
@@ -743,7 +743,7 @@ class AnalysisManager(threading.Thread):
             )
             self.rooter_response = rooter("libvirt_fwo_disable", self.machine.interface, self.machine.ip)
 
-        elif self.route in ("none", "None", "drop"):
+        elif self.route in ("none", "None", "drop", "false"):
             self.rooter_response = rooter("drop_disable", self.machine.ip, str(self.machine.resultserver_port))
         elif self.route[:3] == "tun":
             self.log.info("Disable tunnel interface: %s", self.interface)


### PR DESCRIPTION
If a user or an API call set the routing option to "false":
1.Initial identification (line 540) worked: The system use four different values as indicators to disable routing: "none", "None", "drop", and "false" 
2.The "Drop" command was skipped: The code failed to call rooter("drop_enable", ...) because "false" was missing from the second check. This meant the network traffic might not have been explicitly blocked by the rooter as intended.
3.Cleanup was skipped: During task teardown, rooter("drop_disable", ...) was not called, potentially leaving the network state inconsistent for future tasks.

this fix ensure that rooter correctly enables and disables traffic dropping when "false" is used.
