### PR TITLE
network_etw: accept evtx-rs for Sysmon parsing (fix empty process attribution)

### DIFF
--- a/modules/processing/network_etw.py
+++ b/modules/processing/network_etw.py
@@ -453,7 +453,12 @@ class NetworkETW(Processing):
         pid_to_image = {}
         dns_queries = []
         evtx_path = os.path.join(self.analysis_path, "evtx", "evtx.zip")
-        if not HAVE_EVTX or not os.path.exists(evtx_path):
+        # Either parser can read the snapshot; _iter_sysmon_records prefers
+        # evtx-rs and only falls back to python-evtx. Gating solely on
+        # HAVE_EVTX (python-evtx) silently returned empty on images that ship
+        # only evtx-rs, zeroing out the pid->image map and leaving every
+        # network flow without a process name.
+        if not (HAVE_EVTX or HAVE_EVTX_RS) or not os.path.exists(evtx_path):
             return connections, pid_to_image, dns_queries
 
         tmpdir = tempfile.mkdtemp()


### PR DESCRIPTION
### Problem

`NetworkETW._parse_sysmon_evtx()` gates on `HAVE_EVTX` (python-evtx) alone:

```python
evtx_path = os.path.join(self.analysis_path, "evtx", "evtx.zip")
if not HAVE_EVTX or not os.path.exists(evtx_path):
    return connections, pid_to_image, dns_queries
```

But the parser it actually uses — `_iter_sysmon_records()` — **prefers `evtx-rs`** (`from evtx import PyEvtxParser`) and only falls back to python-evtx. On an install that has `evtx-rs` but **not** python-evtx, this guard short-circuits to empty *before opening `evtx.zip`*, even though the EVTX could be parsed fine.

Consequence: the Sysmon EID 1 `pid -> image` map is always empty (`0 pid->image` in the processor log). Kernel-Network ETW connections still get a PID but never resolve a `process_name`, so `network.tcp/udp/hosts` render with blank process attribution — only capemon-attached processes resolve.

### Fix

Gate on `(HAVE_EVTX or HAVE_EVTX_RS)` — either parser can satisfy the requirement. The one-line guard was the only thing forcing python-evtx; the parsing path was already evtx-rs-capable.

### Verification

On an evtx-rs-only host, reprocessing affected analyses:

- `_parse_sysmon_evtx`: **0 → 27** `pid -> image` entries
- network flow attribution went from ~empty to near-complete on a browser URL job (e.g. 20/20 TCP, 23/23 UDP named; hosts gained `processes[]` like `msedge.exe -> example.com`)

Remaining unnamed flows are short-lived browser sandbox children with no Sysmon EID-1 ProcessCreate — orthogonal to this guard. No other module uses the `HAVE_EVTX`-only guard pattern.