### PR TITLE
Restore FA icons in guac session-ended dialog

### DIFF
--- a/web/guac/templates/guac/index.html
+++ b/web/guac/templates/guac/index.html
@@ -33,9 +33,8 @@
             <div id="terminal"></div>
             <div id="launch_error" style="display:none;position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);z-index:1002;max-width:440px;width:100%;">
                 <div style="background:#212529;border:1px solid #495057;border-radius:8px;padding:20px;box-shadow:0 0 30px rgba(0,0,0,0.8);color:#fff;">
-                    <h6 id="dialog-heading" class="mb-2" style="color:#fff;"><i class="fas fa-exclamation-triangle me-1 text-danger"></i>Session Error</h6>
-                    <p class="message mb-1 small" style="color:#adb5bd;"></p>
-                    <p class="error_msg mb-2 small" style="color:#6c757d;"></p>
+                    <h6 id="dialog-heading" class="mb-2" style="color:#fff;">Session Ended</h6>
+                    <p id="dialog-message" class="mb-2 small" style="color:#6c757d;"></p>
                     <a id="taskStatus" href="/submit/status/{{ task_id }}/" class="btn btn-sm btn-outline-light"><i class="fas fa-tasks me-1"></i>View Task</a>
                 </div>
             </div>

--- a/web/static/js/guac-main.js
+++ b/web/static/js/guac-main.js
@@ -17,6 +17,10 @@ const PASTE_DELAY_MS = 50;
 
 const NON_FATAL_STATUS_CODES = new Set([0, 256]);
 
+const ICON_ERROR = 'fas fa-exclamation-circle text-danger';
+const ICON_WARNING = 'fas fa-exclamation-triangle text-warning';
+const ICON_SUCCESS = 'fas fa-check-circle text-success';
+
 class GuacSession {
     constructor(element, config) {
         this.config = config;
@@ -153,12 +157,25 @@ class GuacSession {
         });
     }
 
-    _showError(title, detail) {
+    _showDialog(title, detail, icon) {
         const dialog = $('#launch_error');
-        dialog.find('.message').html(title);
-        dialog.find('.error_msg').html(detail);
+        const iconHtml = icon ? `<i class="${icon} me-1"></i>` : '';
+        dialog.find('#dialog-heading').html(`${iconHtml}${title}`);
+        dialog.find('#dialog-message').html(detail);
         dialog.dialog({ dialogClass: 'no-close' });
         dialog.dialog(this.dialogContainer);
+    }
+
+    _showError(title, detail) {
+        this._showDialog(title, detail, ICON_ERROR);
+    }
+
+    _showWarning(title, detail) {
+        this._showDialog(title, detail, ICON_WARNING);
+    }
+
+    _showSuccess(title, detail) {
+        this._showDialog(title, detail, ICON_SUCCESS);
     }
 
     _setupErrorHandler() {
@@ -174,9 +191,9 @@ class GuacSession {
             if (error.code === 514) {
                 this._showError("Connection error", "Server timeout.");
             } else if (error.code === 515) {
-                this._showError("Session complete", "Backing VM has disconnected.");
+                this._showSuccess("Session complete", "Backing VM has disconnected.");
             } else if (error.code === 522) {
-                this._showError("Session ended", "Session timed out due to inactivity.");
+                this._showWarning("Session ended", "Session timed out due to inactivity.");
             } else {
                 const _msg = `An unexpected error occurred: ${error.message}`;
                 this._showError("Connection error", _msg);
@@ -228,7 +245,6 @@ function stopTask(taskId, onSuccess, onError) {
   
     const apiUrl = location.origin + "/apiv2/tasks/status/" + taskId + "/";
 
-    var apiUrl = location.origin + "/apiv2/tasks/status/" + taskId + "/";
     fetch(apiUrl, {
         method: 'POST',
         headers: {


### PR DESCRIPTION
Extends the dialog rendering in guac-main.js so the heading shows a Font Awesome icon alongside the title, replacing the previous static 'Session Error' heading that was retained verbatim regardless of why the session ended.

- Introduce _showDialog(title, detail, icon) and thin _showError / _showWarning / _showSuccess wrappers around it. Each wrapper passes its corresponding module-level ICON_* constant.
- Route 514 (server timeout) and the default branch to _showError (red exclamation-circle), 522 (idle timeout) to _showWarning (amber exclamation-triangle), and 515 (backing VM disconnected = normal completion) to _showSuccess (green check-circle).
- Simplify the dialog markup: drop the unused .message paragraph and the dead error_msg class; give the surviving body paragraph an id (#dialog-message) to mirror #dialog-heading.
- Keep 'Session Ended' as a neutral static heading so the dialog still reads sensibly if JS fails to populate it before the dialog is shown.
- Drive-by: remove a duplicate `var apiUrl` declaration in stopTask() left over from the master merge in 1230fa0f — it was a SyntaxError under strict mode.