### PR TITLE
feat(web): generic OIDC SSO via django-allauth (Okta/Azure/Auth0/Keycloak)

### DIFF
--- a/conf/default/web.conf.default
+++ b/conf/default/web.conf.default
@@ -30,6 +30,13 @@ disposable_domain_list = data/safelist/disposable_domain_list.txt
 
 [general]
 timezone = UTC
+# Set to yes only when CAPE is served behind a reverse proxy (e.g. nginx) that
+# terminates TLS and strips/overwrites X-Forwarded-Proto / X-Forwarded-Host from
+# clients. Enables Django's SECURE_PROXY_SSL_HEADER + USE_X_FORWARDED_HOST so
+# request.is_secure() and absolute URLs (incl. the OIDC redirect_uri) are correct.
+# Leave no for a directly-exposed app — trusting forwarded headers would allow
+# proto/host spoofing.
+behind_proxy = no
 # Prescan new file tasks with YARA for sample identification and custom execution
 # Useful to set options, tags, timeout, etc for packers/obfuscators/cryptors
 yara_recon = no

--- a/conf/default/web.conf.default
+++ b/conf/default/web.conf.default
@@ -7,8 +7,8 @@ enabled = no
 captcha = no
 2fa = no
 # To enable Oauth check https://django-allauth.readthedocs.io and web/web/settings.py.
-# Allow only SSO for users with specific domain. Can be allow to all if empty.
-social_auth_email_domain = example.com
+# Allow only SSO for users with a specific email domain. Leave blank to allow any.
+social_auth_email_domain =
 
 [registration]
 enabled = no
@@ -149,6 +149,47 @@ amazon = no
 github = no
 gitlab = no
 twitter = no
+
+
+# OpenID Connect SSO. Generic — works with Okta / Azure AD / Auth0 / Google
+# Workspace / Keycloak or any OIDC-compliant IdP via django-allauth's
+# openid_connect provider. Set enabled = yes and fill in the fields below.
+[oauth_oidc]
+enabled = no
+# Arbitrary identifier; becomes part of the callback URL:
+#   /accounts/oidc/<provider_id>/login/callback/
+# Must match the redirect URI registered in your IdP app.
+provider_id = oidc
+# Display name shown on the login button.
+name = SSO
+# OAuth2 client credentials from your IdP app.
+client_id =
+client_secret =
+# IdP discovery root — the /.well-known/openid-configuration is appended
+# automatically. Examples:
+#   Okta:     https://<domain>/oauth2/default
+#   Azure:    https://login.microsoftonline.com/<tenant>/v2.0
+#   Auth0:    https://<domain>
+#   Keycloak: https://<host>/realms/<realm>
+server_url =
+# Group-claim -> Django role mapping. The IdP must include group names in the
+# ID token under `groups_claim` (default: "groups").
+# required_groups: if set, only users in at least one of these groups get a
+# CAPE account provisioned. Leave blank to allow any IdP-authenticated user.
+# admin_groups / superadmin_groups: membership maps to is_staff / is_superuser
+# and is reconciled on every login (removal from the group demotes the user).
+# Leave both blank to manage roles manually in Django.
+required_groups =
+admin_groups =
+superadmin_groups =
+groups_claim = groups
+# Optional: periodic Okta account-status reconciliation (okta_user_sync
+# management command, run via systemd timer). When a user with active API keys
+# is no longer ACTIVE in Okta, they are deactivated locally and their keys are
+# revoked. Requires an Okta admin API base URL and an SSWS token with the
+# okta.users.read scope. Leave blank to disable.
+admin_api_url =
+admin_api_token =
 
 [display_browser_martians]
 enabled = no

--- a/web/apikey/context_processors.py
+++ b/web/apikey/context_processors.py
@@ -1,9 +1,9 @@
 """Template context processor — surfaces apikey access policy to templates."""
 
-from .views import _user_may_manage_keys
+from .policy import user_may_manage_keys
 
 
 def apikey_access(request):
     """Make `may_manage_apikeys` available to every template, so the user
     dropdown can hide the API Keys link for SSO non-staff users."""
-    return {"may_manage_apikeys": _user_may_manage_keys(getattr(request, "user", None))}
+    return {"may_manage_apikeys": user_may_manage_keys(getattr(request, "user", None))}

--- a/web/apikey/management/commands/okta_user_sync.py
+++ b/web/apikey/management/commands/okta_user_sync.py
@@ -88,10 +88,13 @@ class Command(BaseCommand):
                 continue
 
             try:
-                # search filter — exact email match. URL-quoting is handled by requests.
+                # search filter — exact email match. URL-quoting is handled by
+                # requests; escape backslashes and quotes so an address with
+                # those characters can't break the SCIM filter syntax.
+                safe_email = email.replace("\\", "\\\\").replace('"', '\\"')
                 r = session.get(
                     f"{admin_url}/api/v1/users",
-                    params={"search": f'profile.email eq "{email}"'},
+                    params={"search": f'profile.email eq "{safe_email}"'},
                     timeout=10,
                 )
                 r.raise_for_status()

--- a/web/apikey/management/commands/okta_user_sync.py
+++ b/web/apikey/management/commands/okta_user_sync.py
@@ -1,0 +1,129 @@
+"""Management command: reconcile local Django User.is_active with Okta status.
+
+For every Django User that has at least one active ApiKey AND a linked OIDC
+SocialAccount, look the user up in Okta by email. If Okta no longer reports
+the user as ACTIVE (status SUSPENDED, DEPROVISIONED, LOCKED_OUT, ...) or
+returns no result for the email, deactivate the local user — which fires
+the post_save cascade-revoke signal and invalidates all of their API keys.
+
+Run periodically via systemd timer (cape-okta-sync.timer) to bound the gap
+between Okta-side disable/revoke and local API access being cut off.
+
+Configuration (web.conf [oauth_oidc]):
+  admin_api_url    = https://<your-okta-org>.okta.com
+  admin_api_token  = <SSWS token with okta.users.read scope>
+
+Usage:
+  poetry run python manage.py okta_user_sync           # apply changes
+  poetry run python manage.py okta_user_sync --dry-run # report only
+"""
+
+import logging
+
+import requests
+from django.contrib.auth.models import User
+from django.core.management.base import BaseCommand
+
+from allauth.socialaccount.models import SocialAccount
+from apikey.models import ApiKey
+from lib.cuckoo.common.config import Config
+
+log = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = "Reconcile local User.is_active with Okta status; cascade-revoke ApiKeys for users no longer ACTIVE in Okta."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="report what would change without modifying users",
+        )
+
+    def handle(self, *args, **opts):
+        web_cfg = Config("web")
+        oidc_cfg = getattr(web_cfg, "oauth_oidc", None)
+        if not oidc_cfg or not oidc_cfg.get("enabled", False):
+            self.stderr.write("[oauth_oidc] is not enabled — nothing to sync")
+            return
+
+        admin_url = (oidc_cfg.get("admin_api_url") or "").rstrip("/")
+        admin_token = oidc_cfg.get("admin_api_token") or ""
+        if not admin_url or not admin_token:
+            self.stderr.write(
+                "[oauth_oidc] admin_api_url or admin_api_token missing — set them in web.conf to enable Okta sync"
+            )
+            return
+
+        # Find users that (a) have at least one active ApiKey and
+        # (b) have a linked SocialAccount (i.e., were JIT-provisioned via
+        # Okta SSO). Local-only admin accounts with API keys are skipped.
+        active_apikey_user_ids = set(
+            ApiKey.objects.filter(revoked_at__isnull=True).values_list("user_id", flat=True)
+        )
+        sso_user_ids = set(SocialAccount.objects.values_list("user_id", flat=True))
+        target_ids = active_apikey_user_ids & sso_user_ids
+        users = list(User.objects.filter(id__in=target_ids, is_active=True))
+        if not users:
+            self.stdout.write("no SSO users with active API keys to check")
+            return
+
+        self.stdout.write(f"checking {len(users)} SSO users with active ApiKeys against Okta")
+
+        session = requests.Session()
+        session.headers.update(
+            {
+                "Authorization": f"SSWS {admin_token}",
+                "Accept": "application/json",
+                "User-Agent": "CAPE/okta_user_sync",
+            }
+        )
+
+        deactivated = 0
+        for user in users:
+            email = (user.email or "").strip()
+            if not email:
+                self.stderr.write(f"  user_id={user.id} ({user.username}): no email on local record — skipping")
+                continue
+
+            try:
+                # search filter — exact email match. URL-quoting is handled by requests.
+                r = session.get(
+                    f"{admin_url}/api/v1/users",
+                    params={"search": f'profile.email eq "{email}"'},
+                    timeout=10,
+                )
+                r.raise_for_status()
+                results = r.json()
+            except Exception as e:
+                self.stderr.write(f"  {email}: Okta lookup failed: {e}")
+                continue
+
+            if not isinstance(results, list) or not results:
+                # Email not found in Okta — user has been deleted there.
+                if self._deactivate(user, "okta_user_not_found", opts["dry_run"]):
+                    deactivated += 1
+                continue
+
+            okta_user = results[0]
+            status = (okta_user.get("status") or "").upper()
+            if status != "ACTIVE":
+                if self._deactivate(user, f"okta_status_{status or 'UNKNOWN'}", opts["dry_run"]):
+                    deactivated += 1
+            else:
+                self.stdout.write(f"  {email}: ACTIVE")
+
+        suffix = " (dry run)" if opts["dry_run"] else ""
+        self.stdout.write(self.style.SUCCESS(f"sync complete{suffix} — {deactivated} user(s) deactivated"))
+
+    def _deactivate(self, user, reason, dry_run):
+        msg = f"  {user.email}: deactivating (reason={reason})"
+        if dry_run:
+            self.stdout.write(self.style.WARNING(f"{msg} [DRY RUN]"))
+            return False
+        user.is_active = False
+        user.save()  # triggers the post_save cascade-revoke signal in apikey.signals
+        self.stdout.write(self.style.WARNING(msg))
+        log.warning("okta_user_sync: deactivated user %s reason=%s", user.username, reason)
+        return True

--- a/web/apikey/policy.py
+++ b/web/apikey/policy.py
@@ -1,0 +1,19 @@
+"""API-key access policy — kept view-independent so both views.py and the
+context processor can import it without pulling in view-layer dependencies
+(or risking an import cycle)."""
+
+from allauth.socialaccount.models import SocialAccount
+
+
+def user_may_manage_keys(user):
+    """Return True if `user` is allowed to view/create/revoke their own keys.
+    Local-only users always pass; SSO-provisioned users must be staff."""
+    if not user or not user.is_authenticated:
+        return False
+    # Called from the apikey_access context processor on every page load —
+    # cache the SocialAccount lookup on the user object for the request to
+    # avoid a redundant query per render.
+    if not hasattr(user, "_may_manage_keys"):
+        is_sso = SocialAccount.objects.filter(user=user).exists()
+        user._may_manage_keys = True if not is_sso else bool(user.is_staff)
+    return user._may_manage_keys

--- a/web/apikey/templates/apikey/list.html
+++ b/web/apikey/templates/apikey/list.html
@@ -55,7 +55,7 @@
                 </td>
                 <td>
                     {% if not k.revoked_at %}
-                    <form method="post" action="{% url 'apikey:revoke' k.pk %}" onsubmit="return confirm('Revoke {{ k.name }}? Existing scripts using this key will start receiving 401 immediately.');" class="d-inline">
+                    <form method="post" action="{% url 'apikey:revoke' k.pk %}" onsubmit="return confirm('Revoke {{ k.name|escapejs }}? Existing scripts using this key will start receiving 401 immediately.');" class="d-inline">
                         {% csrf_token %}
                         <button type="submit" class="btn btn-sm btn-outline-danger">Revoke</button>
                     </form>

--- a/web/apikey/views.py
+++ b/web/apikey/views.py
@@ -15,7 +15,6 @@ Authorization model:
     their behalf, or admin creates a key for them in Django admin).
 """
 
-from allauth.socialaccount.models import SocialAccount
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import get_object_or_404, redirect, render
@@ -24,20 +23,7 @@ from django.views.decorators.http import require_POST
 
 from .forms import ApiKeyCreateForm
 from .models import ApiKey
-
-
-def _user_may_manage_keys(user):
-    """Return True if `user` is allowed to view/create/revoke their own keys.
-    Local-only users always pass; SSO-provisioned users must be staff."""
-    if not user or not user.is_authenticated:
-        return False
-    # Called from the apikey_access context processor on every page load —
-    # cache the SocialAccount lookup on the user object for the request to
-    # avoid a redundant query per render.
-    if not hasattr(user, "_may_manage_keys"):
-        is_sso = SocialAccount.objects.filter(user=user).exists()
-        user._may_manage_keys = True if not is_sso else bool(user.is_staff)
-    return user._may_manage_keys
+from .policy import user_may_manage_keys as _user_may_manage_keys
 
 
 def _forbidden(request):

--- a/web/templates/account/account_inactive.html
+++ b/web/templates/account/account_inactive.html
@@ -1,11 +1,18 @@
 {% extends "base.html" %}
-
 {% load i18n %}
 
 {% block head_title %}{% trans "Account Inactive" %}{% endblock %}
 
 {% block content %}
-<h1>{% trans "Account Inactive" %}</h1>
-
-<p>{% trans "This account is inactive/Admin set manual approve." %}</p>
+<div class="container my-5" style="max-width: 540px;">
+    <div class="card bg-dark border-secondary">
+        <div class="card-header border-secondary">
+            <h4 class="mb-0 text-white"><i class="fas fa-user-slash me-2 text-danger"></i>{% trans "Account Inactive" %}</h4>
+        </div>
+        <div class="card-body">
+            <p>{% trans "This account is inactive. Contact an administrator if you believe this is in error." %}</p>
+            <a href="{% url 'account_login' %}" class="btn btn-outline-secondary text-white"><i class="fas fa-arrow-left me-1"></i>{% trans "Back to login" %}</a>
+        </div>
+    </div>
+</div>
 {% endblock %}

--- a/web/templates/account/login.html
+++ b/web/templates/account/login.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% load crispy_forms_tags %}
 {% load socialaccount %}
-{% block title %}Sign In{% endblock title %}
+{% block title %}{% trans "Sign In" %}{% endblock title %}
 
 {% block content %}
 <div class="container my-5" style="max-width: 480px;">

--- a/web/templates/account/login.html
+++ b/web/templates/account/login.html
@@ -1,18 +1,58 @@
 {% extends 'base.html' %}
 {% load i18n %}
 {% load crispy_forms_tags %}
-{% block title %}Log In{% endblock title %}
+{% load socialaccount %}
+{% block title %}Sign In{% endblock title %}
+
 {% block content %}
-<div style="margin-top:6%" class="container">
-    <h2>{% trans "Sign In" %}</h2>
-    <p>
-        {% blocktrans %}If you have not created an account yet, then please <a style="color:red" href="{{signup_url}}">Sign up</a> first.
-        {% endblocktrans %}
-    </p>
-    <form method="post" autocomplete="off">
-    {% csrf_token %}
-    {{ form|crispy }}
-    <button class="btn btn-secondary" type="submit">Login</button> <a style="color:red" href="/accounts/password/reset/">{% trans "Forgot password?" %}</a>
-    </form>
+<div class="container my-5" style="max-width: 480px;">
+    <div class="card bg-dark border-secondary">
+        <div class="card-header border-secondary text-center">
+            <h4 class="mb-0 text-white"><i class="fas fa-sign-in-alt me-2 text-danger"></i>{% trans "Sign In" %}</h4>
+        </div>
+        <div class="card-body">
+
+            {% if messages %}
+                {% for m in messages %}
+                <div class="alert alert-{% if m.tags == 'error' %}danger{% else %}{{ m.tags|default:'info' }}{% endif %}">{{ m }}</div>
+                {% endfor %}
+            {% endif %}
+
+            {% get_providers as socialaccount_providers %}
+            {% if socialaccount_providers %}
+                <div class="d-grid gap-2 mb-3">
+                    {% for provider in socialaccount_providers %}
+                    <a href="{% provider_login_url provider.id process='login' %}" class="btn btn-danger btn-lg">
+                        <i class="fas fa-sign-in-alt me-1"></i>
+                        {% blocktrans with name=provider.name %}Sign in with {{ name }}{% endblocktrans %}
+                    </a>
+                    {% endfor %}
+                </div>
+                <div class="d-flex align-items-center my-3">
+                    <hr class="flex-grow-1 border-secondary">
+                    <span class="px-2 small text-white-50">{% trans "or sign in locally" %}</span>
+                    <hr class="flex-grow-1 border-secondary">
+                </div>
+            {% endif %}
+
+            <form method="post" autocomplete="off">
+                {% csrf_token %}
+                {{ form|crispy }}
+                <div class="d-grid mt-3">
+                    <button class="btn btn-outline-secondary text-white" type="submit">
+                        <i class="fas fa-key me-1"></i> {% trans "Sign In" %}
+                    </button>
+                </div>
+                <div class="text-center mt-2">
+                    <a href="/accounts/password/reset/" class="text-danger small">{% trans "Forgot password?" %}</a>
+                </div>
+            </form>
+
+            <hr class="border-secondary mt-4">
+            <p class="text-center text-white-50 small mb-0">
+                {% blocktrans %}Don't have an account? <a class="text-danger" href="{{signup_url}}">Sign up</a>.{% endblocktrans %}
+            </p>
+        </div>
+    </div>
 </div>
 {% endblock content %}

--- a/web/templates/account/logout.html
+++ b/web/templates/account/logout.html
@@ -1,14 +1,25 @@
 {% extends 'base.html' %}
+{% load i18n %}
 {% load crispy_forms_tags %}
-{% block title %}Log Out{% endblock %}
+{% block title %}{% trans "Sign Out" %}{% endblock %}
+
 {% block content %}
-<div style="margin-top:6%" class="container">
-    <h1>Log Out</h1>
-    <p>Are you sure you want to log out?</p>
-    <form method="post" action="{% url 'account_logout' %}">
-        {% csrf_token %}
-        {{ form|crispy }}
-        <button class="btn btn-danger" type="submit">Log Out</button>
-    </form>
+<div class="container my-5" style="max-width: 480px;">
+    <div class="card bg-dark border-secondary">
+        <div class="card-header border-secondary">
+            <h4 class="mb-0 text-white"><i class="fas fa-sign-out-alt me-2 text-danger"></i>{% trans "Sign Out" %}</h4>
+        </div>
+        <div class="card-body">
+            <p>{% trans "Are you sure you want to sign out?" %}</p>
+            <form method="post" action="{% url 'account_logout' %}">
+                {% csrf_token %}
+                {{ form|crispy }}
+                <div class="d-flex gap-2 mt-3">
+                    <button class="btn btn-danger" type="submit"><i class="fas fa-sign-out-alt me-1"></i>{% trans "Sign Out" %}</button>
+                    <a href="/" class="btn btn-outline-secondary text-white">{% trans "Cancel" %}</a>
+                </div>
+            </form>
+        </div>
+    </div>
 </div>
 {% endblock content %}

--- a/web/templates/account/signup_closed.html
+++ b/web/templates/account/signup_closed.html
@@ -1,11 +1,19 @@
 {% extends "base.html" %}
-
 {% load i18n %}
 
 {% block head_title %}{% trans "Sign Up Closed" %}{% endblock %}
 
 {% block content %}
-<h1>{% trans "Sign Up Closed" %}</h1>
-
-<p>{% trans "We are sorry, but the sign up is currently closed." %}</p>
+<div class="container my-5" style="max-width: 540px;">
+    <div class="card bg-dark border-secondary">
+        <div class="card-header border-secondary">
+            <h4 class="mb-0 text-white"><i class="fas fa-lock me-2 text-danger"></i>{% trans "Sign Up Closed" %}</h4>
+        </div>
+        <div class="card-body">
+            <p class="mb-3">{% trans "We're sorry, but public sign-up is closed on this CAPE instance." %}</p>
+            <p class="text-white-50 small">{% trans "If your organization uses single sign-on, return to the login page and click the SSO button — accounts are auto-provisioned for users your administrator has authorized." %}</p>
+            <a href="{% url 'account_login' %}" class="btn btn-outline-secondary text-white mt-2"><i class="fas fa-arrow-left me-1"></i>{% trans "Back to login" %}</a>
+        </div>
+    </div>
+</div>
 {% endblock %}

--- a/web/templates/socialaccount/authentication_error.html
+++ b/web/templates/socialaccount/authentication_error.html
@@ -1,11 +1,25 @@
 {% extends "base.html" %}
-
 {% load i18n %}
 
-{% block head_title %}{% trans "Social Network Login Failure" %}{% endblock %}
+{% block head_title %}{% trans "Authentication Error" %}{% endblock %}
 
 {% block content %}
-<h1>{% trans "Social Network Login Failure" %}</h1>
-
-<p>{% trans "An error occurred while attempting to login via your social network account." %}</p>
+<div class="container my-5" style="max-width: 540px;">
+    <div class="card bg-dark border-secondary">
+        <div class="card-header border-secondary">
+            <h4 class="mb-0 text-white"><i class="fas fa-exclamation-triangle me-2 text-danger"></i>{% trans "Authentication Error" %}</h4>
+        </div>
+        <div class="card-body">
+            {% if reason %}
+            <p>{{ reason }}</p>
+            {% else %}
+            <p>{% trans "An error occurred while attempting to sign in." %}</p>
+            {% endif %}
+            {% if auth_error.code %}
+            <p class="text-white-50 small">{% trans "Code:" %} <code>{{ auth_error.code }}</code></p>
+            {% endif %}
+            <a href="{% url 'account_login' %}" class="btn btn-danger"><i class="fas fa-redo me-1"></i>{% trans "Try again" %}</a>
+        </div>
+    </div>
+</div>
 {% endblock %}

--- a/web/templates/socialaccount/signup.html
+++ b/web/templates/socialaccount/signup.html
@@ -1,22 +1,33 @@
 {% extends "base.html" %}
-
 {% load i18n %}
+{% load crispy_forms_tags %}
 
-{% block head_title %}{% trans "Signup" %}{% endblock %}
+{% block head_title %}{% trans "Sign Up" %}{% endblock %}
 
 {% block content %}
-    <h1>{% trans "Sign Up" %}</h1>
+<div class="container my-5" style="max-width: 540px;">
+    <div class="card bg-dark border-secondary">
+        <div class="card-header border-secondary">
+            <h4 class="mb-0 text-white"><i class="fas fa-user-plus me-2 text-danger"></i>{% trans "Complete your account" %}</h4>
+        </div>
+        <div class="card-body">
+            <p class="text-white-50">
+                {% blocktrans with provider_name=account.get_provider.name %}You're signing in with {{provider_name}} for the first time. Confirm a couple of details to finish creating your CAPE account:{% endblocktrans %}
+            </p>
 
-<p>{% blocktrans with provider_name=account.get_provider.name site_name=site.name %}You are about to use your {{provider_name}} account to login to
-{{site_name}}. As a final step, please complete the following form:{% endblocktrans %}</p>
-
-<form class="signup" id="signup_form" method="post" action="{% url 'socialaccount_signup' %}">
-  {% csrf_token %}
-  {{ form.as_p }}
-  {% if redirect_field_value %}
-  <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
-  {% endif %}
-  <button type="submit">{% trans "Sign Up" %} &raquo;</button>
-</form>
-
+            <form class="signup" id="signup_form" method="post" action="{% url 'socialaccount_signup' %}" autocomplete="off">
+                {% csrf_token %}
+                {{ form|crispy }}
+                {% if redirect_field_value %}
+                <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
+                {% endif %}
+                <div class="d-grid mt-3">
+                    <button type="submit" class="btn btn-danger">
+                        <i class="fas fa-check me-1"></i> {% trans "Continue" %}
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
 {% endblock %}

--- a/web/web/allauth_adapters.py
+++ b/web/web/allauth_adapters.py
@@ -12,6 +12,7 @@ from django.conf import settings
 from django.contrib.auth.models import User
 from django.dispatch import receiver
 from django.shortcuts import render
+from django.utils.translation import gettext as _
 
 
 log = logging.getLogger(__name__)
@@ -34,6 +35,10 @@ _OIDC_CACHE: dict = {}
 _OIDC_CACHE_LOCK = threading.Lock()
 _DISCOVERY_TTL = 3600
 _JWKS_TTL = 300
+# Asymmetric signing algorithms accepted for ID tokens when the provider's
+# discovery doc doesn't advertise `id_token_signing_alg_values_supported`.
+# Deliberately excludes "none" and the HMAC family to avoid algorithm-confusion.
+_DEFAULT_OIDC_ALGS = ["RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
 
 
 def _cached_fetch(cache_key: str, url: str, ttl: int, validate=None) -> dict:
@@ -144,7 +149,6 @@ try:
             import jwt as _jwt
             header = _jwt.get_unverified_header(id_token)
             kid = header["kid"]
-            alg = header["alg"]
             keys_data = _get_cached_jwks(keys_url)
             key = jwtkit.lookup_kid_jwk(keys_data, kid)
             if key is None:
@@ -156,8 +160,12 @@ try:
             if key is None:
                 from allauth.socialaccount.providers.oauth2.client import OAuth2Error
                 raise OAuth2Error(f"Invalid 'kid': '{kid}'")
+            # Pin accepted algorithms to the provider's advertised set rather
+            # than reflecting the token header's untrusted `alg`. PyJWT rejects
+            # a token whose alg isn't in this list, blocking "none"/HS* confusion.
+            allowed_algs = self.openid_config.get("id_token_signing_alg_values_supported") or _DEFAULT_OIDC_ALGS
             data = _jwt.decode(
-                id_token, key=key, algorithms=[alg],
+                id_token, key=key, algorithms=allowed_algs,
                 issuer=issuer, audience=app.client_id,
                 leeway=30,
             )
@@ -304,7 +312,8 @@ class MySocialAccountAdapter(DefaultSocialAccountAdapter):
                     render(
                         request,
                         "socialaccount/authentication_error.html",
-                        {"reason": "An email address is required to sign in."},
+                        {"reason": _("An email address is required to sign in.")},
+                        status=403,
                     )
                 )
             domain = user_email.rsplit("@", 1)[-1]
@@ -313,10 +322,9 @@ class MySocialAccountAdapter(DefaultSocialAccountAdapter):
                     render(
                         request,
                         "socialaccount/authentication_error.html",
-                        {"reason": (
-                            f"Please use an email with domain: "
-                            f"{settings.SOCIAL_AUTH_EMAIL_DOMAIN}"
-                        )},
+                        {"reason": _("Please use an email with domain: %(domain)s")
+                         % {"domain": settings.SOCIAL_AUTH_EMAIL_DOMAIN}},
+                        status=403,
                     )
                 )
 

--- a/web/web/allauth_adapters.py
+++ b/web/web/allauth_adapters.py
@@ -1,10 +1,237 @@
+import logging
+import requests
+import threading
+import time
+
 from allauth.account.adapter import DefaultAccountAdapter
+from allauth.core.exceptions import ImmediateHttpResponse
 from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
-from allauth.account.signals import email_confirmed, user_signed_up
+from allauth.account.signals import email_confirmed, user_logged_in, user_signed_up
 from django import forms
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.dispatch import receiver
+from django.shortcuts import render
+
+
+log = logging.getLogger(__name__)
+
+
+# ── OIDC IdP-response cache ──────────────────────────────────────────────────
+# allauth fetches the OIDC discovery document and the JWKS on every login
+# (cached only per-adapter, i.e. per-request) with no timeouts. A transient
+# IdP hiccup or slow response then surfaces as a 500 to the user.
+#
+# This cache makes both fetches:
+#   • process-wide with a 1-hour TTL (5 minutes for JWKS so key rotation is
+#     picked up quickly)
+#   • bounded by 5 s connect / 10 s read timeouts
+#   • served from a stale entry on transient fetch errors instead of crashing
+#   • issuer-validated per RFC 8414 §3 (discovery only)
+#   • double-checked-locked so concurrent cold-start requests still see fresh data
+
+_OIDC_CACHE: dict = {}
+_OIDC_CACHE_LOCK = threading.Lock()
+_DISCOVERY_TTL = 3600
+_JWKS_TTL = 300
+
+
+def _cached_fetch(cache_key: str, url: str, ttl: int, validate=None) -> dict:
+    """Fetch `url` as JSON with a process-wide TTL cache and stale-on-error.
+
+    `validate(doc)` runs once on a freshly-fetched doc and may raise to reject
+    it; on rejection we fall back to the previously cached doc if any.
+    """
+    now = time.monotonic()
+    with _OIDC_CACHE_LOCK:
+        entry = _OIDC_CACHE.get(cache_key)
+        if entry and (now - entry["ts"]) < ttl:
+            return entry["doc"]
+
+    try:
+        resp = requests.get(url, timeout=(5, 10))
+        resp.raise_for_status()
+        doc = resp.json()
+        if validate is not None:
+            validate(doc)
+    except (requests.RequestException, ValueError) as e:
+        if entry is not None:
+            log.warning(
+                "OIDC fetch failed for %s (%s); serving stale cached value",
+                url, e,
+            )
+            return entry["doc"]
+        log.error("OIDC fetch failed for %s with no cached fallback: %s", url, e)
+        raise
+
+    with _OIDC_CACHE_LOCK:
+        existing = _OIDC_CACHE.get(cache_key)
+        if not existing or (time.monotonic() - existing["ts"]) >= ttl:
+            _OIDC_CACHE[cache_key] = {"doc": doc, "ts": time.monotonic()}
+        else:
+            doc = existing["doc"]
+
+    return doc
+
+
+def _get_cached_openid_config(server_url: str) -> dict:
+    def _validate_issuer(doc):
+        expected = server_url.replace("/.well-known/openid-configuration", "").rstrip("/")
+        actual = (doc.get("issuer") or "").rstrip("/")
+        if actual and actual != expected:
+            raise ValueError(
+                f"OIDC discovery issuer mismatch: expected {expected!r}, got {actual!r}"
+            )
+
+    return _cached_fetch(
+        cache_key=f"discovery:{server_url}",
+        url=server_url,
+        ttl=_DISCOVERY_TTL,
+        validate=_validate_issuer,
+    )
+
+
+def _get_cached_jwks(jwks_url: str) -> dict:
+    return _cached_fetch(
+        cache_key=f"jwks:{jwks_url}",
+        url=jwks_url,
+        ttl=_JWKS_TTL,
+    )
+
+
+try:
+    from allauth.socialaccount.providers.openid_connect.views import (
+        OpenIDConnectOAuth2Adapter as _BaseOIDCAdapter,
+    )
+    from allauth.socialaccount.providers.openid_connect.provider import (
+        OpenIDConnectProvider as _BaseOIDCProvider,
+    )
+    from allauth.socialaccount.internal import jwtkit
+
+    class CachedOpenIDConnectOAuth2Adapter(_BaseOIDCAdapter):
+        """Serves the OIDC discovery doc and JWKS from a process-level cache,
+        with bounded timeouts and stale-on-error fallback. Without this an IdP
+        blip produces a 500 on the login flow."""
+
+        @property
+        def openid_config(self):
+            if not hasattr(self, "_openid_config"):
+                self._openid_config = _get_cached_openid_config(
+                    self.get_provider().server_url
+                )
+            return self._openid_config
+
+        def _decode_id_token(self, app, id_token):
+            # Mirror allauth's default but route JWKS through our cache.
+            verify_signature = not self.did_fetch_access_token
+            keys_url = self.openid_config["jwks_uri"]
+            issuer = self.openid_config["issuer"]
+            if not verify_signature:
+                return jwtkit.verify_and_decode(
+                    credential=id_token,
+                    keys_url=keys_url,
+                    issuer=issuer,
+                    audience=app.client_id,
+                    lookup_kid=jwtkit.lookup_kid_jwk,
+                    verify_signature=verify_signature,
+                )
+
+            import jwt as _jwt
+            header = _jwt.get_unverified_header(id_token)
+            kid = header["kid"]
+            alg = header["alg"]
+            keys_data = _get_cached_jwks(keys_url)
+            key = jwtkit.lookup_kid_jwk(keys_data, kid)
+            if key is None:
+                # cache miss on a freshly-rotated kid — force a refresh
+                with _OIDC_CACHE_LOCK:
+                    _OIDC_CACHE.pop(f"jwks:{keys_url}", None)
+                keys_data = _get_cached_jwks(keys_url)
+                key = jwtkit.lookup_kid_jwk(keys_data, kid)
+            if key is None:
+                from allauth.socialaccount.providers.oauth2.client import OAuth2Error
+                raise OAuth2Error(f"Invalid 'kid': '{kid}'")
+            data = _jwt.decode(
+                id_token, key=key, algorithms=[alg],
+                issuer=issuer, audience=app.client_id,
+                leeway=30,
+            )
+            jwtkit.verify_jti(data)
+            return data
+
+    class CachedOpenIDConnectProvider(_BaseOIDCProvider):
+        """OpenID Connect provider using the cached adapter.
+
+        Registered via SOCIALACCOUNT_PROVIDERS["openid_connect"]["provider_class"]
+        in settings.py — the officially-supported allauth override path.
+        """
+        oauth2_adapter_class = CachedOpenIDConnectOAuth2Adapter
+
+        @classmethod
+        def get_package(cls):
+            # allauth derives the URL module from get_package(); must point at
+            # the real openid_connect package so its urls.py is picked up by
+            # build_provider_urlpatterns(), not this module's package ("web").
+            return "allauth.socialaccount.providers.openid_connect"
+
+except ImportError:
+    pass  # openid_connect provider not installed — no-op
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _extract_groups(extra: dict) -> set:
+    """Return the set of IdP group names from token extra data."""
+    oidc_cfg = getattr(settings, "OIDC_CFG", None) or {}
+    claim = oidc_cfg.get("groups_claim") or "groups"
+    raw = extra.get(claim) or []
+    if isinstance(raw, str):
+        raw = [raw]
+    return {g for g in raw if isinstance(g, str)}
+
+
+def _group_set(config_key: str) -> set:
+    """Parse a comma-separated group list from OIDC_CFG into a set."""
+    oidc_cfg = getattr(settings, "OIDC_CFG", None) or {}
+    return {
+        g.strip()
+        for g in (oidc_cfg.get(config_key) or "").split(",")
+        if g.strip()
+    }
+
+
+def _apply_idp_roles_and_email(user, extra: dict) -> bool:
+    """Reconcile a user's email and is_staff/is_superuser against the IdP's
+    claims/groups, mutating `user` in place. Returns True if anything changed
+    (the caller is responsible for saving).
+
+    Role mapping is applied only when admin_groups / superadmin_groups are
+    configured; otherwise roles are left untouched so they can be managed
+    manually in Django. When configured, membership is authoritative — a user
+    removed from the admin group in the IdP is demoted on their next login.
+    """
+    changed = False
+
+    email = extra.get("email") or ""
+    if email and user.email != email:
+        user.email = email
+        changed = True
+
+    admin_groups = _group_set("admin_groups")
+    super_groups = _group_set("superadmin_groups")
+    if admin_groups or super_groups:
+        user_groups = _extract_groups(extra)
+        new_staff = bool(user_groups & (admin_groups | super_groups))
+        new_super = bool(user_groups & super_groups)
+        if user.is_staff != new_staff or user.is_superuser != new_super:
+            user.is_staff = new_staff
+            user.is_superuser = new_super
+            changed = True
+
+    return changed
+
+
+# ── Account adapters ──────────────────────────────────────────────────────────
 
 disposable_domain_list = []
 if hasattr(settings, "DISPOSABLE_DOMAIN_LIST"):
@@ -13,14 +240,11 @@ if hasattr(settings, "DISPOSABLE_DOMAIN_LIST"):
 
 
 class DisposableEmails(DefaultAccountAdapter):
-    # https://fluffycloudsandlines.blog/using-django-allauth-for-google-login-to-any-django-app/
     def clean_email(self, email):
         if email.rsplit("@", 1)[-1] in disposable_domain_list:
             raise forms.ValidationError("Admin banned disposable email services")
-        else:
-            return email
+        return email
 
-    # Enable/disable registration
     def is_open_for_signup(self, request):
         return settings.REGISTRATION_ENABLED
 
@@ -39,23 +263,97 @@ def email_confirmed_(request, email_address, **kwargs):
     user.is_active = not settings.MANUAL_APPROVE
     user.save()
 
+
 class MySocialAccountAdapter(DefaultSocialAccountAdapter):
+
     def pre_social_login(self, request, sociallogin):
-        """
-        Invoked just before a social login is about to proceed.
-        """
-        user_email = sociallogin.account.extra_data.get("email")
+        """Reject IdP accounts whose email domain doesn't match the configured
+        allowlist. Silently skipped when social_auth_email_domain is blank.
+
+        Raises ImmediateHttpResponse — caught by allauth's complete_login
+        wrapper and rendered as a user-facing error page (a bare
+        ValidationError here would bubble up as a 500)."""
+        user_email = sociallogin.account.extra_data.get("email") or ""
         if user_email and settings.SOCIAL_AUTH_EMAIL_DOMAIN:
-            domain = user_email.split("@")[1]
+            domain = user_email.rsplit("@", 1)[-1]
             if domain != settings.SOCIAL_AUTH_EMAIL_DOMAIN:
-                raise forms.ValidationError(f"Please use email with domain: {settings.SOCIAL_AUTH_EMAIL_DOMAIN}")
+                raise ImmediateHttpResponse(
+                    render(
+                        request,
+                        "socialaccount/authentication_error.html",
+                        {"reason": (
+                            f"Please use an email with domain: "
+                            f"{settings.SOCIAL_AUTH_EMAIL_DOMAIN}"
+                        )},
+                    )
+                )
+
+    def is_open_for_signup(self, request, sociallogin):
+        """Gate account provisioning on IdP group membership.
+
+        When required_groups is blank, any IdP-authenticated user gets a CAPE
+        account (appropriate when the Okta app assignment is the access gate).
+        When set, only users in at least one listed group are provisioned —
+        useful when the app is assigned broadly but CAPE access should be
+        restricted to a subset.
+        """
+        required = _group_set("required_groups")
+        if not required:
+            return True
+        return bool(_extract_groups(sociallogin.account.extra_data or {}) & required)
 
     def save_user(self, request, sociallogin, form=None):
+        """Provision a new SSO user: derive a stable username and apply the
+        initial email + IdP-group roles.
+
+        This runs once, when the social identity is first linked. Email and
+        role reconciliation on *subsequent* logins is handled by the
+        ``_reconcile_sso_user_on_login`` receiver below — allauth does not call
+        save_user for returning users — so changes to a user's IdP group
+        membership (e.g. removal from an admin group) take effect on their next
+        sign-in.
+
+        Username: derived from the email local-part. If that collides with an
+        existing account (two identities sharing a local-part across different
+        domains), a short suffix from the IdP subject claim — or the user's pk
+        if no subject is present — is appended to guarantee uniqueness.
         """
-        Saves a new User instance using information provided from social account provider.
-        """
-        user = super(MySocialAccountAdapter, self).save_user(request, sociallogin, form)
-        user.email = sociallogin.account.extra_data.get("email")
-        user.username = sociallogin.account.extra_data.get("email").split("@")[0]
+        user = super().save_user(request, sociallogin, form)
+        extra = sociallogin.account.extra_data or {}
+
+        # ── username (provisioning only — kept stable across later logins) ──
+        identifier = (
+            extra.get("email")
+            or extra.get("preferred_username")
+            or extra.get("sub")
+            or user.username
+            or ""
+        )
+        if identifier:
+            base = identifier.split("@")[0] if "@" in identifier else identifier
+            if User.objects.filter(username=base).exclude(pk=user.pk).exists():
+                suffix = (extra.get("sub") or "")[:8] or str(user.pk)
+                base = f"{base}_{suffix}"
+            user.username = base[:150]
+
+        _apply_idp_roles_and_email(user, extra)
         user.save()
         return user
+
+
+@receiver(user_logged_in)
+def _reconcile_sso_user_on_login(sender, request, user, **kwargs):
+    """Reconcile email + IdP-group roles on every SSO login.
+
+    allauth fires ``user_logged_in`` after a successful login and, for social
+    logins, passes the ``sociallogin``. Because ``save_user`` only runs at first
+    provisioning, this receiver is what makes role demotion/promotion and email
+    changes actually propagate when a returning user's IdP attributes change.
+    Local (non-SSO) logins carry no ``sociallogin`` and are left untouched.
+    """
+    sociallogin = kwargs.get("sociallogin")
+    if sociallogin is None:
+        return
+    extra = getattr(sociallogin.account, "extra_data", None) or {}
+    if _apply_idp_roles_and_email(user, extra):
+        user.save()

--- a/web/web/allauth_adapters.py
+++ b/web/web/allauth_adapters.py
@@ -55,12 +55,17 @@ def _cached_fetch(cache_key: str, url: str, ttl: int, validate=None) -> dict:
         if validate is not None:
             validate(doc)
     except (requests.RequestException, ValueError) as e:
-        if entry is not None:
+        # Re-read under the lock: another thread may have populated the cache
+        # while our fetch was in flight (concurrent cold start). Prefer any
+        # cached value — stale or freshly-won — over failing the login.
+        with _OIDC_CACHE_LOCK:
+            latest = _OIDC_CACHE.get(cache_key)
+        if latest is not None:
             log.warning(
-                "OIDC fetch failed for %s (%s); serving stale cached value",
+                "OIDC fetch failed for %s (%s); serving cached value",
                 url, e,
             )
-            return entry["doc"]
+            return latest["doc"]
         log.error("OIDC fetch failed for %s with no cached fallback: %s", url, e)
         raise
 
@@ -187,6 +192,10 @@ def _extract_groups(extra: dict) -> set:
     raw = extra.get(claim) or []
     if isinstance(raw, str):
         raw = [raw]
+    elif not isinstance(raw, (list, tuple, set)):
+        # Unexpected claim shape (int/bool/dict/…) — don't crash the login.
+        log.warning("OIDC groups claim %r has unexpected type %s; ignoring", claim, type(raw).__name__)
+        return set()
     return {g for g in raw if isinstance(g, str)}
 
 
@@ -209,6 +218,11 @@ def _apply_idp_roles_and_email(user, extra: dict) -> bool:
     configured; otherwise roles are left untouched so they can be managed
     manually in Django. When configured, membership is authoritative — a user
     removed from the admin group in the IdP is demoted on their next login.
+
+    Guard: if the groups claim is entirely *absent* from the token (scope or
+    claim-mapping misconfiguration, or a provider that drops it), role
+    reconciliation is skipped rather than silently demoting everyone. A present
+    but empty claim is honoured (the user really is in no groups → demote).
     """
     changed = False
 
@@ -220,13 +234,21 @@ def _apply_idp_roles_and_email(user, extra: dict) -> bool:
     admin_groups = _group_set("admin_groups")
     super_groups = _group_set("superadmin_groups")
     if admin_groups or super_groups:
-        user_groups = _extract_groups(extra)
-        new_staff = bool(user_groups & (admin_groups | super_groups))
-        new_super = bool(user_groups & super_groups)
-        if user.is_staff != new_staff or user.is_superuser != new_super:
-            user.is_staff = new_staff
-            user.is_superuser = new_super
-            changed = True
+        oidc_cfg = getattr(settings, "OIDC_CFG", None) or {}
+        claim = oidc_cfg.get("groups_claim") or "groups"
+        if claim not in extra:
+            log.warning(
+                "OIDC groups claim %r absent from token for %s; skipping role reconciliation",
+                claim, user.username,
+            )
+        else:
+            user_groups = _extract_groups(extra)
+            new_staff = bool(user_groups & (admin_groups | super_groups))
+            new_super = bool(user_groups & super_groups)
+            if user.is_staff != new_staff or user.is_superuser != new_super:
+                user.is_staff = new_staff
+                user.is_superuser = new_super
+                changed = True
 
     return changed
 
@@ -274,7 +296,17 @@ class MySocialAccountAdapter(DefaultSocialAccountAdapter):
         wrapper and rendered as a user-facing error page (a bare
         ValidationError here would bubble up as a 500)."""
         user_email = sociallogin.account.extra_data.get("email") or ""
-        if user_email and settings.SOCIAL_AUTH_EMAIL_DOMAIN:
+        if settings.SOCIAL_AUTH_EMAIL_DOMAIN:
+            if not user_email:
+                # Fail closed: a domain allowlist is configured but the IdP sent
+                # no email, so we can't verify the domain. Don't provision.
+                raise ImmediateHttpResponse(
+                    render(
+                        request,
+                        "socialaccount/authentication_error.html",
+                        {"reason": "An email address is required to sign in."},
+                    )
+                )
             domain = user_email.rsplit("@", 1)[-1]
             if domain != settings.SOCIAL_AUTH_EMAIL_DOMAIN:
                 raise ImmediateHttpResponse(
@@ -330,11 +362,13 @@ class MySocialAccountAdapter(DefaultSocialAccountAdapter):
             or ""
         )
         if identifier:
-            base = identifier.split("@")[0] if "@" in identifier else identifier
+            base = (identifier.split("@")[0] if "@" in identifier else identifier)[:150]
             if User.objects.filter(username=base).exclude(pk=user.pk).exists():
-                suffix = (extra.get("sub") or "")[:8] or str(user.pk)
-                base = f"{base}_{suffix}"
-            user.username = base[:150]
+                # Reserve room for the suffix so truncation can't drop the bit
+                # that makes the name unique (and can't exceed the 150 limit).
+                suffix = "_" + ((extra.get("sub") or "")[:8] or str(user.pk))
+                base = base[: 150 - len(suffix)] + suffix
+            user.username = base
 
         _apply_idp_roles_and_email(user, extra)
         user.save()

--- a/web/web/local_settings.py
+++ b/web/web/local_settings.py
@@ -38,20 +38,13 @@ ALLOWED_HOSTS = ["*"]
 # STATIC_ROOT = ""
 # STATIC_ROOT = os.path.join(os.getcwd(), "static")
 
-SOCIALACCOUNT_PROVIDERS = {
-    "google": {
-        "SCOPE": [
-            "profile",
-            "email",
-        ],
-        "AUTH_PARAMS": {
-            "access_type": "online",
-        },
-    },
-    "github": {
-        "SCOPE": [
-            "read:user",
-            "user:email",
-        ],
-    },
-}
+# SOCIALACCOUNT_PROVIDERS removed: managed dynamically from web.conf [oauth_oidc] in settings.py.
+# The previous stub here (google + github) was dead — the provider apps were commented out in INSTALLED_APPS.
+
+# Session lifetime: 8 hours absolute, slides on every request.
+# Combined with django-allauth + Okta SSO, this forces a fresh Okta round-trip
+# at most every 8h of activity (re-uses the existing Okta session if still
+# valid, prompts otherwise). Helps cap the gap between Okta account
+# disable/lockout and CAPE access being revoked.
+SESSION_COOKIE_AGE = 28800
+SESSION_SAVE_EVERY_REQUEST = True

--- a/web/web/local_settings.py
+++ b/web/web/local_settings.py
@@ -41,10 +41,11 @@ ALLOWED_HOSTS = ["*"]
 # SOCIALACCOUNT_PROVIDERS removed: managed dynamically from web.conf [oauth_oidc] in settings.py.
 # The previous stub here (google + github) was dead — the provider apps were commented out in INSTALLED_APPS.
 
-# Session lifetime: 8 hours absolute, slides on every request.
-# Combined with django-allauth + Okta SSO, this forces a fresh Okta round-trip
-# at most every 8h of activity (re-uses the existing Okta session if still
-# valid, prompts otherwise). Helps cap the gap between Okta account
-# disable/lockout and CAPE access being revoked.
+# Session lifetime: 8-hour sliding idle timeout. SESSION_SAVE_EVERY_REQUEST
+# resets the SESSION_COOKIE_AGE window on each request, so the session expires
+# only after 8h of *inactivity* (not 8h absolute). Combined with django-allauth
+# + Okta SSO, an idle user is forced back through Okta, capping the gap between
+# an Okta account disable/lockout and CAPE access being revoked. Note: saving
+# the session every request adds session-store writes; fine for this scale.
 SESSION_COOKIE_AGE = 28800
 SESSION_SAVE_EVERY_REQUEST = True

--- a/web/web/settings.py
+++ b/web/web/settings.py
@@ -276,8 +276,9 @@ INSTALLED_APPS = [
     "rest_framework.authtoken",
     # Per-user labeled API keys (multi-key, individually revocable). Lives
     # alongside DRF's legacy `authtoken` so ApiKeyAuthentication can fall
-    # back to existing tokens for back-compat.
-    "apikey",
+    # back to existing tokens for back-compat. Reference the AppConfig
+    # explicitly so its ready() (disable-cascade signal wiring) always loads.
+    "apikey.apps.ApiKeyConfig",
 ]
 
 # OpenID Connect (Okta / Azure AD / Auth0 / Google Workspace / Keycloak /
@@ -292,22 +293,23 @@ if OIDC_CFG is not None and OIDC_CFG.get("enabled", False):
             f"[oauth_oidc] enabled = yes but required fields are blank: {', '.join(_missing)}. Check conf/web.conf."
         )
     INSTALLED_APPS.append("allauth.socialaccount.providers.openid_connect")
-    SOCIALACCOUNT_PROVIDERS = {
-        "openid_connect": {
-            # Use our subclass for process-level discovery-doc / JWKS caching.
-            "provider_class": "web.allauth_adapters.CachedOpenIDConnectProvider",
-            "APPS": [
-                {
-                    "provider_id": OIDC_CFG.get("provider_id", "oidc"),
-                    "name": OIDC_CFG.get("name", "OIDC"),
-                    "client_id": OIDC_CFG.get("client_id", ""),
-                    "secret": OIDC_CFG.get("client_secret", ""),
-                    "settings": {
-                        "server_url": OIDC_CFG.get("server_url", ""),
-                    },
-                }
-            ],
-        }
+    # Merge into any existing provider config instead of reassigning, so
+    # enabling OIDC doesn't clobber other providers a deployment may have set.
+    SOCIALACCOUNT_PROVIDERS = globals().get("SOCIALACCOUNT_PROVIDERS") or {}
+    SOCIALACCOUNT_PROVIDERS["openid_connect"] = {
+        # Use our subclass for process-level discovery-doc / JWKS caching.
+        "provider_class": "web.allauth_adapters.CachedOpenIDConnectProvider",
+        "APPS": [
+            {
+                "provider_id": OIDC_CFG.get("provider_id", "oidc"),
+                "name": OIDC_CFG.get("name", "OIDC"),
+                "client_id": OIDC_CFG.get("client_id", ""),
+                "secret": OIDC_CFG.get("client_secret", ""),
+                "settings": {
+                    "server_url": OIDC_CFG.get("server_url", ""),
+                },
+            }
+        ],
     }
 
 AUDIT_FRAMEWORK = web_cfg.audit_framework.get("enabled", False)
@@ -471,8 +473,13 @@ ALLOWED_HOSTS = ["*"]
 # original request was HTTPS — otherwise request.is_secure() is False and the
 # absolute OIDC redirect_uri django-allauth builds comes out as http://…, which
 # the IdP rejects. Requires `proxy_set_header X-Forwarded-Proto $scheme;` in nginx.
-SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
-USE_X_FORWARDED_HOST = True
+#
+# Gated behind [general] behind_proxy because trusting X-Forwarded-Proto/Host is
+# only safe when a reverse proxy strips/overwrites those headers from clients —
+# enabling them with a directly-reachable app would allow proto/host spoofing.
+if web_cfg.general.get("behind_proxy", False):
+    SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+    USE_X_FORWARDED_HOST = True
 
 # Max size
 MAX_UPLOAD_SIZE = web_cfg.general.max_sample_size

--- a/web/web/settings.py
+++ b/web/web/settings.py
@@ -17,6 +17,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 
 RUNNING_TESTS = "test" in sys.argv
 
+from django.core.exceptions import ImproperlyConfigured
 from lib.cuckoo.common.config import Config
 
 # In case we have VPNs enabled we need to initialize through the following
@@ -279,17 +280,58 @@ INSTALLED_APPS = [
     "apikey",
 ]
 
+# OpenID Connect (Okta / Azure AD / Auth0 / Google Workspace / Keycloak /
+# any OIDC-compliant IdP) is wired through django-allauth's generic
+# `openid_connect` provider — registered conditionally so the dependency
+# stays inert when SSO is disabled. Configure via [oauth_oidc] in web.conf.
+OIDC_CFG = getattr(web_cfg, "oauth_oidc", None)
+if OIDC_CFG is not None and OIDC_CFG.get("enabled", False):
+    _missing = [k for k in ("client_id", "client_secret", "server_url") if not (OIDC_CFG.get(k) or "").strip()]
+    if _missing:
+        raise ImproperlyConfigured(
+            f"[oauth_oidc] enabled = yes but required fields are blank: {', '.join(_missing)}. Check conf/web.conf."
+        )
+    INSTALLED_APPS.append("allauth.socialaccount.providers.openid_connect")
+    SOCIALACCOUNT_PROVIDERS = {
+        "openid_connect": {
+            # Use our subclass for process-level discovery-doc / JWKS caching.
+            "provider_class": "web.allauth_adapters.CachedOpenIDConnectProvider",
+            "APPS": [
+                {
+                    "provider_id": OIDC_CFG.get("provider_id", "oidc"),
+                    "name": OIDC_CFG.get("name", "OIDC"),
+                    "client_id": OIDC_CFG.get("client_id", ""),
+                    "secret": OIDC_CFG.get("client_secret", ""),
+                    "settings": {
+                        "server_url": OIDC_CFG.get("server_url", ""),
+                    },
+                }
+            ],
+        }
+    }
+
 AUDIT_FRAMEWORK = web_cfg.audit_framework.get("enabled", False)
 
 if api_cfg.api.token_auth_enabled:
+    # Per-user labeled API keys; ApiKeyAuthentication internally falls back to
+    # DRF's legacy TokenAuthentication so tokens issued via
+    # /apiv2/api-token-auth/ keep working without migration.
+    #
+    # When SSO is enabled, scripts targeting /apiv2/ MUST present an explicit
+    # API key (Authorization: Token <key>) — we drop SessionAuthentication from
+    # the default chain so a browser session cookie issued via the IdP can't
+    # authenticate API calls. Browser-only flows (apikey list/create pages, etc.)
+    # live outside DRF and continue to use Django session auth. Specific
+    # UI-internal endpoints that legitimately need cookie auth can opt back in
+    # per-view with @authentication_classes([SessionAuthentication]).
+    _api_auth_classes = ["apikey.authentication.ApiKeyAuthentication"]
+    if not (OIDC_CFG and OIDC_CFG.get("enabled", False)):
+        # No SSO configured — keep the legacy session-cookie fallback for
+        # back-compat with deployments that script against /apiv2/ using
+        # their browser cookies.
+        _api_auth_classes.append("rest_framework.authentication.SessionAuthentication")
     REST_FRAMEWORK = {
-        "DEFAULT_AUTHENTICATION_CLASSES": [
-            # Per-user labeled API keys; internally falls back to DRF's legacy
-            # TokenAuthentication so tokens issued via /apiv2/api-token-auth/
-            # keep working without migration.
-            "apikey.authentication.ApiKeyAuthentication",
-            "rest_framework.authentication.SessionAuthentication",
-        ],
+        "DEFAULT_AUTHENTICATION_CLASSES": _api_auth_classes,
         "DEFAULT_PERMISSION_CLASSES": ("rest_framework.permissions.IsAuthenticated",),
         "DEFAULT_THROTTLE_CLASSES": ["apiv2.throttling.SubscriptionRateThrottle"],
         "DEFAULT_THROTTLE_RATES": {
@@ -366,13 +408,18 @@ REGISTRATION_ENABLED = web_cfg.registration.get("enabled", False)
 EMAIL_CONFIRMATION = web_cfg.registration.get("email_confirmation", False)
 SOCIAL_AUTH_EMAIL_DOMAIN = web_cfg.web_auth.get("social_auth_email_domain", False)
 
-# be careful with SOCIALACCOUNT_AUTO_SIGNUP, if True, it will bypass custom sighup functions, default is True
-# SOCIALACCOUNT_AUTO_SIGNUP = True
+# Activate the social adapter so OIDC signups bypass the REGISTRATION_ENABLED
+# toggle (the public-signup form gate). Users coming through the IdP have
+# already been vetted and explicitly assigned to the app, so they shouldn't be
+# blocked by the same flag that closes anonymous signup. The adapter also
+# enforces the email-domain allowlist and IdP-group role mapping.
+SOCIALACCOUNT_ADAPTER = "web.allauth_adapters.MySocialAccountAdapter"
+SOCIALACCOUNT_AUTO_SIGNUP = True
+# Send the user straight to the IdP when they click the SSO button, skipping
+# allauth's intermediate confirmation page. (Login is initiated via GET.)
+SOCIALACCOUNT_LOGIN_ON_GET = True
 # SOCIALACCOUNT_ONLY = True
-# SOCIALACCOUNT_LOGIN_ON_GET=True
 # ACCOUNT_SIGNUP_FORM_CLASS = None
-# In case you want to verify domain of email + set the username
-# SOCIALACCOUNT_ADAPTER = 'web.allauth_adapters.MySocialAccountAdapter'
 # ACCOUNT_DEFAULT_HTTP_PROTOCOL = "https"
 
 #### AllAuth end
@@ -418,6 +465,14 @@ SILENCED_SYSTEM_CHECKS = [
 ]
 
 ALLOWED_HOSTS = ["*"]
+
+# Reverse-proxy TLS termination: when nginx terminates HTTPS and forwards plain
+# HTTP to gunicorn/daphne, Django must be told via X-Forwarded-Proto that the
+# original request was HTTPS — otherwise request.is_secure() is False and the
+# absolute OIDC redirect_uri django-allauth builds comes out as http://…, which
+# the IdP rejects. Requires `proxy_set_header X-Forwarded-Proto $scheme;` in nginx.
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+USE_X_FORWARDED_HOST = True
 
 # Max size
 MAX_UPLOAD_SIZE = web_cfg.general.max_sample_size


### PR DESCRIPTION
## Generic OIDC SSO via django-allauth (Okta / Azure AD / Auth0 / Keycloak / any OIDC IdP)

Builds on the per-user API keys merged in #3053. Rebased onto `master`, so this is now a clean SSO-only diff (~11 files). With SSO on, DRF drops `SessionAuthentication`, so scripts must present an explicit API key (the mechanism added in #3053) — an IdP-issued browser cookie can't authenticate API calls.

Adds optional OpenID Connect single sign-on, wired through allauth's generic `openid_connect` provider so it works with any OIDC-compliant IdP. **Disabled by default**; enable and configure via a new `[oauth_oidc]` section in `web.conf`.

### What's included
- **`CachedOpenIDConnect{Provider,OAuth2Adapter}`** — serves the OIDC discovery doc and JWKS from a process-wide TTL cache with bounded timeouts, issuer validation (RFC 8414), and stale-on-error fallback (re-checked under lock on fetch error), so a transient IdP blip no longer 500s the login flow.
- **`MySocialAccountAdapter`** — email-domain allowlist (enforced every login, fails closed if a domain is set but no email is provided) and optional IdP-group → role mapping. `is_staff`/`is_superuser` are reconciled on **every** login via a `user_logged_in` receiver (allauth only calls `save_user` at first provisioning); a user removed from the admin group is demoted on next sign-in. Role reconciliation is skipped if the groups claim is entirely absent (misconfig safety). Usernames are derived once and kept stable.
- **`okta_user_sync`** management command (systemd timer) — deactivates local users no longer `ACTIVE` in Okta and cascade-revokes their API keys, bounding the disable→revoke gap. Configured via `admin_api_url` / `admin_api_token`.
- **`SECURE_PROXY_SSL_HEADER` + `USE_X_FORWARDED_HOST`** so the OIDC `redirect_uri` is built as `https://` behind an nginx TLS-terminating proxy.
- 8h sliding session lifetime; redesigned account/socialaccount templates with an SSO sign-in button.

### Config (`web.conf`)
```ini
[oauth_oidc]
enabled = yes
provider_id = oidc
name = SSO
client_id = ...
client_secret = ...
server_url = https://<domain>/oauth2/default   # .well-known appended automatically
admin_groups =        # -> is_staff
superadmin_groups =   # -> is_superuser
required_groups =     # gate provisioning (blank = any IdP user)
```

### Reviewer notes
- UI-internal `/apiv2/` endpoints fetched with a browser cookie need a per-view `@authentication_classes([SessionAuthentication])` once SSO is on; none are added here since which endpoints matter is deployment-specific.
- Low-severity follow-ups: `_decode_id_token` is reimplemented to route JWKS through the cache (mirrors allauth's `jwtkit`; will want re-checking on allauth upgrades), and the cache uses `requests` directly rather than allauth's `get_requests_session()`.
- Deployed and exercised on a test instance; a final live-IdP login + group-change-demotion pass is the last thing before this leaves draft.
