### PR TITLE
Update guac docs after auth changes

### DIFF
--- a/extra/guac related/nginx-site-config.txt
+++ b/extra/guac related/nginx-site-config.txt
@@ -37,7 +37,7 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 
-    location /guac/ {
+    location ^~ /guac/websocket-tunnel/ {
         proxy_pass http://127.0.0.1:8008;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header Host $host;

--- a/web/web/guac_settings.py
+++ b/web/web/guac_settings.py
@@ -58,7 +58,6 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     "django.contrib.sessions.middleware.SessionMiddleware",
-    "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",

--- a/web/web/guac_settings.py
+++ b/web/web/guac_settings.py
@@ -4,10 +4,10 @@ import sys
 from pathlib import Path
 
 from django.utils.log import DEFAULT_LOGGING
+from lib.cuckoo.common.config import Config
+
 CUCKOO_PATH = os.path.join(Path.cwd(), "..")
 sys.path.append(CUCKOO_PATH)
-
-from lib.cuckoo.common.config import Config
 
 # Build paths inside the project like this: BASE_DIR / "subdir".
 BASE_DIR = Path(__file__).resolve().parent.parent

--- a/web/web/guac_settings.py
+++ b/web/web/guac_settings.py
@@ -39,7 +39,7 @@ DEBUG = True
 
 LOGGING_CONFIG = None
 
-WEB_AUTHENTICATION = getattr(Config("web"), "web_auth", {}).get("enabled", False)
+WEB_AUTHENTICATION = Config("web").web_auth.get("enabled", False)
 
 ALLOWED_HOSTS = [
     "*",

--- a/web/web/guac_settings.py
+++ b/web/web/guac_settings.py
@@ -4,7 +4,6 @@ import sys
 from pathlib import Path
 
 from django.utils.log import DEFAULT_LOGGING
-from lib.cuckoo.common.config import Config
 
 CUCKOO_PATH = os.path.join(Path.cwd(), "..")
 sys.path.append(CUCKOO_PATH)
@@ -38,8 +37,6 @@ except ImportError:
 DEBUG = True
 
 LOGGING_CONFIG = None
-
-WEB_AUTHENTICATION = Config("web").web_auth.get("enabled", False)
 
 ALLOWED_HOSTS = [
     "*",
@@ -182,3 +179,4 @@ if _CapeConfig('web').guacamole.get('enabled', False):
     from lib.cuckoo.core.data.guac_session import GuacSession  # noqa: F401
     from lib.cuckoo.core.data.db_common import Base
     Base.metadata.create_all(_db.engine)
+


### PR DESCRIPTION
The changes made in https://github.com/kevoreilly/CAPEv2/pull/2964 moved most of the guac routing to the main web app. 

These changes update the nginx-site-config.txt documentation to reflected the narrowed scope of the ASGI app (guacamole web socket handling only). 

In addition, it reverts the changes made to guac_settings.py, which aren't required when the nginx routing scope is narrowed.