### PR TITLE
Standardize TLP parameter, match TLP HTML component to spec

### DIFF
--- a/lib/cuckoo/core/data/tasking.py
+++ b/lib/cuckoo/core/data/tasking.py
@@ -201,6 +201,9 @@ class TasksMixIn:
         else:
             return None
 
+        if tlp:
+            tlp = tlp.lower()
+
         task.category = obj.__class__.__name__.lower()
         task.timeout = timeout
         task.package = package

--- a/web/templates/analysis/report.html
+++ b/web/templates/analysis/report.html
@@ -50,39 +50,39 @@ $(function() {
 </script>
 <style type="text/css">
 .alert-tlp_green {
-    background-color: #008000;
-    padding: 3px;
-    padding-left: 10px;
-    margin-bottom: 3px;
-    text-align: center;
-    font-size: 12;
+  background-color: black;
+  color: rgb(51, 255, 0);
 }
 .alert-tlp_amber {
-    background-color: #FFBF00;
-    padding: 3px;
-    padding-left: 10px;
-    margin-bottom: 3px;
-    text-align: center;
-    font-size: 12;
+  background-color: black;
+  color: rgb(255, 192, 0);
 }
 .alert-tlp_red {
-    background-color: #FF2626;
-    padding: 3px;
-    padding-left: 10px;
-    margin-bottom: 3px;
-    text-align: center;
-    font-size: 12;
+  background-color: black;
+  color: rgb(255, 43, 43);
 }
 </style>
 {% if analysis.info.tlp %}
-    {% if analysis.info.tlp == "Red" %}
-    <div class="alert alert-tlp_red">
-    {% elif analysis.info.tlp == "Amber" %}
-    <div class="alert alert-tlp_amber">
-    {% elif analysis.info.tlp == "Green" %}
-        <div class="alert alert-tlp_amber">
-    {% endif %}
-    </div>
+  <div
+    class="mt-1 mb-1 p-1 fw-bold text-center alert-tlp_{{ analysis.info.tlp|lower }}"
+    aria-controls="alert-tlp-description"
+    aria-expanded="false"
+    data-bs-target="#alert-tlp-description"
+    data-bs-toggle="collapse"
+    role="button"
+  >
+    TLP:{{ analysis.info.tlp|upper }}
+  </div>
+
+  <div class="mt-1 mb-1 p-2 collapse text-center" id="alert-tlp-description">
+  {% if analysis.info.tlp|lower == "red" %}
+    Analysis report (including the sample) MUST NOT be mentioned, shared or exported outside of the system by the users.
+  {% elif analysis.info.tlp|lower == "amber" %}
+    Analysis report (including the sample) MAY be shared on a need-to-know basis within organization.
+  {% elif analysis.info.tlp|lower == "green" %}
+    Analysis report (including the sample) MAY be shared within community but SHOULD NOT be shared via publicly accessible channells.
+  {% endif %}
+  </div>
 {% endif %}
 
 <ul class="nav nav-pills nav-fill bg-dark rounded shadow-sm p-1 mb-3" id="reportTabs" role="tablist">

--- a/web/templates/analysis/report.html
+++ b/web/templates/analysis/report.html
@@ -80,7 +80,7 @@ $(function() {
   {% elif analysis.info.tlp|lower == "amber" %}
     Analysis report (including the sample) MAY be shared on a need-to-know basis within organization.
   {% elif analysis.info.tlp|lower == "green" %}
-    Analysis report (including the sample) MAY be shared within community but SHOULD NOT be shared via publicly accessible channells.
+    Analysis report (including the sample) MAY be shared within community but SHOULD NOT be shared via publicly accessible channels.
   {% endif %}
   </div>
 {% endif %}

--- a/web/templates/submission/index.html
+++ b/web/templates/submission/index.html
@@ -945,9 +945,9 @@
                                     <select class="form-select border-secondary" id="form_tlp"
                                         name="tlp">
                                         <option value="" selected data-color="#ffffff" style="color: #ffffff;">White</option>
-                                        <option value="Green" data-color="#198754" style="color: #198754;">Green</option>
-                                        <option value="Amber" data-color="#ffc107" style="color: #ffc107;">Amber</option>
-                                        <option value="Red" data-color="#dc3545" style="color: #dc3545;">Red</option>
+                                        <option value="green" data-color="#198754" style="color: #198754;">Green</option>
+                                        <option value="amber" data-color="#ffc107" style="color: #ffc107;">Amber</option>
+                                        <option value="red" data-color="#dc3545" style="color: #dc3545;">Red</option>
                                     </select>
                                 </div>
                                 {% endif %}


### PR DESCRIPTION
Previously TLP information was displayed as a bar with the color that would match the TLP category, which didn't match recommended usage: https://www.first.org/tlp/#Usage and wasn't clear for recipients that didn't schedule analysis or don't look at CAPE codebase

This version matches more closely (although not fully - they recommend right justify that wouldn't match CAPE interface). Additionally it standardizes tlp parameter to be always lowercase when added to the database. Since previous analysis may contain different case in the tlp field lowercase is also enforced in html template