### PR TITLE
fix NitrogenLoader YARA

### DIFF
--- a/data/yara/CAPE/NitrogenLoader.yar
+++ b/data/yara/CAPE/NitrogenLoader.yar
@@ -31,5 +31,6 @@ rule NitrogenLoader
         $rc4decrypt_1 = {48 89 ?? 4? 89 ?? E8 [4] 4? 8B ?? 24 [1-4] 4? 89 ?? 4? 89 ?? 4? 89 C1 [0-1] 89 ?? E8 [4] 4? 89}
         $rc4decrypt_2 = {E8 [4] 8B ?? 24 [1-4] 4? 89 ?? 48 89 ?? 4? 89 C1 E8 [3] FF}
     condition:
-        (2 of ($string*) and any of ($syscall*)) or 4 of ($decrypt*) or ((3 of ($taskman_*) or 3 of ($installers*)) and all of ($rc4decrypt_*))
+        ((2 of ($string*) and any of ($syscall*)) or 4 of ($decrypt*) or ((3 of ($taskman_*) or 3 of ($installers*)) and all of ($rc4decrypt_*)))
+        and uint16(0) == 0x5a4d
 }

--- a/data/yara/CAPE/NitrogenLoader.yar
+++ b/data/yara/CAPE/NitrogenLoader.yar
@@ -31,6 +31,6 @@ rule NitrogenLoader
         $rc4decrypt_1 = {48 89 ?? 4? 89 ?? E8 [4] 4? 8B ?? 24 [1-4] 4? 89 ?? 4? 89 ?? 4? 89 C1 [0-1] 89 ?? E8 [4] 4? 89}
         $rc4decrypt_2 = {E8 [4] 8B ?? 24 [1-4] 4? 89 ?? 48 89 ?? 4? 89 C1 E8 [3] FF}
     condition:
-        ((2 of ($string*) and any of ($syscall*)) or 4 of ($decrypt*) or ((3 of ($taskman_*) or 3 of ($installers*)) and all of ($rc4decrypt_*)))
-        and uint16(0) == 0x5a4d
+        uint16(0) == 0x5a4d and
+        ((2 of ($string*) and any of ($syscall*)) or 4 of ($decrypt*) or ((3 of ($taskman_*) or 3 of ($installers*)) and all of ($rc4decrypt_*)))        
 }


### PR DESCRIPTION
The rule matches on the ELF binary /usr/bin/git-remote-keybase (151e6dfdaa05c93e9c36e3e6dd015e9b8dc786ae9a88a373be9f1a04e3db7a20) so I added a `uint16(0) == 0x5a4d` to limit it to PE.

matched strings were:
```
$ yara -s nitro.yar /usr/bin/git-remote-keybase 
NitrogenLoader /usr/bin/git-remote-keybase
0x2587ca0:$stringaes1: 63 7C 77 7B F2 6B 6F C5 30 01 67 2B FE D7 AB 76 CA 82 C9 7D FA
0x2587da0:$stringaes2: 52 09 6A D5 30 36 A5 38 BF 40 A3 9E 81 F3 D7 FB 7C E3 39 82 9B
0x7bbba6:$syscallnumber: 49 89 C3 B8 02 00 00 00 E8 4D 79 00 00
```

It probably has more false positives on PE files if it hits on a ELF, you might want to check it out.

