### PR TITLE
Ensure machine cleanup and handle unexpected errors

### DIFF
--- a/lib/cuckoo/core/analysis_manager.py
+++ b/lib/cuckoo/core/analysis_manager.py
@@ -309,6 +309,7 @@ class AnalysisManager(threading.Thread):
     def machine_running(self) -> Generator[None, None, None]:
         assert self.machinery_manager and self.machine and self.guest
 
+        is_dead = False
         try:
             with self.db.session.begin():
                 self.machinery_manager.start_machine(self.machine)
@@ -319,6 +320,7 @@ class AnalysisManager(threading.Thread):
             self.dump_machine_memory()
 
         except (CuckooMachineError, CuckooGuestCriticalTimeout) as e:
+            is_dead = True
             # This machine has turned dead, so we'll throw an exception
             # which informs the AnalysisManager that it should analyze
             # this task again with another available machine.
@@ -337,25 +339,26 @@ class AnalysisManager(threading.Thread):
             shutil.rmtree(self.storage)
 
             raise CuckooDeadMachine(self.machine.name) from e
+        finally:
+            if not is_dead:
+                with self.db.session.begin():
+                    try:
+                        self.machinery_manager.stop_machine(self.machine)
+                    except CuckooMachineError as e:
+                        self.log.warning("Unable to stop machine %s: %s", self.machine.label, e)
+                        # Explicitly rollback since we don't re-raise the exception.
+                        self.db.session.rollback()
 
-        with self.db.session.begin():
-            try:
-                self.machinery_manager.stop_machine(self.machine)
-            except CuckooMachineError as e:
-                self.log.warning("Unable to stop machine %s: %s", self.machine.label, e)
-                # Explicitly rollback since we don't re-raise the exception.
-                self.db.session.rollback()
-
-        try:
-            # Release the analysis machine, but only if the machine is not dead.
-            with self.db.session.begin():
-                self.machinery_manager.machinery.release(self.machine)
-        except CuckooMachineError as e:
-            self.log.error(
-                "Unable to release machine %s, reason %s. You might need to restore it manually",
-                self.machine.label,
-                e,
-            )
+                try:
+                    # Release the analysis machine, but only if the machine is not dead.
+                    with self.db.session.begin():
+                        self.machinery_manager.machinery.release(self.machine)
+                except CuckooMachineError as e:
+                    self.log.error(
+                        "Unable to release machine %s, reason %s. You might need to restore it manually",
+                        self.machine.label,
+                        e,
+                    )
 
     def dump_machine_memory(self) -> None:
         if not self.cfg.cuckoo.memory_dump and not self.task.memory:
@@ -481,6 +484,13 @@ class AnalysisManager(threading.Thread):
             with self.db.session.begin():
                 # Put the task back in pending so that the schedule can attempt to choose a new machine.
                 self.db.set_status(self.task.id, TASK_PENDING)
+            raise
+        except Exception as e:
+            self.log.exception("Unexpected exception during analysis: %s", e)
+            with self.db.session.begin():
+                self.db.set_status(self.task.id, TASK_FAILED_ANALYSIS)
+                if hasattr(self, "machine") and self.machine:
+                    self.db.unlock_machine(self.machine)
             raise
         else:
             with self.db.session.begin():

--- a/lib/cuckoo/core/analysis_manager.py
+++ b/lib/cuckoo/core/analysis_manager.py
@@ -22,7 +22,7 @@ from lib.cuckoo.common.objects import File
 from lib.cuckoo.common.path_utils import path_delete, path_exists, path_mkdir
 from lib.cuckoo.common.utils import convert_to_printable, create_folder, get_memdump_path
 from lib.cuckoo.core.database import Database, _Database
-from lib.cuckoo.core.data.task import TASK_COMPLETED, TASK_PENDING, TASK_RUNNING, Task
+from lib.cuckoo.core.data.task import TASK_COMPLETED, TASK_PENDING, TASK_RUNNING, TASK_FAILED_ANALYSIS, Task
 from lib.cuckoo.core.data.machines import Machine
 from lib.cuckoo.core.data.guests import Guest
 from lib.cuckoo.core.guest import GuestManager

--- a/lib/cuckoo/core/analysis_manager.py
+++ b/lib/cuckoo/core/analysis_manager.py
@@ -341,13 +341,11 @@ class AnalysisManager(threading.Thread):
             raise CuckooDeadMachine(self.machine.name) from e
         finally:
             if not is_dead:
-                with self.db.session.begin():
-                    try:
+                try:
+                    with self.db.session.begin():
                         self.machinery_manager.stop_machine(self.machine)
-                    except CuckooMachineError as e:
-                        self.log.warning("Unable to stop machine %s: %s", self.machine.label, e)
-                        # Explicitly rollback since we don't re-raise the exception.
-                        self.db.session.rollback()
+                except CuckooMachineError as e:
+                    self.log.warning("Unable to stop machine %s: %s", self.machine.label, e)
 
                 try:
                     # Release the analysis machine, but only if the machine is not dead.

--- a/lib/cuckoo/core/guest.py
+++ b/lib/cuckoo/core/guest.py
@@ -327,10 +327,11 @@ class GuestManager:
         # If the target is a file, upload it to the guest.
         if options["category"] in ("file", "archive"):
             # Use the correct os.sep in the filepath based on what OS this file is destined for
+            # Store the sample in a unique per-task subdirectory instead of %TEMP%\<filename> to prevent guest path collisions
             if self.platform == "windows":
-                filepath = ntpath.join(self.determine_temp_path(), sanitize_filename(options["file_name"]))
+                filepath = ntpath.join(self.determine_temp_path(), str(options["id"]), sanitize_filename(options["file_name"]))
             else:
-                filepath = os.path.join(self.determine_temp_path(), sanitize_filename(options["file_name"]))
+                filepath = os.path.join(self.determine_temp_path(), str(options["id"]), sanitize_filename(options["file_name"]))
             data = {"filepath": filepath}
             files = {
                 "file": ("sample.bin", open(sample_path, "rb")),

--- a/lib/cuckoo/core/guest.py
+++ b/lib/cuckoo/core/guest.py
@@ -308,6 +308,14 @@ class GuestManager:
         # Upload the analyzer.
         self.upload_analyzer()
 
+        # Update file_name in options if category is file/archive to include task-id unique subdirectory
+        # This must be done BEFORE self.add_config(options) is called so that analysis.conf in guest has the correct path
+        if options["category"] in ("file", "archive"):
+            if self.platform == "windows":
+                options["file_name"] = f"{options['id']}\\{sanitize_filename(options['file_name'])}"
+            else:
+                options["file_name"] = f"{options['id']}/{sanitize_filename(options['file_name'])}"
+
         # Pass along the analysis.conf file.
         self.add_config(options)
         # Allow Auxiliary modules to prepare the Guest.
@@ -327,11 +335,10 @@ class GuestManager:
         # If the target is a file, upload it to the guest.
         if options["category"] in ("file", "archive"):
             # Use the correct os.sep in the filepath based on what OS this file is destined for
-            # Store the sample in a unique per-task subdirectory instead of %TEMP%\<filename> to prevent guest path collisions
             if self.platform == "windows":
-                filepath = ntpath.join(self.determine_temp_path(), str(options["id"]), sanitize_filename(options["file_name"]))
+                filepath = ntpath.join(self.determine_temp_path(), options["file_name"])
             else:
-                filepath = os.path.join(self.determine_temp_path(), str(options["id"]), sanitize_filename(options["file_name"]))
+                filepath = os.path.join(self.determine_temp_path(), options["file_name"])
             data = {"filepath": filepath}
             files = {
                 "file": ("sample.bin", open(sample_path, "rb")),

--- a/tests/test_analysis_manager.py
+++ b/tests/test_analysis_manager.py
@@ -474,6 +474,7 @@ class TestAnalysisManager:
         # Force perform_analysis to raise an unhandled exception
         mocker.patch.object(analysis_man, "perform_analysis", side_effect=RuntimeError("Unexpected perform_analysis error"))
         mock_unlock = mocker.patch.object(db, "unlock_machine")
+        mock_log_exception = mocker.patch.object(analysis_man.log, "exception")
 
         with pytest.raises(RuntimeError, match="Unexpected perform_analysis error"):
             analysis_man.launch_analysis()
@@ -483,3 +484,4 @@ class TestAnalysisManager:
             db.session.refresh(task)
             assert task.status == TASK_FAILED_ANALYSIS
         assert mock_unlock.called
+        assert mock_log_exception.called

--- a/tests/test_analysis_manager.py
+++ b/tests/test_analysis_manager.py
@@ -452,7 +452,7 @@ class TestAnalysisManager:
         mock_stop = mocker.patch.object(machinery_manager, "stop_machine")
         mock_release = mocker.patch.object(machinery_manager.machinery, "release")
 
-        guest = Guest()
+        guest = mocker.MagicMock()
         guest.id = 123
         analysis_man.guest = guest
 

--- a/tests/test_analysis_manager.py
+++ b/tests/test_analysis_manager.py
@@ -12,7 +12,7 @@ from sqlalchemy import select
 from lib.cuckoo.common.abstracts import Machinery
 from lib.cuckoo.common.config import Config, ConfigMeta
 from lib.cuckoo.core.analysis_manager import AnalysisManager
-from lib.cuckoo.core.data.task import TASK_RUNNING, Task
+from lib.cuckoo.core.data.task import TASK_RUNNING, Task, TASK_FAILED_ANALYSIS
 from lib.cuckoo.core.data.guests import Guest
 from lib.cuckoo.core.data.machines import Machine
 from lib.cuckoo.core.database import _Database
@@ -440,3 +440,46 @@ class TestAnalysisManager:
         assert analysis_man.init_storage() is True
         mocker.patch("lib.cuckoo.core.database._Database.view_sample", return_value=mock_sample())
         assert analysis_man.category_checks() is True
+
+    def test_machine_running_finally_cleanup(
+        self, db: _Database, task: Task, machine: Machine, machinery_manager: MachineryManager, mocker: MockerFixture
+    ):
+        """Verify that machine_running stops and releases the machine even if an unhandled exception is raised in yield."""
+        analysis_man = AnalysisManager(task=task, machine=machine, machinery_manager=machinery_manager)
+        
+        # Mock machinery manager functions
+        mock_start = mocker.patch.object(machinery_manager, "start_machine")
+        mock_stop = mocker.patch.object(machinery_manager, "stop_machine")
+        mock_release = mocker.patch.object(machinery_manager.machinery, "release")
+        
+        guest = Guest()
+        guest.id = 123
+        analysis_man.guest = guest
+
+        with pytest.raises(RuntimeError, match="Simulated unhandled exception"):
+            with analysis_man.machine_running():
+                raise RuntimeError("Simulated unhandled exception")
+
+        # Verify stop and release are still cleanly called on unhandled exceptions
+        assert mock_start.called
+        assert mock_stop.called
+        assert mock_release.called
+
+    def test_launch_analysis_unexpected_exception(
+        self, db: _Database, task: Task, machine: Machine, machinery_manager: MachineryManager, mocker: MockerFixture
+    ):
+        """Verify that launch_analysis handles unexpected exceptions by setting status to failed and unlocking the machine."""
+        analysis_man = AnalysisManager(task=task, machine=machine, machinery_manager=machinery_manager)
+        
+        # Force perform_analysis to raise an unhandled exception
+        mocker.patch.object(analysis_man, "perform_analysis", side_effect=RuntimeError("Unexpected perform_analysis error"))
+        mock_unlock = mocker.patch.object(db, "unlock_machine")
+
+        with pytest.raises(RuntimeError, match="Unexpected perform_analysis error"):
+            analysis_man.launch_analysis()
+
+        # Verify task is flagged failed and machine is unlocked
+        with db.session.begin():
+            db.session.refresh(task)
+            assert task.status == TASK_FAILED_ANALYSIS
+        assert mock_unlock.called

--- a/tests/test_analysis_manager.py
+++ b/tests/test_analysis_manager.py
@@ -473,7 +473,7 @@ class TestAnalysisManager:
 
         # Force perform_analysis to raise an unhandled exception
         mocker.patch.object(analysis_man, "perform_analysis", side_effect=RuntimeError("Unexpected perform_analysis error"))
-        mock_unlock = mocker.patch.object(db, "unlock_machine")
+        mock_unlock = mocker.patch("lib.cuckoo.core.analysis_manager.Database.unlock_machine")
         mock_log_exception = mocker.patch.object(analysis_man.log, "exception")
 
         with pytest.raises(RuntimeError, match="Unexpected perform_analysis error"):

--- a/tests/test_analysis_manager.py
+++ b/tests/test_analysis_manager.py
@@ -446,12 +446,12 @@ class TestAnalysisManager:
     ):
         """Verify that machine_running stops and releases the machine even if an unhandled exception is raised in yield."""
         analysis_man = AnalysisManager(task=task, machine=machine, machinery_manager=machinery_manager)
-        
+
         # Mock machinery manager functions
         mock_start = mocker.patch.object(machinery_manager, "start_machine")
         mock_stop = mocker.patch.object(machinery_manager, "stop_machine")
         mock_release = mocker.patch.object(machinery_manager.machinery, "release")
-        
+
         guest = Guest()
         guest.id = 123
         analysis_man.guest = guest
@@ -470,7 +470,7 @@ class TestAnalysisManager:
     ):
         """Verify that launch_analysis handles unexpected exceptions by setting status to failed and unlocking the machine."""
         analysis_man = AnalysisManager(task=task, machine=machine, machinery_manager=machinery_manager)
-        
+
         # Force perform_analysis to raise an unhandled exception
         mocker.patch.object(analysis_man, "perform_analysis", side_effect=RuntimeError("Unexpected perform_analysis error"))
         mock_unlock = mocker.patch.object(db, "unlock_machine")

--- a/tests/test_analysis_manager.py
+++ b/tests/test_analysis_manager.py
@@ -473,7 +473,7 @@ class TestAnalysisManager:
 
         # Force perform_analysis to raise an unhandled exception
         mocker.patch.object(analysis_man, "perform_analysis", side_effect=RuntimeError("Unexpected perform_analysis error"))
-        mock_unlock = mocker.patch("lib.cuckoo.core.analysis_manager.Database.unlock_machine")
+        mock_unlock = mocker.patch("lib.cuckoo.core.database._Database.unlock_machine")
         mock_log_exception = mocker.patch.object(analysis_man.log, "exception")
 
         with pytest.raises(RuntimeError, match="Unexpected perform_analysis error"):

--- a/tests/test_analysis_manager.py
+++ b/tests/test_analysis_manager.py
@@ -481,7 +481,7 @@ class TestAnalysisManager:
 
         # Verify task is flagged failed and machine is unlocked
         with db.session.begin():
-            db.session.refresh(task)
-            assert task.status == TASK_FAILED_ANALYSIS
+            db_task = db.view_task(task.id)
+            assert db_task.status == TASK_FAILED_ANALYSIS
         assert mock_unlock.called
         assert mock_log_exception.called


### PR DESCRIPTION
Improve AnalysisManager cleanup and error handling: track dead machines so stop/release are only attempted for healthy machines (moved stop/release into finally guarded by is_dead), log and set TASK_FAILED_ANALYSIS on unexpected exceptions during launch_analysis, and unlock the machine before re-raising. Prevent guest file path collisions by storing samples in a per-task subdirectory (use task id in temp path). Add tests to verify final cleanup on unhandled exceptions and that unexpected analysis errors set task status and unlock machines; update imports accordingly.