### PR TITLE
Remove pcap flavours from the report zip archive

### DIFF
--- a/web/apiv2/views.py
+++ b/web/apiv2/views.py
@@ -1201,8 +1201,17 @@ def tasks_report(request, task_id, report_format="json", make_zip=False):
     }
 
     report_formats = {
-        # Use the 'all' option if you want all generated files except for memory.dmp
-        "all": {"type": "-", "files": ["memory.dmp"]},
+        # Use the 'all' option if you want all generated files except for memory.dmp and derived pcaps
+        "all": {
+            "type": "-",
+            "files": [
+                "memory.dmp",
+                "dump_decrypted.pcap",
+                "dump_mixed.pcap",
+                "dump_mixed_sorted.pcap",
+                "dump_sorted.pcap",
+            ],
+        },
         # Use the 'dropped' option if you want all dropped files found in the /files directory
         "dropped": {"type": "+", "files": ["files"]},
         # Use the 'dist' option if you want all generated files except for binary, dump_sorted.pcap, memory.dmp, and

--- a/web/apiv2/views.py
+++ b/web/apiv2/views.py
@@ -1206,6 +1206,7 @@ def tasks_report(request, task_id, report_format="json", make_zip=False):
             "type": "-",
             "files": [
                 "memory.dmp",
+                "dump.pcapng",
                 "dump_decrypted.pcap",
                 "dump_mixed.pcap",
                 "dump_mixed_sorted.pcap",


### PR DESCRIPTION
Pcap flavours carry information that can be found already within the archive - original pcap and TLS info are still included.

Removing them from archive can significantly reduce the resulting archive size and reduce the time needed for the API endpoint response

## Justification

Analysis with a lot of network traffic produced this artifacts:

```
/opt/CAPEv2/storage/analyses/537# ls -lahS
total 1.4G
-rw-r--r--   1 cape cape 469M Apr 21 18:15 dump_mixed.pcap
-rw-r--r--   1 cape cape 468M Apr 21 18:18 dump.pcapng
-rw-rw-r--   1 cape cape 467M Apr 21 18:15 dump.pcap
-rw-r--r--   1 cape cape 2.0M Apr 21 18:15 dump_decrypted.pcap
-rw-r--r--   1 cape cape 508K Apr 21 18:15 analysis.log
-rw-rw-r--   1 cape cape 125K Apr 21 18:15 cuckoo.log
-rw-rw-r--   1 cape cape  54K Apr 21 18:18 files.json
```

When trying to download zip archive with `apiv2/tasks/get/report/<id>/all/zip/`, archive creation took over 3 minutes (when we increased nginx proxy timeout) blocking the whole CPU core for this computation.

## Alternative solution

I understand if you want to keep all of the resulting pcap flavours in the resulting archive - I propose as alternative solution another type of export, something like `all_but_derived_pcaps` (better name needs to be found).