### PR TITLE
fix: DNS and Hosts network tables support multiple process attributions

### DIFF
--- a/web/templates/analysis/network/_dns.html
+++ b/web/templates/analysis/network/_dns.html
@@ -56,10 +56,14 @@
                             </td>
                             {% if settings.NETWORK_PROC_MAP %}
                                 <td>
-                                    {% if p.process_name %}
-                                        {{ p.process_name }}{% if p.process_id %} ({{ p.process_id }}){% endif %}
+                                    {% if p.processes %}
+                                        {% for proc in p.processes %}
+                                            <span class="badge bg-warning text-dark">{% if proc.process_name %}{{ proc.process_name }}{% else %}(unknown){% endif %}{% if proc.pid %} ({{ proc.pid }}){% endif %}</span>
+                                        {% endfor %}
+                                    {% elif p.process_name or p.process_id %}
+                                        <span class="badge bg-warning text-dark">{% if p.process_name %}{{ p.process_name }}{% else %}(unknown){% endif %}{% if p.process_id %} ({{ p.process_id }}){% endif %}</span>
                                     {% else %}
-                                        -
+                                        <span class="text-muted">-</span>
                                     {% endif %}
                                 </td>
                             {% endif %}

--- a/web/templates/analysis/network/_dns_not_ajax.html
+++ b/web/templates/analysis/network/_dns_not_ajax.html
@@ -51,10 +51,14 @@
                     </td>
                     {% if settings.NETWORK_PROC_MAP %}
                         <td>
-                            {% if p.process_name %}
-                                {{ p.process_name }}{% if p.process_id %} ({{ p.process_id }}){% endif %}
+                            {% if p.processes %}
+                                {% for proc in p.processes %}
+                                    <span class="badge bg-warning text-dark">{% if proc.process_name %}{{ proc.process_name }}{% else %}(unknown){% endif %}{% if proc.pid %} ({{ proc.pid }}){% endif %}</span>
+                                {% endfor %}
+                            {% elif p.process_name or p.process_id %}
+                                <span class="badge bg-warning text-dark">{% if p.process_name %}{{ p.process_name }}{% else %}(unknown){% endif %}{% if p.process_id %} ({{ p.process_id }}){% endif %}</span>
                             {% else %}
-                                -
+                                <span class="text-muted">-</span>
                             {% endif %}
                         </td>
                     {% endif %}

--- a/web/templates/analysis/network/_hosts_not_ajax.html
+++ b/web/templates/analysis/network/_hosts_not_ajax.html
@@ -27,15 +27,24 @@
                     {% endif %}
                     </td>
                     <td>{{host.country_name}}</td>
-                    {% if host.asn %}
-                        <td><a href="/analysis/search/asn:{{host.asn}}"><span title="{{host.asn_name}}" style="font-weight: bold;">{{host.asn}}</span></a></td>
-                    {% endif %}
+                    <td>
+                        {% if host.asn %}<a href="/analysis/search/asn:{{host.asn}}"><span title="{{host.asn_name}}" style="font-weight: bold;">{{host.asn}}</span></a>{% else %}<span class="text-muted">-</span>{% endif %}
+                    </td>
                     {% if settings.NETWORK_PROC_MAP %}
                         <td>
-                            {% if host.process_name %}
-                                {{ host.process_name }}{% if host.process_id %} ({{ host.process_id }}){% endif %}
+                            {% if host.processes %}
+                                {% for p in host.processes %}
+                                    <span class="badge bg-warning text-dark"
+                                          title="{% if p.source %}source: {{p.source}}{% endif %}{% if p.resolved_hostname %} | resolved via {{p.resolved_hostname}}{% endif %}{% if p.protocol %} | {{p.protocol}}{% endif %}{% if p.dst_port %}:{{p.dst_port}}{% endif %}">
+                                        {% if p.process_name %}{{ p.process_name }}{% else %}(unknown){% endif %}{% if p.pid %} ({{ p.pid }}){% endif %}
+                                    </span>
+                                {% endfor %}
+                            {% elif host.process_name or host.process_id %}
+                                <span class="badge bg-warning text-dark">
+                                    {% if host.process_name %}{{ host.process_name }}{% else %}(unknown){% endif %}{% if host.process_id %} ({{ host.process_id }}){% endif %}
+                                </span>
                             {% else %}
-                                -
+                                <span class="text-muted">-</span>
                             {% endif %}
                         </td>
                     {% endif %}

--- a/web/templates/analysis/network/_hosts_not_ajax.html
+++ b/web/templates/analysis/network/_hosts_not_ajax.html
@@ -35,7 +35,7 @@
                             {% if host.processes %}
                                 {% for p in host.processes %}
                                     <span class="badge bg-warning text-dark"
-                                          title="{% if p.source %}source: {{p.source}}{% endif %}{% if p.resolved_hostname %} | resolved via {{p.resolved_hostname}}{% endif %}{% if p.protocol %} | {{p.protocol}}{% endif %}{% if p.dst_port %}:{{p.dst_port}}{% endif %}">
+                                          {% spaceless %}title="{% if p.source %}source: {{ p.source }}{% endif %}{% if p.resolved_hostname %}{% if p.source %} | {% endif %}resolved via {{ p.resolved_hostname }}{% endif %}{% if p.protocol %}{% if p.source or p.resolved_hostname %} | {% endif %}{{ p.protocol }}{% if p.dst_port %}:{{ p.dst_port }}{% endif %}{% endif %}"{% endspaceless %}
                                         {% if p.process_name %}{{ p.process_name }}{% else %}(unknown){% endif %}{% if p.pid %} ({{ p.pid }}){% endif %}
                                     </span>
                                 {% endfor %}


### PR DESCRIPTION
## Summary

When multiple processes query the same hostname or connect to the same IP (e.g. both `javaw.exe` and `python.exe` resolve `pypi.org`), the DNS and Hosts tables previously showed only the first attributed process. This PR renders one badge per attributed process.

Companion to the `network_etw` module changes where `ProcessFlowIndex._dns_host_to_pid` was changed from a single-value dict to a list, and `for_host_all()` was added to return all attributions. DNS records now include a `processes` list field alongside the legacy `process_name`/`process_id` fields.

## Changes

- **`_dns.html` / `_dns_not_ajax.html`**: Iterate `p.processes` for the Process Name (PID) column; fall back to legacy single-field render for analyses that predate this change.
- **`_hosts_not_ajax.html`**: Sync multi-process badge iteration to match the AJAX version (which already supported it).

## Test plan
- [ ] Submit a sample where multiple processes make DNS queries (e.g. Java + Python stealer) and verify multiple badges appear per DNS row
- [ ] Verify fallback render still works for old analyses without `p.processes`

🤖 Generated with [Claude Code](https://claude.com/claude-code)