### PR TITLE
allauth: read OIDC claims from nested userinfo in extra_data

### DIFF
--- a/web/web/allauth_adapters.py
+++ b/web/web/allauth_adapters.py
@@ -201,8 +201,13 @@ def _claims(extra: dict) -> dict:
     (email, groups, preferred_username, sub) live under ``userinfo``, not at the
     top level. Other providers store the claims flat, so fall back to the dict
     itself when there's no nested ``userinfo``.
+
+    Gated on ``"id_token"`` (which the openid_connect provider always puts at the
+    top level) so the function is idempotent: calling it on already-flattened
+    claims — or on a flat provider's data — returns them unchanged even if they
+    happen to carry their own ``userinfo`` key.
     """
-    if isinstance(extra, dict):
+    if isinstance(extra, dict) and "id_token" in extra:
         ui = extra.get("userinfo")
         if isinstance(ui, dict) and ui:
             return ui
@@ -323,7 +328,7 @@ class MySocialAccountAdapter(DefaultSocialAccountAdapter):
         ValidationError here would bubble up as a 500)."""
         user_email = (
             _claims(sociallogin.account.extra_data or {}).get("email")
-            or getattr(getattr(sociallogin, "user", None), "email", None)
+            or (sociallogin.user.email if sociallogin.user else "")
             or ""
         )
         if settings.SOCIAL_AUTH_EMAIL_DOMAIN:

--- a/web/web/allauth_adapters.py
+++ b/web/web/allauth_adapters.py
@@ -193,8 +193,25 @@ except ImportError:
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
+def _claims(extra: dict) -> dict:
+    """Flatten allauth's OIDC extra_data to the actual claim dict.
+
+    The openid_connect provider stores extra_data as
+    ``{"id_token": <jwt>, "userinfo": {...claims...}}`` — the OIDC claims
+    (email, groups, preferred_username, sub) live under ``userinfo``, not at the
+    top level. Other providers store the claims flat, so fall back to the dict
+    itself when there's no nested ``userinfo``.
+    """
+    if isinstance(extra, dict):
+        ui = extra.get("userinfo")
+        if isinstance(ui, dict) and ui:
+            return ui
+    return extra or {}
+
+
 def _extract_groups(extra: dict) -> set:
     """Return the set of IdP group names from token extra data."""
+    extra = _claims(extra)
     oidc_cfg = getattr(settings, "OIDC_CFG", None) or {}
     claim = oidc_cfg.get("groups_claim") or "groups"
     raw = extra.get(claim) or []
@@ -233,6 +250,7 @@ def _apply_idp_roles_and_email(user, extra: dict) -> bool:
     but empty claim is honoured (the user really is in no groups → demote).
     """
     changed = False
+    extra = _claims(extra)
 
     email = extra.get("email") or ""
     if email and user.email != email:
@@ -303,7 +321,11 @@ class MySocialAccountAdapter(DefaultSocialAccountAdapter):
         Raises ImmediateHttpResponse — caught by allauth's complete_login
         wrapper and rendered as a user-facing error page (a bare
         ValidationError here would bubble up as a 500)."""
-        user_email = sociallogin.account.extra_data.get("email") or ""
+        user_email = (
+            _claims(sociallogin.account.extra_data or {}).get("email")
+            or getattr(getattr(sociallogin, "user", None), "email", None)
+            or ""
+        )
         if settings.SOCIAL_AUTH_EMAIL_DOMAIN:
             if not user_email:
                 # Fail closed: a domain allowlist is configured but the IdP sent
@@ -359,7 +381,7 @@ class MySocialAccountAdapter(DefaultSocialAccountAdapter):
         if no subject is present — is appended to guarantee uniqueness.
         """
         user = super().save_user(request, sociallogin, form)
-        extra = sociallogin.account.extra_data or {}
+        extra = _claims(sociallogin.account.extra_data or {})
 
         # ── username (provisioning only — kept stable across later logins) ──
         identifier = (


### PR DESCRIPTION
### Problem

With the `openid_connect` provider, django-allauth stores `SocialAccount.extra_data` as:

```json
{"id_token": "<jwt>", "userinfo": {"email": "...", "groups": [...], "preferred_username": "...", "sub": "..."}}
```

The OIDC claims live under **`userinfo`**, not at the top level. The adapter reads them flat (`extra_data.get("email")`, `extra.get(groups_claim)`, …), so against a standard OIDC IdP (tested with Keycloak):

- `email` comes back blank → `pre_social_login` raises **403 "An email address is required to sign in."** on the callback,
- the groups claim is empty → no role mapping via `admin_groups` / `superadmin_groups`,
- the username falls back to `sub`.

### Fix

Add a small `_claims()` helper that returns `extra["userinfo"]` when it's a non-empty dict and otherwise falls back to `extra` itself (providers that store claims flat are unaffected), and route the claim-reading paths through it: `_extract_groups`, `_apply_idp_roles_and_email`, `pre_social_login`, and `save_user`. `pre_social_login` additionally falls back to `sociallogin.user.email` so domain validation still works when the email is only populated on the `sociallogin.user`.

`+24/−2`, no behavior change for providers that already store claims flat.

### Testing

Verified end-to-end against Keycloak: before, the SSO callback 403'd with "email required"; after, login completes, email/groups populate, and `admin_groups`/`superadmin_groups` role mapping works.