### PR TITLE
Add env config support for cape-processor

### DIFF
--- a/conf/copy_configs.sh
+++ b/conf/copy_configs.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
 for filename in conf/default/*.conf.default conf/default/*.env; do
-    cp -vf "./$filename" "./$(echo "$filename" | sed -e 's/.default//g' | sed -e 's/default//g')";
+    dest="conf/${filename#conf/default/}"
+    cp -vf "./$filename" "./${dest%.default}"
 done

--- a/conf/copy_configs.sh
+++ b/conf/copy_configs.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-for filename in conf/default/*.conf.default; do
+for filename in conf/default/*.conf.default conf/default/*.env; do
     cp -vf "./$filename" "./$(echo "$filename" | sed -e 's/.default//g' | sed -e 's/default//g')";
 done

--- a/conf/default/cape-processor.env
+++ b/conf/default/cape-processor.env
@@ -1,0 +1,26 @@
+# CAPE Processor Configuration overrides
+# Un-comment the variables you want to change
+
+# ID of the analysis to process (default: auto)
+#CAPE_ID=auto
+
+# Max amount of time spent in processing before we fail a task (default: 300)
+#CAPE_PROCESSING_TIMEOUT=900
+
+# Number of parallel threads to use (default: 1)
+#CAPE_PARALLEL=7
+
+# Max children tasks per worker (default: 7)
+#CAPE_MAXTASKSPERCHILD=7
+
+# Enable debug messages (default: false)
+#CAPE_DEBUG=true
+
+# Reprocess failed processing (default: false)
+#CAPE_FAILED_PROCESSING=true
+
+# Enable logging garbage collection related info (default: false)
+#CAPE_MEMORY_DEBUGGING=true
+
+# Disable memory limit (default: false)
+#CAPE_DISABLE_MEMORY_LIMIT=true

--- a/installer/cape2.sh
+++ b/installer/cape2.sh
@@ -1399,8 +1399,8 @@ function install_CAPE() {
     fi
 
     cd "$CAPE_ROOT/" || return
-    # copy *.conf.default to *.conf so we have all properly updated fields, as we can't ignore old configs in repository
-    for filename in conf/default/*.conf.default; do cp -vf "./$filename" "./$(echo "$filename" | sed -e 's/.default//g' | sed -e 's/default//g')";  done
+    # copy *.conf.default and *.env to their destination so we have all properly updated fields
+    for filename in conf/default/*.conf.default conf/default/*.env; do cp -vf "./$filename" "./$(echo "$filename" | sed -e 's/.default//g' | sed -e 's/default//g')";  done
 
     sed -i "/connection =/cconnection = postgresql://${USER}:${PASSWD}@localhost:5432/${USER}" conf/cuckoo.conf
     # sed -i "/tor/{n;s/enabled = no/enabled = yes/g}" conf/routing.conf

--- a/installer/cape2.sh
+++ b/installer/cape2.sh
@@ -1400,7 +1400,10 @@ function install_CAPE() {
 
     cd "$CAPE_ROOT/" || return
     # copy *.conf.default and *.env to their destination so we have all properly updated fields
-    for filename in conf/default/*.conf.default conf/default/*.env; do cp -vf "./$filename" "./$(echo "$filename" | sed -e 's/.default//g' | sed -e 's/default//g')";  done
+    for filename in conf/default/*.conf.default conf/default/*.env; do
+        dest="conf/${filename#conf/default/}"
+        cp -vf "./$filename" "./${dest%.default}"
+    done
 
     sed -i "/connection =/cconnection = postgresql://${USER}:${PASSWD}@localhost:5432/${USER}" conf/cuckoo.conf
     # sed -i "/tor/{n;s/enabled = no/enabled = yes/g}" conf/routing.conf

--- a/systemd/cape-processor.service
+++ b/systemd/cape-processor.service
@@ -5,12 +5,28 @@ Wants=cape.service
 After=cape-rooter.service
 
 [Service]
-WorkingDirectory=/opt/CAPEv2/utils/
-ExecStart=/etc/poetry/bin/poetry run python process.py -p7 auto -pt 900
+Type=exec
+WorkingDirectory=/opt/CAPEv2
+# Default configuration via environment variables
+Environment=CAPE_PROCESSING_TIMEOUT=900
+Environment=CAPE_PARALLEL=7
+Environment=CAPE_MAXTASKSPERCHILD=7
+Environment=CAPE_ID=auto
+# Optional environment variables (can be set to 'true' or '1' to enable)
+# Environment=CAPE_DEBUG=false
+# Environment=CAPE_FAILED_PROCESSING=false
+# Environment=CAPE_MEMORY_DEBUGGING=false
+# Environment=CAPE_DISABLE_MEMORY_LIMIT=false
+
+# Allow user overrides via file
+EnvironmentFile=-/opt/CAPEv2/conf/default/cape-processor.env
+EnvironmentFile=-/opt/CAPEv2/conf/cape-processor.env
+
+ExecStart=/etc/poetry/bin/poetry run python utils/process.py
 User=cape
 Group=cape
 Restart=always
-RestartSec=5m
+RestartSec=10
 LimitNOFILE=100000
 
 [Install]

--- a/utils/process.py
+++ b/utils/process.py
@@ -630,7 +630,7 @@ def main():
         action="store",
         type=int,
         required=False,
-        default=int(os.getenv("CAPE_MAXTASKSPERCHILD", 7)),
+        default=int(os.getenv("CAPE_MAXTASKSPERCHILD") or 7),
     )
     parser.add_argument(
         "-md",

--- a/utils/process.py
+++ b/utils/process.py
@@ -550,7 +550,9 @@ def _load_report(task_id: int):
 def str_to_bool(v):
     if isinstance(v, bool):
         return v
-    return v.lower() in ("yes", "true", "t", "y", "1")
+    if isinstance(v, str):
+        return v.lower() in ("yes", "true", "t", "y", "1")
+    return False
 
 
 def parse_id(id_string: str):

--- a/utils/process.py
+++ b/utils/process.py
@@ -547,6 +547,12 @@ def _load_report(task_id: int):
     return False
 
 
+def str_to_bool(v):
+    if isinstance(v, bool):
+        return v
+    return v.lower() in ("yes", "true", "t", "y", "1")
+
+
 def parse_id(id_string: str):
     """
     Parses a string representing a range or list of ranges of IDs and returns a list of tuples.
@@ -586,18 +592,43 @@ def main():
         "id",
         type=parse_id,
         help="ID of the analysis to process (auto for continuous processing of unprocessed tasks). Can be 1 or 1-10 or 1,3,5,7",
+        default=os.getenv("CAPE_ID", "auto"),
+        nargs="?",
     )
     parser.add_argument("-c", "--caperesubmit", help="Allow CAPE resubmit processing.", action="store_true", required=False)
-    parser.add_argument("-d", "--debug", help="Display debug messages", action="store_true", required=False)
+    parser.add_argument(
+        "-d",
+        "--debug",
+        help="Display debug messages",
+        action="store_true",
+        required=False,
+        default=str_to_bool(os.getenv("CAPE_DEBUG", "false")),
+    )
     parser.add_argument("-r", "--report", help="Re-generate report", action="store_true", required=False)
     parser.add_argument(
-        "-p", "--parallel", help="Number of parallel threads to use (auto mode only).", type=int, required=False, default=1
+        "-p",
+        "--parallel",
+        help="Number of parallel threads to use (auto mode only).",
+        type=int,
+        required=False,
+        default=int(os.getenv("CAPE_PARALLEL", 1)),
     )
     parser.add_argument(
-        "-fp", "--failed-processing", help="reprocess failed processing", action="store_true", required=False, default=False
+        "-fp",
+        "--failed-processing",
+        help="reprocess failed processing",
+        action="store_true",
+        required=False,
+        default=str_to_bool(os.getenv("CAPE_FAILED_PROCESSING", "false")),
     )
     parser.add_argument(
-        "-mc", "--maxtasksperchild", help="Max children tasks per worker", action="store", type=int, required=False, default=7
+        "-mc",
+        "--maxtasksperchild",
+        help="Max children tasks per worker",
+        action="store",
+        type=int,
+        required=False,
+        default=int(os.getenv("CAPE_MAXTASKSPERCHILD", 7)),
     )
     parser.add_argument(
         "-md",
@@ -605,7 +636,7 @@ def main():
         help="Enable logging garbage collection related info",
         action="store_true",
         required=False,
-        default=False,
+        default=str_to_bool(os.getenv("CAPE_MEMORY_DEBUGGING", "false")),
     )
     parser.add_argument(
         "-pt",
@@ -614,7 +645,7 @@ def main():
         action="store",
         type=int,
         required=False,
-        default=300,
+        default=int(os.getenv("CAPE_PROCESSING_TIMEOUT", 300)),
     )
     testing_args = parser.add_argument_group("Signature testing options")
     testing_args.add_argument(
@@ -641,7 +672,13 @@ def main():
         default=False,
         required=False,
     )
-    parser.add_argument("--disable-memory-limit", help="Disable memory limit.", action="store_true", default=False, required=False)
+    parser.add_argument(
+        "--disable-memory-limit",
+        help="Disable memory limit.",
+        action="store_true",
+        required=False,
+        default=str_to_bool(os.getenv("CAPE_DISABLE_MEMORY_LIMIT", "false")),
+    )
     args = parser.parse_args()
 
     init_database()

--- a/utils/process.py
+++ b/utils/process.py
@@ -647,7 +647,7 @@ def main():
         action="store",
         type=int,
         required=False,
-        default=int(os.getenv("CAPE_PROCESSING_TIMEOUT", 300)),
+        default=int(os.getenv("CAPE_PROCESSING_TIMEOUT") or 300),
     )
     testing_args = parser.add_argument_group("Signature testing options")
     testing_args.add_argument(

--- a/utils/process.py
+++ b/utils/process.py
@@ -613,7 +613,7 @@ def main():
         help="Number of parallel threads to use (auto mode only).",
         type=int,
         required=False,
-        default=int(os.getenv("CAPE_PARALLEL", 1)),
+        default=int(os.getenv("CAPE_PARALLEL") or 1),
     )
     parser.add_argument(
         "-fp",

--- a/utils/process.py
+++ b/utils/process.py
@@ -594,7 +594,7 @@ def main():
         "id",
         type=parse_id,
         help="ID of the analysis to process (auto for continuous processing of unprocessed tasks). Can be 1 or 1-10 or 1,3,5,7",
-        default=os.getenv("CAPE_ID", "auto"),
+        default=os.getenv("CAPE_ID") or "auto",
         nargs="?",
     )
     parser.add_argument("-c", "--caperesubmit", help="Allow CAPE resubmit processing.", action="store_true", required=False)


### PR DESCRIPTION
Add support for .env configuration for the CAPE processor and wire those variables into the service and runtime. Changes include: copying conf/default/*.env in installer and copy script; adding a default conf/default/cape-processor.env; updating systemd service to load environment variables and files, set sensible defaults and use utils/process.py as ExecStart; and updating utils/process.py to read configuration from environment variables (with a str_to_bool helper) for ID, parallelism, timeouts, memory flags, and other options. Also adjusted service RestartSec. This enables easier configuration via environment files or systemd Environment settings.