### PR TITLE
Warn instead of fail when script storage fails during submission

### DIFF
--- a/lib/cuckoo/common/web_utils.py
+++ b/lib/cuckoo/common/web_utils.py
@@ -930,6 +930,7 @@ def download_file(**kwargs):
     if not static and "dist_extract" in kwargs["options"]:
         static = True
 
+    warnings = []
     for machine in kwargs.get("task_machines", []):
         if machine == "first":
             machine = None
@@ -961,7 +962,7 @@ def download_file(**kwargs):
             save_script_to_storage(task_ids_new, kwargs)
         except Exception as e:
             log.error("Error saving scripts to storage: %s", e)
-            return "error", {"error": "Error: Storing scripts to tempstorage"}
+            warnings.append({"script": f"{e}"})
 
         if isinstance(kwargs.get("task_ids", False), list):
             kwargs["task_ids"].extend(task_ids_new)
@@ -972,7 +973,8 @@ def download_file(**kwargs):
     if not onesuccess:
         return "error", {"error": f"Provided hash not found on {kwargs['service']}"}
 
-    return "ok", {"task_ids": kwargs["task_ids"], "errors": extra_details.get("errors", [])}
+    errors = extra_details.get("errors", []) + warnings
+    return "ok", {"task_ids": kwargs["task_ids"], "errors": errors}
 
 
 def save_script_to_storage(task_ids: list, kwargs):

--- a/web/templates/submission/complete.html
+++ b/web/templates/submission/complete.html
@@ -32,7 +32,7 @@
 {% endif %}
 
 {% if errors %}
-    <div class="alert alert-danger"><h4>Submission Failed!</h4>
+    <div class="alert alert-danger"><h4>Errors</h4>
     <ul>
     {% for block in errors %}
         {% for k, v in block.items %}


### PR DESCRIPTION
Previously, a failure in `save_script_to_storage` caused `download_file` to return an immediate error response with a hardcoded message. The submission view routes to `error.html` vs `complete.html` based solely on whether task IDs were produced — so callers that received an error status would never set `task_ids`, sending the user to `error.html` with the generic "Error adding task(s) to CAPE's database." message, even though the tasks had already been created in the database.

Now the exception is caught and its message appended to a warnings list, which is merged into the `errors` field of the final `ok` response. Task submission proceeds, task IDs are returned to the caller, and the user lands on `complete.html` seeing the actual exception rather than a hardcoded fallback string.

Also fixes a pre-existing misleading label on `complete.html`: the error block heading read "Submission Failed!" but that template is only ever rendered when tasks were successfully queued. Renamed to "Errors" to accurately reflect that it surfaces non-fatal warnings alongside a successful submission.