### PR TITLE
feat: COM logical parent enrichment in process tree (LethalHTA / DCOM evasion)

### DIFF
--- a/modules/processing/behavior.py
+++ b/modules/processing/behavior.py
@@ -1247,7 +1247,7 @@ class NetworkMap:
         "0002df01-0000-0000-c000-000000000046": "iexplore.exe",
         "9ba05972-f6a8-11cf-a442-00a0c90a8f39": "explorer.exe",
         "c08afd90-f2a1-11d1-8455-00a0c91f3880": "explorer.exe",
-        "25336920-03f9-11cf-8fd0-00aa00686f13": "mshtml.dll",
+        "25336920-03f9-11cf-8fd0-00aa00686f13": "mshta.exe",  # HTMLDocument OOP → mshta
     }
 
     def event_apicall(self, call, process):
@@ -1259,15 +1259,9 @@ class NetworkMap:
                 clsid = (args_map.get("rclsid") or "").lower()
                 progid = (args_map.get("progid") or "").strip()
                 # Capture any out-of-process activation (CLSCTX includes LOCAL_SERVER=4)
-                try:
-                    ctx = int(args_map.get("clscontext", "0"), 16)
-                except (ValueError, TypeError):
-                    ctx = 0
+                ctx = _safe_int(args_map.get("clscontext", "0"))
                 if ctx & 0x4 or clsid in self._OOP_CLSIDS:
-                    key = (process.get("process_id"), clsid)
-                    if not any((a.get("activator_pid"), a.get("clsid")) == key
-                               for a in self.com_activations):
-                        self.com_activations.append({
+                    self.com_activations.append({
                             "clsid": clsid,
                             "progid": progid,
                             "activator_pid": process.get("process_id"),
@@ -1537,6 +1531,9 @@ class BehaviorAnalysis(Processing):
                                 instance.event_apicall(call, process)
                             except Exception:
                                 log.exception('Failure in partial behavior "%s"', instance.key)
+                    # Reset the iterator so reporting modules can read the calls again
+                    with suppress(AttributeError):
+                        process["calls"].reset()
 
             for instance in instances:
                 try:

--- a/modules/processing/behavior.py
+++ b/modules/processing/behavior.py
@@ -1467,7 +1467,6 @@ class EncryptedBuffers:
 
 def _enrich_tree_com_parents(tree_nodes, com_activations):
     """Walk the processtree and annotate nodes whose binary matches a COM activation record."""
-    import os as _os
     # Build lookup: target_binary_lower -> list of activations
     binary_map = {}
     for act in com_activations:

--- a/modules/processing/behavior.py
+++ b/modules/processing/behavior.py
@@ -1239,9 +1239,43 @@ class NetworkMap:
         self.http_requests = []  # url -> [pinfo]
         self.dns_intents = defaultdict(list)  # domain -> [intent]
         self._winhttp_state = {"processes": {}}
+        self.com_activations = []  # out-of-process CoCreateInstance calls
+
+    # CLSIDs for known out-of-process COM servers
+    _OOP_CLSIDS = {
+        "3050f4d8-98b5-11cf-bb82-00aa00bdce0b": "mshta.exe",
+        "0002df01-0000-0000-c000-000000000046": "iexplore.exe",
+        "9ba05972-f6a8-11cf-a442-00a0c90a8f39": "explorer.exe",
+        "c08afd90-f2a1-11d1-8455-00a0c91f3880": "explorer.exe",
+        "25336920-03f9-11cf-8fd0-00aa00686f13": "mshtml.dll",
+    }
 
     def event_apicall(self, call, process):
-        if call.get("category") != "network":
+        cat = call.get("category") or ""
+        if cat == "com":
+            api = (call.get("api") or "").lower()
+            if api == "cocreateinstance":
+                args_map = _get_call_args_dict(call)
+                clsid = (args_map.get("rclsid") or "").lower()
+                progid = (args_map.get("progid") or "").strip()
+                # Capture any out-of-process activation (CLSCTX includes LOCAL_SERVER=4)
+                try:
+                    ctx = int(args_map.get("clscontext", "0"), 16)
+                except (ValueError, TypeError):
+                    ctx = 0
+                if ctx & 0x4 or clsid in self._OOP_CLSIDS:
+                    key = (process.get("process_id"), clsid)
+                    if not any((a.get("activator_pid"), a.get("clsid")) == key
+                               for a in self.com_activations):
+                        self.com_activations.append({
+                            "clsid": clsid,
+                            "progid": progid,
+                            "activator_pid": process.get("process_id"),
+                            "activator_name": process.get("process_name", ""),
+                            "target_binary": self._OOP_CLSIDS.get(clsid, ""),
+                        })
+            return
+        if cat != "network":
             return
 
         api = (call.get("api") or "").lower()
@@ -1350,17 +1384,17 @@ class NetworkMap:
         # BSON/JSON keys must be strings.
         # Let's convert tuple keys to string representation "ip:port"
 
-        endpoint_map_list = [{"ip_port": f"{ip}:{port}", "pinfo": entries} for (ip, port), entries in self.endpoint_map.items()]
-
-        http_host_map_list = [{"host": k, "pinfo": v} for k, v in self.http_host_map.items()]
-        dns_intents_list = [{"domain": k, "intents": v} for k, v in self.dns_intents.items()]
+        endpoint_map_str = {}
+        for (ip, port), entries in self.endpoint_map.items():
+            endpoint_map_str[f"{ip}:{port}"] = entries
 
         return {
-            "endpoint_map": endpoint_map_list,
-            "http_host_map": http_host_map_list,
-            "dns_intents": dns_intents_list,
+            "endpoint_map": endpoint_map_str,
+            "http_host_map": self.http_host_map,
+            "dns_intents": self.dns_intents,
             "http_requests": self.http_requests,
             "winhttp_sessions": winhttp_finalize_sessions(self._winhttp_state),
+            "com_activations": self.com_activations,
         }
 
 
@@ -1436,6 +1470,40 @@ class EncryptedBuffers:
         return self.bufs
 
 
+
+def _enrich_tree_com_parents(tree_nodes, com_activations):
+    """Walk the processtree and annotate nodes whose binary matches a COM activation record."""
+    import os as _os
+    # Build lookup: target_binary_lower -> list of activations
+    binary_map = {}
+    for act in com_activations:
+        binary = (act.get("target_binary") or "").lower()
+        if not binary:
+            # Fall back to ProgID heuristic
+            progid = (act.get("progid") or "").lower()
+            _progid_to_binary = {
+                "htafile": "mshta.exe",
+                "internetexplorer.application": "iexplore.exe",
+                "shell.application": "explorer.exe",
+            }
+            binary = _progid_to_binary.get(progid, "")
+        if binary:
+            binary_map.setdefault(binary, []).append(act)
+
+    def _walk(nodes):
+        for node in nodes:
+            path = node.get("module_path") or ""
+            name = path.replace("\\", "/").rsplit("/", 1)[-1].lower()
+            if name in binary_map:
+                act = binary_map[name][0]
+                node["com_logical_parent_pid"] = act["activator_pid"]
+                node["com_logical_parent_name"] = act["activator_name"]
+                node["com_progid"] = act.get("progid", "")
+                node["com_clsid"] = act.get("clsid", "")
+            _walk(node.get("children") or [])
+
+    _walk(tree_nodes)
+
 class BehaviorAnalysis(Processing):
     """Behavior Analyzer."""
 
@@ -1469,15 +1537,17 @@ class BehaviorAnalysis(Processing):
                                 instance.event_apicall(call, process)
                             except Exception:
                                 log.exception('Failure in partial behavior "%s"', instance.key)
-                    # Reset the iterator so reporting modules can read the calls again
-                    with suppress(AttributeError):
-                        process["calls"].reset()
 
             for instance in instances:
                 try:
                     behavior[instance.key] = instance.run()
                 except Exception as e:
                     log.exception('Failed to run partial behavior class "%s" due to "%s"', instance.key, e)
+
+            # Enrich processtree nodes with COM logical parent relationships
+            com_acts = (behavior.get("network_map") or {}).get("com_activations") or []
+            if com_acts and behavior.get("processtree"):
+                _enrich_tree_com_parents(behavior["processtree"], com_acts)
         else:
             log.warning('Analysis results folder does not exist at path "%s"', self.logs_path)
             # load behavior from json if exist or env CAPE_REPORT variable

--- a/web/analysis/templatetags/generic_tags.py
+++ b/web/analysis/templatetags/generic_tags.py
@@ -28,6 +28,10 @@ def proctreetolist(tree):
             newnode["name"] = node["name"]
             if "module_path" in node:
                 newnode["module_path"] = node["module_path"]
+            for _com_field in ("com_logical_parent_pid", "com_logical_parent_name",
+                               "com_progid", "com_clsid"):
+                if _com_field in node:
+                    newnode[_com_field] = node[_com_field]
             if "environ" in node and "CommandLine" in node["environ"]:
                 cmdline = node["environ"]["CommandLine"]
                 if cmdline.startswith('"'):

--- a/web/templates/analysis/behavior/_tree.html
+++ b/web/templates/analysis/behavior/_tree.html
@@ -23,6 +23,20 @@
                 {% if detections2pid|get_detection_by_pid:process.pid %}
                     <span class="badge bg-danger ms-2">{{ detections2pid|get_detection_by_pid:process.pid }}</span>
                 {% endif %}
+                {% if process.com_logical_parent_pid %}
+                <div class="text-warning-emphasis small mt-1 ms-1" style="border-left:2px dashed #ffc107;padding-left:6px;">
+                    <i class="fas fa-arrow-up me-1 text-warning"></i>
+                    <span class="text-warning">COM-activated by</span>
+                    <a href="javascript:show_tab('process_{{ process.com_logical_parent_pid }}');" class="text-warning fw-bold">
+                        {{ process.com_logical_parent_name }} ({{ process.com_logical_parent_pid }})
+                    </a>
+                    {% if process.com_progid %}
+                    <span class="text-muted">via <code class="text-warning-emphasis">{{ process.com_progid }}</code></span>
+                    {% elif process.com_clsid %}
+                    <span class="text-muted">via CLSID <code class="text-warning-emphasis">{{ process.com_clsid }}</code></span>
+                    {% endif %}
+                </div>
+                {% endif %}
             </li>
             {% endif %}
         {% endfor %}


### PR DESCRIPTION
## Summary

When malware uses DCOM out-of-process activation (LethalHTA, embedded OLE objects), the OS-level process parent is the svchost/DcomLaunch broker — hiding the true originator. An Excel document embedding an HTA object activates `mshta.exe -Embedding` via svchost, making the process tree appear as `svchost → mshta` with no visible link to Excel.

This PR reconstructs the COM logical parent-child relationship from hooked CoCreateInstance calls and annotates the process tree with a dashed visual link.

## Changes

**`modules/processing/behavior.py`**
- `NetworkMap` now handles `category=com` calls in addition to `network`, capturing `CoCreateInstance` calls with `CLSCTX_LOCAL_SERVER` context or known out-of-process CLSIDs (htafile/mshta, InternetExplorer, ShellWindows, etc.) into `network_map.com_activations`.
- `_enrich_tree_com_parents()` post-processing step walks the processtree after all behavior instances run, annotating nodes whose binary matches a COM activation record with `com_logical_parent_pid`, `com_logical_parent_name`, `com_progid`, and `com_clsid`.

**`web/analysis/templatetags/generic_tags.py`**
- `proctreetolist` passes the four new COM fields through to the flattened output.

**`web/templates/analysis/behavior/_tree.html`**
- Processes with `com_logical_parent_pid` render a dashed annotation:  
  `↑ COM-activated by EXCEL.EXE (1528) via htafile`  
  linking back to the logical originator.

## Test plan
- [ ] Submit `New Order.xls` (or similar HTA-embedded Office doc) and verify mshta.exe node shows COM parent annotation pointing to Excel
- [ ] Confirm `behavior.network_map.com_activations` contains `{clsid: "3050f4d8-...", progid: "htafile", activator_name: "EXCEL.EXE", target_binary: "mshta.exe"}`
- [ ] Verify clean tasks (no COM activation) show no annotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)