### PR TITLE
Add Direct VNC Hypervisor Console and VM Lifecycle/Snapshot Management via Guacamole

### DIFF
--- a/conf/default/web.conf.default
+++ b/conf/default/web.conf.default
@@ -237,6 +237,10 @@ enabled = yes
 enabled = no
 
 [guacamole]
+# Show a VNC Console dropdown of VM guests in the navigation bar
+vnc_console_enabled = no
+# Open VNC console sessions in a new tab
+vnc_console_new_tab = yes
 enabled = no
 mode = vnc
 username =

--- a/conf/default/web.conf.default
+++ b/conf/default/web.conf.default
@@ -237,10 +237,6 @@ enabled = yes
 enabled = no
 
 [guacamole]
-# Show a VNC Console dropdown of VM guests in the navigation bar
-vnc_console_enabled = no
-# Open VNC console sessions in a new tab
-vnc_console_new_tab = yes
 enabled = no
 mode = vnc
 username =
@@ -281,6 +277,10 @@ vnc_color_depth = 16
 vnc_cursor = local
 # Audio (enable only if needed, consumes bandwidth)
 enable_audio = no
+# Show a VNC Console dropdown of VM guests in the navigation bar
+vnc_console_enabled = no
+# Open VNC console sessions in a new tab
+vnc_console_new_tab = no
 
 [packages]
 # VM tags may be used to specify on which guest machines a sample should be run

--- a/web/guac/consumers.py
+++ b/web/guac/consumers.py
@@ -64,6 +64,30 @@ def _get_vnc_port(vm_label):
                 pass
 
 
+def _check_vm_running(vm_label):
+    """Check if the VM is running in libvirt. Must be called from sync context."""
+    if not LIBVIRT_AVAILABLE:
+        return False
+
+    conn = None
+    try:
+        conn = libvirt.open(machinery_dsn)
+        if conn:
+            dom = conn.lookupByName(vm_label)
+            if dom:
+                state = dom.state(flags=0)
+                return state and state[0] == 1
+    except Exception as e:
+        logger.error("Error checking VM status for %s: %s", vm_label, e)
+    finally:
+        if conn:
+            try:
+                conn.close()
+            except Exception:
+                pass
+    return False
+
+
 class GuacamoleWebSocketConsumer(AsyncWebsocketConsumer):
     subprotocols = ["guacamole"]
 
@@ -342,23 +366,7 @@ class GuacamoleWebSocketConsumer(AsyncWebsocketConsumer):
                 if self.guac_task_id > 0:
                     break
 
-                is_running = False
-                conn = None
-                try:
-                    conn = await sync_to_async(libvirt.open)(machinery_dsn)
-                    if conn:
-                        dom = conn.lookupByName(self.vm_label)
-                        if dom:
-                            state = dom.state(flags=0)
-                            is_running = state and state[0] == 1
-                except Exception as e:
-                    logger.error("Error checking VM status for %s: %s", self.vm_label, e)
-                finally:
-                    if conn:
-                        try:
-                            conn.close()
-                        except Exception:
-                            pass
+                is_running = await sync_to_async(_check_vm_running)(self.vm_label)
 
                 if not is_running:
                     logger.info("VM %s is no longer running, unlocking and disconnecting", self.vm_label)

--- a/web/guac/consumers.py
+++ b/web/guac/consumers.py
@@ -74,6 +74,7 @@ class GuacamoleWebSocketConsumer(AsyncWebsocketConsumer):
         self.monitor_task = None
         self.guac_token = None
         self.guac_task_id = None
+        self.vm_label = None
         self.is_closing = False
         self.timeout_manager = None
         self.timeout_task = None
@@ -138,7 +139,8 @@ class GuacamoleWebSocketConsumer(AsyncWebsocketConsumer):
 
             self.guac_token = str(token)
             self.guac_task_id = session_data["task_id"]
-            vm_label = session_data["vm_label"]
+            self.vm_label = session_data["vm_label"]
+            vm_label = self.vm_label
 
             vnc_port = None
             if self.guac_task_id > 0:
@@ -296,6 +298,8 @@ class GuacamoleWebSocketConsumer(AsyncWebsocketConsumer):
                 self.task = asyncio.create_task(self.read_guacd())
                 if self.guac_task_id > 0:
                     self.monitor_task = asyncio.create_task(self.monitor_task_status())
+                else:
+                    self.monitor_task = asyncio.create_task(self.monitor_vm_status())
                 if self.timeout_manager and self.timeout_manager.idle_timeout_seconds > 0:
                     self.timeout_task = asyncio.create_task(self.monitor_timeout())
             else:
@@ -329,6 +333,46 @@ class GuacamoleWebSocketConsumer(AsyncWebsocketConsumer):
             pass
         except Exception as e:
             logger.error("Error in task monitor: %s", e)
+
+    async def monitor_vm_status(self):
+        """Periodically check if the VM is still running. If not, release the lock and close."""
+        try:
+            while True:
+                await asyncio.sleep(TASK_POLL_INTERVAL)
+                if self.guac_task_id > 0:
+                    break
+
+                is_running = False
+                conn = None
+                try:
+                    conn = await sync_to_async(libvirt.open)(machinery_dsn)
+                    if conn:
+                        dom = conn.lookupByName(self.vm_label)
+                        if dom:
+                            state = dom.state(flags=0)
+                            is_running = state and state[0] == 1
+                except Exception as e:
+                    logger.error("Error checking VM status for %s: %s", self.vm_label, e)
+                finally:
+                    if conn:
+                        try:
+                            conn.close()
+                        except Exception:
+                            pass
+
+                if not is_running:
+                    logger.info("VM %s is no longer running, unlocking and disconnecting", self.vm_label)
+                    db = Database()
+                    machine = await sync_to_async(db.view_machine_by_label)(self.vm_label)
+                    if machine and machine.locked:
+                        await sync_to_async(db.unlock_machine)(machine)
+                        await sync_to_async(db.session.commit)()
+                    await self._close_websocket()
+                    break
+        except asyncio.CancelledError:
+            pass
+        except Exception as e:
+            logger.error("Error in VM monitor: %s", e)
 
     async def disconnect(self, code):
         """Clean up on WebSocket disconnect."""

--- a/web/guac/consumers.py
+++ b/web/guac/consumers.py
@@ -35,6 +35,7 @@ def _get_vnc_port(vm_label):
     """Look up VNC port for a VM from libvirt. Must be called from sync context."""
     if not LIBVIRT_AVAILABLE:
         return None
+
     conn = None
     try:
         conn = libvirt.open(machinery_dsn)
@@ -139,24 +140,47 @@ class GuacamoleWebSocketConsumer(AsyncWebsocketConsumer):
             self.guac_task_id = session_data["task_id"]
             vm_label = session_data["vm_label"]
 
-            # 3. Verify task can still host an interactive session
-            task = await sync_to_async(db.view_task)(self.guac_task_id)
-            if not task or task.status not in ACTIVE_GUAC_TASK_STATUSES:
-                logger.warning(
-                    "WebSocket rejected: task %s is not active for guac", self.guac_task_id
-                )
-                await self._delete_guac_session()
-                await self.close()
-                return
+            vnc_port = None
+            if self.guac_task_id > 0:
+                # 3. Verify task can still host an interactive session
+                task = await sync_to_async(db.view_task)(self.guac_task_id)
+                if not task or task.status not in ACTIVE_GUAC_TASK_STATUSES:
+                    logger.warning(
+                        "WebSocket rejected: task %s is not active for guac", self.guac_task_id
+                    )
+                    await self._delete_guac_session()
+                    await self.close()
+                    return
 
-            # 4. Look up VNC port server-side from libvirt
-            vnc_port = await sync_to_async(_get_vnc_port)(vm_label)
-            if not vnc_port:
-                logger.warning(
-                    "WebSocket rejected: no VNC port for VM %s", vm_label
-                )
-                await self.close()
-                return
+                # 4. Look up VNC port server-side from libvirt
+                vnc_port = await sync_to_async(_get_vnc_port)(vm_label)
+                if not vnc_port:
+                    logger.warning(
+                        "WebSocket rejected: no VNC port for VM %s", vm_label
+                    )
+                    await self.close()
+                    return
+            else:
+                # Direct VNC connection
+                guest_ip = session_data.get("guest_ip")
+                if not guest_ip:
+                    # Autodiscover port given just the VM name
+                    vnc_port = await sync_to_async(_get_vnc_port)(vm_label)
+                    if not vnc_port:
+                        logger.warning(
+                            "WebSocket rejected: could not autodiscover VNC port for VM %s", vm_label
+                        )
+                        await self.close()
+                        return
+                else:
+                    try:
+                        vnc_port = int(vm_label)
+                    except ValueError:
+                        logger.warning(
+                            "WebSocket rejected: invalid direct VNC port %s", vm_label
+                        )
+                        await self.close()
+                        return
 
             # 5. Parse config
             guacd_hostname = web_cfg.guacamole.guacd_host or "localhost"
@@ -174,22 +198,38 @@ class GuacamoleWebSocketConsumer(AsyncWebsocketConsumer):
             raw_recording = params.get("recording_name", ["task-recording"])[0]
             guacd_recording_name = re.sub(r"[^a-zA-Z0-9_-]", "", raw_recording)
 
-            if "rdp" in guest_protocol:
-                guest_host = session_data.get("guest_ip", vm_label)
-                if not guest_host:
-                    guest_host = vm_label
-                guest_port = int(web_cfg.guacamole.guest_rdp_port) or 3389
-                ignore_cert = (
-                    "true"
-                    if web_cfg.guacamole.ignore_rdp_cert is True
-                    else "false"
-                )
-                extra_args = {
-                    "disable-wallpaper": "true",
-                    "disable-theming": "true",
-                }
+            if self.guac_task_id > 0:
+                if "rdp" in guest_protocol:
+                    guest_host = session_data.get("guest_ip", vm_label)
+                    if not guest_host:
+                        guest_host = vm_label
+                    guest_port = int(web_cfg.guacamole.guest_rdp_port) or 3389
+                    ignore_cert = (
+                        "true"
+                        if web_cfg.guacamole.ignore_rdp_cert is True
+                        else "false"
+                    )
+                    extra_args = {
+                        "disable-wallpaper": "true",
+                        "disable-theming": "true",
+                    }
+                else:
+                    guest_host = web_cfg.guacamole.vnc_host or "localhost"
+                    guest_port = vnc_port
+                    ignore_cert = "false"
+                    vnc_color_depth = str(
+                        getattr(web_cfg.guacamole, "vnc_color_depth", 16)
+                    )
+                    vnc_cursor = getattr(web_cfg.guacamole, "vnc_cursor", "local")
+                    extra_args = {
+                        "color-depth": vnc_color_depth,
+                        "cursor": vnc_cursor,
+                    }
             else:
-                guest_host = web_cfg.guacamole.vnc_host or "localhost"
+                # Direct VNC connection
+                guest_protocol = "vnc"
+                guest_ip = session_data.get("guest_ip")
+                guest_host = guest_ip or web_cfg.guacamole.vnc_host or "localhost"
                 guest_port = vnc_port
                 ignore_cert = "false"
                 vnc_color_depth = str(
@@ -203,6 +243,16 @@ class GuacamoleWebSocketConsumer(AsyncWebsocketConsumer):
 
             # 6. Connect to guacd
             self.client = GuacamoleClient(guacd_hostname, guacd_port)
+
+            logger.info(
+                "Guacamole connecting to guacd at %s:%s. Handshake: protocol=%s, host=%s, port=%s, recording_name=%s",
+                guacd_hostname,
+                guacd_port,
+                guest_protocol,
+                guest_host,
+                guest_port,
+                guacd_recording_name,
+            )
 
             await sync_to_async(self.client.handshake)(
                 protocol=guest_protocol,
@@ -227,21 +277,25 @@ class GuacamoleWebSocketConsumer(AsyncWebsocketConsumer):
                 )
 
                 # 7. Initialize timeout handling
-                try:
-                    vm_ip = session_data.get("guest_ip") or guest_host
-                    self.timeout_manager = SessionTimeoutManager(
-                        vm_ip=vm_ip,
-                        user="unknown_user",
-                        session_id=self.guac_token,
-                        task_id=str(self.guac_task_id),
-                    )
-                except Exception as e:
-                    logger.error("Failed to initialize timeout manager: %s", e)
+                if self.guac_task_id > 0:
+                    try:
+                        vm_ip = session_data.get("guest_ip") or guest_host
+                        self.timeout_manager = SessionTimeoutManager(
+                            vm_ip=vm_ip,
+                            user="unknown_user",
+                            session_id=self.guac_token,
+                            task_id=str(self.guac_task_id),
+                        )
+                    except Exception as e:
+                        logger.error("Failed to initialize timeout manager: %s", e)
+                        self.timeout_manager = None
+                else:
                     self.timeout_manager = None
 
                 # 8. Start background tasks
                 self.task = asyncio.create_task(self.read_guacd())
-                self.monitor_task = asyncio.create_task(self.monitor_task_status())
+                if self.guac_task_id > 0:
+                    self.monitor_task = asyncio.create_task(self.monitor_task_status())
                 if self.timeout_manager and self.timeout_manager.idle_timeout_seconds > 0:
                     self.timeout_task = asyncio.create_task(self.monitor_timeout())
             else:

--- a/web/guac/context_processors.py
+++ b/web/guac/context_processors.py
@@ -1,0 +1,21 @@
+from lib.cuckoo.common.config import Config
+from lib.cuckoo.core.database import Database
+
+web_cfg = Config("web")
+
+
+def guac_vnc_console(request):
+    """Context processor that exposes VNC Console settings and guests to templates."""
+    enabled = web_cfg.guacamole.get("vnc_console_enabled", False)
+    if not enabled:
+        return {"vnc_console_enabled": False}
+
+    db = Database()
+    machines = [machine.label for machine in db.list_machines(include_reserved=True)]
+    new_tab = web_cfg.guacamole.get("vnc_console_new_tab", True)
+
+    return {
+        "vnc_console_enabled": True,
+        "vnc_console_machines": machines,
+        "vnc_console_new_tab": new_tab,
+    }

--- a/web/guac/context_processors.py
+++ b/web/guac/context_processors.py
@@ -7,6 +7,8 @@ web_cfg = Config("web")
 def guac_vnc_console(request):
     """Context processor that exposes VNC Console settings and guests to templates."""
     enabled = web_cfg.guacamole.get("vnc_console_enabled", False)
+    if isinstance(enabled, str):
+        enabled = enabled.lower() in ("yes", "true", "on", "1")
     if not enabled:
         return {"vnc_console_enabled": False}
 

--- a/web/guac/context_processors.py
+++ b/web/guac/context_processors.py
@@ -15,6 +15,8 @@ def guac_vnc_console(request):
     db = Database()
     machines = [machine.label for machine in db.list_machines(include_reserved=True)]
     new_tab = web_cfg.guacamole.get("vnc_console_new_tab", True)
+    if isinstance(new_tab, str):
+        new_tab = new_tab.lower() in ("yes", "true", "on", "1")
 
     return {
         "vnc_console_enabled": True,

--- a/web/guac/routing.py
+++ b/web/guac/routing.py
@@ -4,7 +4,7 @@ from .consumers import GuacamoleWebSocketConsumer
 
 websocket_urlpatterns = [
     re_path(
-        r"^guac/websocket-tunnel/(?P<session_id>\w+)/?$",
+        r"^guac/websocket-tunnel/(?P<session_id>[\w-]+)/?$",
         GuacamoleWebSocketConsumer.as_asgi(),
     ),
 ]

--- a/web/guac/templates/guac/index.html
+++ b/web/guac/templates/guac/index.html
@@ -32,8 +32,22 @@
             </button>
             {% else %}
             <span class="text-secondary small me-1">Direct VNC</span>
-            <span class="text-info small me-auto">{{ vnc_host }}:{{ vnc_port }}</span>
-            <button id="stopTask" class="btn btn-sm btn-outline-danger">
+            <span class="text-info small me-2">{{ vnc_host }}</span>
+            <span class="text-secondary me-2 small">|</span>
+            <span class="text-secondary small me-1">Route:</span>
+            <select id="routeSelect" class="form-select form-select-sm bg-dark text-white border-secondary me-auto" style="width: auto; height: 30px; padding-top: 2px; padding-bottom: 2px; font-size: 12px;">
+                <option value="none" {% if current_route == 'none' %}selected{% endif %}>None (No Internet)</option>
+                {% if internet_configured %}
+                <option value="internet" {% if current_route == 'internet' %}selected{% endif %}>Internet (Dirty Line)</option>
+                {% endif %}
+                {% if tor_enabled %}
+                <option value="tor" {% if current_route == 'tor' %}selected{% endif %}>Tor</option>
+                {% endif %}
+                {% for vpn in vpns %}
+                <option value="{{ vpn.name }}" {% if current_route == vpn.name %}selected{% endif %}>VPN: {{ vpn.description }}</option>
+                {% endfor %}
+            </select>
+            <button id="stopTask" class="btn btn-sm btn-outline-danger ms-3">
                 <i class="fas fa-sign-out-alt me-1"></i>Disconnect
             </button>
             {% endif %}
@@ -129,6 +143,38 @@
             .catch(function(err) {
                 console.error("Error shutting down:", err);
                 window.location.href = "/";
+            });
+        }
+        {% if not task_id or task_id == 0 or task_id == '0' %}
+        var routeSelect = document.getElementById("routeSelect");
+        if (routeSelect) {
+            routeSelect.addEventListener("change", function() {
+                var selectedRoute = routeSelect.value;
+                routeSelect.disabled = true;
+                
+                fetch('/guac/direct/vnc/{{ vnc_host }}/route/', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRFToken': getCsrfToken()
+                    },
+                    body: JSON.stringify({ route: selectedRoute })
+                })
+                .then(response => response.json())
+                .then(data => {
+                    routeSelect.disabled = false;
+                    if (data.status !== 'success') {
+                        alert('Failed to update routing: ' + (data.message || 'Unknown error'));
+                        if (data.current_route) {
+                            routeSelect.value = data.current_route;
+                        }
+                    }
+                })
+                .catch(error => {
+                    console.error('Error changing route:', error);
+                    alert('Error changing route');
+                    routeSelect.disabled = false;
+                });
             });
         }
         {% endif %}

--- a/web/guac/templates/guac/index.html
+++ b/web/guac/templates/guac/index.html
@@ -15,6 +15,7 @@
     <script src="{% static 'js/guacamole-1.6.0-all.min.js' %}"></script>
     <script src="{% static 'js/jquery.js' %}"></script>
     <script src="{% static 'js/jquery-ui.min.js' %}"></script>
+    <script src="{% static 'js/bootstrap.bundle.min.js' %}"></script>
 </head>
 <body class="bg-dark text-white" style="margin:0;padding:0;overflow:hidden;">
     <div class="guaconsole">
@@ -52,6 +53,30 @@
             </div>
         </div>
     </div>
+    {% if started_by_console %}
+    <!-- Disconnect / Shutdown Modal -->
+    <div class="modal fade text-white" id="disconnectModal" tabindex="-1" aria-labelledby="disconnectModalLabel" aria-hidden="true" style="z-index: 2000;">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content bg-dark border-secondary shadow-lg">
+                <div class="modal-header border-secondary">
+                    <h5 class="modal-title" id="disconnectModalLabel"><i class="fas fa-power-off text-danger me-2"></i> Disconnect Session</h5>
+                    <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body text-start">
+                    <p>This virtual machine was started by the VNC Console.</p>
+                    <p class="text-secondary small">Choose how you want to handle the virtual machine upon disconnecting:</p>
+                </div>
+                <div class="modal-footer border-secondary justify-content-between">
+                    <button type="button" id="btnDisconnectOnly" class="btn btn-outline-light btn-sm"><i class="fas fa-sign-out-alt me-1"></i> Keep Running</button>
+                    <div>
+                        <button type="button" id="btnShutdownGraceful" class="btn btn-warning btn-sm"><i class="fas fa-stop me-1"></i> Shutdown</button>
+                        <button type="button" id="btnShutdownForce" class="btn btn-danger btn-sm"><i class="fas fa-bolt me-1"></i> Force Off</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    {% endif %}
     <script>
         {% if task_id and task_id != 0 and task_id != '0' %}
         document.getElementById("stopTask").addEventListener("click", function() {
@@ -59,9 +84,55 @@
         });
         {% else %}
         document.getElementById("stopTask").addEventListener("click", function() {
+            {% if started_by_console %}
+            var disconnectModalEl = document.getElementById('disconnectModal');
+            var myModal = new bootstrap.Modal(disconnectModalEl);
+            myModal.show();
+            {% else %}
             window.location.href = "/";
+            {% endif %}
         });
         {% endif %}
+
+        {% if started_by_console %}
+        document.getElementById("btnDisconnectOnly").addEventListener("click", function() {
+            window.location.href = "/";
+        });
+        document.getElementById("btnShutdownGraceful").addEventListener("click", function() {
+            performShutdown(false);
+        });
+        document.getElementById("btnShutdownForce").addEventListener("click", function() {
+            performShutdown(true);
+        });
+
+        function performShutdown(force) {
+            document.getElementById("btnDisconnectOnly").disabled = true;
+            document.getElementById("btnShutdownGraceful").disabled = true;
+            document.getElementById("btnShutdownForce").disabled = true;
+
+            var url = "/guac/direct/vnc/{{ vnc_host }}/shutdown/";
+            var data = {
+                force: force
+            };
+
+            fetch(url, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRFToken': getCsrfToken()
+                },
+                body: JSON.stringify(data)
+            })
+            .then(function() {
+                window.location.href = "/";
+            })
+            .catch(function(err) {
+                console.error("Error shutting down:", err);
+                window.location.href = "/";
+            });
+        }
+        {% endif %}
+
         GuacMe("html", "{{ session_id }}", "{{ recording_name }}");
     </script>
 </body>

--- a/web/guac/templates/guac/index.html
+++ b/web/guac/templates/guac/index.html
@@ -23,11 +23,19 @@
                 <img src="{% static 'graphic/cape.png' %}" height="28" alt="CAPE Sandbox">
             </a>
             <span class="text-secondary me-2 small">|</span>
+            {% if task_id and task_id != 0 and task_id != '0' %}
             <span class="text-secondary small me-1">Task</span>
             <a href="/submit/status/{{ task_id }}/" class="text-info small me-auto text-decoration-none">#{{ task_id }}</a>
             <button id="stopTask" class="btn btn-sm btn-outline-danger">
                 <i class="fas fa-stop-circle me-1"></i>End Session
             </button>
+            {% else %}
+            <span class="text-secondary small me-1">Direct VNC</span>
+            <span class="text-info small me-auto">{{ vnc_host }}:{{ vnc_port }}</span>
+            <button id="stopTask" class="btn btn-sm btn-outline-danger">
+                <i class="fas fa-sign-out-alt me-1"></i>Disconnect
+            </button>
+            {% endif %}
         </div>
         <div id="container">
             <div id="terminal"></div>
@@ -35,15 +43,25 @@
                 <div style="background:#212529;border:1px solid #495057;border-radius:8px;padding:20px;box-shadow:0 0 30px rgba(0,0,0,0.8);color:#fff;">
                     <h6 id="dialog-heading" class="mb-2" style="color:#fff;">Session Ended</h6>
                     <p id="dialog-message" class="mb-2 small" style="color:#6c757d;"></p>
+                    {% if task_id and task_id != 0 and task_id != '0' %}
                     <a id="taskStatus" href="/submit/status/{{ task_id }}/" class="btn btn-sm btn-outline-light"><i class="fas fa-tasks me-1"></i>View Task</a>
+                    {% else %}
+                    <a id="taskStatus" href="/" class="btn btn-sm btn-outline-light"><i class="fas fa-home me-1"></i>Go Home</a>
+                    {% endif %}
                 </div>
             </div>
         </div>
     </div>
     <script>
+        {% if task_id and task_id != 0 and task_id != '0' %}
         document.getElementById("stopTask").addEventListener("click", function() {
             stopTask("{{ task_id }}");
         });
+        {% else %}
+        document.getElementById("stopTask").addEventListener("click", function() {
+            window.location.href = "/";
+        });
+        {% endif %}
         GuacMe("html", "{{ session_id }}", "{{ recording_name }}");
     </script>
 </body>

--- a/web/guac/templates/guac/index.html
+++ b/web/guac/templates/guac/index.html
@@ -145,6 +145,8 @@
                 window.location.href = "/";
             });
         }
+        {% endif %}
+
         {% if not task_id or task_id == 0 or task_id == '0' %}
         var routeSelect = document.getElementById("routeSelect");
         if (routeSelect) {

--- a/web/guac/templates/guac/index.html
+++ b/web/guac/templates/guac/index.html
@@ -47,6 +47,17 @@
                 <option value="{{ vpn.name }}" {% if current_route == vpn.name %}selected{% endif %}>VPN: {{ vpn.description }}</option>
                 {% endfor %}
             </select>
+            {% if started_by_console %}
+            <div class="dropdown ms-3">
+                <button class="btn btn-sm btn-outline-secondary dropdown-toggle" type="button" id="snapshotMenu" data-bs-toggle="dropdown" aria-expanded="false">
+                    <i class="fas fa-camera me-1"></i>Snapshots
+                </button>
+                <ul class="dropdown-menu dropdown-menu-dark border-secondary shadow" aria-labelledby="snapshotMenu" style="font-size: 12px;">
+                    <li><a class="dropdown-item" href="#" id="takeSnapshotBtn"><i class="fas fa-plus-circle me-2 text-success"></i>Take Snapshot</a></li>
+                    <li><a class="dropdown-item" href="#" id="deleteSnapshotBtn"><i class="fas fa-trash-alt me-2 text-danger"></i>Delete Snapshot</a></li>
+                </ul>
+            </div>
+            {% endif %}
             <button id="stopTask" class="btn btn-sm btn-outline-danger ms-3">
                 <i class="fas fa-sign-out-alt me-1"></i>Disconnect
             </button>
@@ -86,6 +97,59 @@
                         <button type="button" id="btnShutdownGraceful" class="btn btn-warning btn-sm"><i class="fas fa-stop me-1"></i> Shutdown</button>
                         <button type="button" id="btnShutdownForce" class="btn btn-danger btn-sm"><i class="fas fa-bolt me-1"></i> Force Off</button>
                     </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Take Snapshot Modal -->
+    <div class="modal fade text-white" id="takeSnapshotModal" tabindex="-1" aria-labelledby="takeSnapshotModalLabel" aria-hidden="true" style="z-index: 2000;">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content bg-dark border-secondary shadow-lg">
+                <div class="modal-header border-secondary">
+                    <h5 class="modal-title" id="takeSnapshotModalLabel"><i class="fas fa-camera text-success me-2"></i> Take Snapshot</h5>
+                    <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body text-start">
+                    <div class="mb-3">
+                        <label for="newSnapshotName" class="form-label small text-secondary">Snapshot Name</label>
+                        <input type="text" class="form-control form-control-sm bg-dark text-white border-secondary" id="newSnapshotName" placeholder="e.g. baseline_clean" required>
+                    </div>
+                    <div class="mb-3">
+                        <label for="newSnapshotDesc" class="form-label small text-secondary">Description (Optional)</label>
+                        <textarea class="form-control form-control-sm bg-dark text-white border-secondary" id="newSnapshotDesc" rows="2" placeholder="e.g. Installed software baseline"></textarea>
+                    </div>
+                    <div id="takeSnapshotError" class="text-danger small" style="display: none;"></div>
+                </div>
+                <div class="modal-footer border-secondary justify-content-end">
+                    <button type="button" class="btn btn-outline-light btn-sm me-2" data-bs-dismiss="modal">Cancel</button>
+                    <button type="button" id="btnConfirmTakeSnapshot" class="btn btn-success btn-sm"><i class="fas fa-save me-1"></i> Save Snapshot</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Delete Snapshot Modal -->
+    <div class="modal fade text-white" id="deleteSnapshotModal" tabindex="-1" aria-labelledby="deleteSnapshotModalLabel" aria-hidden="true" style="z-index: 2000;">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content bg-dark border-secondary shadow-lg">
+                <div class="modal-header border-secondary">
+                    <h5 class="modal-title" id="deleteSnapshotModalLabel"><i class="fas fa-trash-alt text-danger me-2"></i> Delete Snapshot</h5>
+                    <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body text-start">
+                    <p class="small text-secondary">Select the snapshot you want to permanently delete. If you delete the last/configured snapshot, the VM's fallback in the database will be cleared or updated.</p>
+                    <div class="mb-3">
+                        <label for="deleteSnapshotSelect" class="form-label small text-secondary">Select Snapshot</label>
+                        <select id="deleteSnapshotSelect" class="form-select form-select-sm bg-dark text-white border-secondary">
+                            <!-- Populated dynamically -->
+                        </select>
+                    </div>
+                    <div id="deleteSnapshotError" class="text-danger small" style="display: none;"></div>
+                </div>
+                <div class="modal-footer border-secondary justify-content-end">
+                    <button type="button" class="btn btn-outline-light btn-sm me-2" data-bs-dismiss="modal">Cancel</button>
+                    <button type="button" id="btnConfirmDeleteSnapshot" class="btn btn-danger btn-sm"><i class="fas fa-trash me-1"></i> Delete</button>
                 </div>
             </div>
         </div>
@@ -145,6 +209,146 @@
                 window.location.href = "/";
             });
         }
+
+        // Take Snapshot handlers
+        var takeSnapshotModalEl = document.getElementById('takeSnapshotModal');
+        var takeSnapshotModal = new bootstrap.Modal(takeSnapshotModalEl);
+
+        document.getElementById('takeSnapshotBtn').addEventListener('click', function(e) {
+            e.preventDefault();
+            document.getElementById('newSnapshotName').value = '';
+            document.getElementById('newSnapshotDesc').value = '';
+            document.getElementById('takeSnapshotError').style.display = 'none';
+            takeSnapshotModal.show();
+        });
+
+        document.getElementById('btnConfirmTakeSnapshot').addEventListener('click', function() {
+            var name = document.getElementById('newSnapshotName').value.trim();
+            var desc = document.getElementById('newSnapshotDesc').value.trim();
+            var errDiv = document.getElementById('takeSnapshotError');
+            
+            if (!name) {
+                errDiv.textContent = 'Snapshot name is required.';
+                errDiv.style.display = 'block';
+                return;
+            }
+
+            if (!/^[a-zA-Z0-9_\-]+$/.test(name)) {
+                errDiv.textContent = 'Snapshot name can only contain letters, numbers, underscores, and hyphens.';
+                errDiv.style.display = 'block';
+                return;
+            }
+
+            errDiv.style.display = 'none';
+            document.getElementById('btnConfirmTakeSnapshot').disabled = true;
+
+            fetch("/guac/direct/vnc/{{ vnc_host }}/snapshot/create/", {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRFToken': getCsrfToken()
+                },
+                body: JSON.stringify({ name: name, description: desc })
+            })
+            .then(response => response.json())
+            .then(data => {
+                document.getElementById('btnConfirmTakeSnapshot').disabled = false;
+                if (data.status === 'success') {
+                    takeSnapshotModal.hide();
+                    alert(data.message || 'Snapshot created successfully.');
+                } else {
+                    errDiv.textContent = data.message || 'Failed to create snapshot.';
+                    errDiv.style.display = 'block';
+                }
+            })
+            .catch(error => {
+                document.getElementById('btnConfirmTakeSnapshot').disabled = false;
+                console.error('Error creating snapshot:', error);
+                errDiv.textContent = 'Network or server error occurred.';
+                errDiv.style.display = 'block';
+            });
+        });
+
+        // Delete Snapshot handlers
+        var deleteSnapshotModalEl = document.getElementById('deleteSnapshotModal');
+        var deleteSnapshotModal = new bootstrap.Modal(deleteSnapshotModalEl);
+
+        document.getElementById('deleteSnapshotBtn').addEventListener('click', function(e) {
+            e.preventDefault();
+            var select = document.getElementById('deleteSnapshotSelect');
+            var errDiv = document.getElementById('deleteSnapshotError');
+            errDiv.style.display = 'none';
+            select.innerHTML = '<option value="">Loading snapshots...</option>';
+            document.getElementById('btnConfirmDeleteSnapshot').disabled = true;
+            deleteSnapshotModal.show();
+
+            // Fetch list of snapshots
+            fetch("/guac/direct/vnc/{{ vnc_host }}/snapshots/")
+            .then(response => response.json())
+            .then(data => {
+                select.innerHTML = '';
+                if (data.status === 'success' && data.snapshots && data.snapshots.length > 0) {
+                    data.snapshots.forEach(function(snapName) {
+                        var opt = document.createElement('option');
+                        opt.value = snapName;
+                        opt.textContent = snapName + (snapName === data.default_snapshot ? ' (Configured Default)' : '');
+                        select.appendChild(opt);
+                    });
+                    document.getElementById('btnConfirmDeleteSnapshot').disabled = false;
+                } else {
+                    select.innerHTML = '<option value="">No snapshots found</option>';
+                }
+            })
+            .catch(error => {
+                console.error('Error loading snapshots:', error);
+                select.innerHTML = '<option value="">Error loading snapshots</option>';
+            });
+        });
+
+        document.getElementById('btnConfirmDeleteSnapshot').addEventListener('click', function() {
+            var select = document.getElementById('deleteSnapshotSelect');
+            var name = select.value;
+            var errDiv = document.getElementById('deleteSnapshotError');
+            
+            if (!name) {
+                errDiv.textContent = 'Please select a snapshot to delete.';
+                errDiv.style.display = 'block';
+                return;
+            }
+
+            if (!confirm('Are you sure you want to permanently delete snapshot "' + name + '"?')) {
+                return;
+            }
+
+            errDiv.style.display = 'none';
+            document.getElementById('btnConfirmDeleteSnapshot').disabled = true;
+
+            fetch("/guac/direct/vnc/{{ vnc_host }}/snapshot/delete/", {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRFToken': getCsrfToken()
+                },
+                body: JSON.stringify({ name: name })
+            })
+            .then(response => response.json())
+            .then(data => {
+                document.getElementById('btnConfirmDeleteSnapshot').disabled = false;
+                if (data.status === 'success') {
+                    deleteSnapshotModal.hide();
+                    alert(data.message || 'Snapshot deleted successfully.');
+                } else {
+                    errDiv.textContent = data.message || 'Failed to delete snapshot.';
+                    errDiv.style.display = 'block';
+                }
+            })
+            .catch(error => {
+                document.getElementById('btnConfirmDeleteSnapshot').disabled = false;
+                console.error('Error deleting snapshot:', error);
+                errDiv.textContent = 'Network or server error occurred.';
+                errDiv.style.display = 'block';
+            });
+        });
         {% endif %}
 
         {% if not task_id or task_id == 0 or task_id == '0' %}

--- a/web/guac/templates/guac/index.html
+++ b/web/guac/templates/guac/index.html
@@ -33,6 +33,7 @@
             {% else %}
             <span class="text-secondary small me-1">Direct VNC</span>
             <span class="text-info small me-2">{{ vnc_host }}</span>
+            <span id="runningSnapshotBadgeContainer" class="me-2"></span>
             <span class="text-secondary me-2 small">|</span>
             <span class="text-secondary small me-1">Route:</span>
             <select id="routeSelect" class="form-select form-select-sm bg-dark text-white border-secondary me-auto" style="width: auto; height: 30px; padding-top: 2px; padding-bottom: 2px; font-size: 12px;">
@@ -52,9 +53,12 @@
                 <button class="btn btn-sm btn-outline-secondary dropdown-toggle" type="button" id="snapshotMenu" data-bs-toggle="dropdown" aria-expanded="false">
                     <i class="fas fa-camera me-1"></i>Snapshots
                 </button>
-                <ul class="dropdown-menu dropdown-menu-dark border-secondary shadow" aria-labelledby="snapshotMenu" style="font-size: 12px;">
+                <ul class="dropdown-menu dropdown-menu-dark border-secondary shadow" aria-labelledby="snapshotMenu" style="font-size: 12px; min-width: 220px;">
                     <li><a class="dropdown-item" href="#" id="takeSnapshotBtn"><i class="fas fa-plus-circle me-2 text-success"></i>Take Snapshot</a></li>
                     <li><a class="dropdown-item" href="#" id="deleteSnapshotBtn"><i class="fas fa-trash-alt me-2 text-danger"></i>Delete Snapshot</a></li>
+                    <li><hr class="dropdown-divider border-secondary"></li>
+                    <li class="dropdown-header text-secondary py-1" style="font-size: 10px;">EXISTING SNAPSHOTS</li>
+                    <div id="dropdownSnapshotsList"></div>
                 </ul>
             </div>
             {% endif %}
@@ -256,6 +260,7 @@
                 if (data.status === 'success') {
                     takeSnapshotModal.hide();
                     alert(data.message || 'Snapshot created successfully.');
+                    loadSnapshotsMenu();
                 } else {
                     errDiv.textContent = data.message || 'Failed to create snapshot.';
                     errDiv.style.display = 'block';
@@ -337,6 +342,7 @@
                 if (data.status === 'success') {
                     deleteSnapshotModal.hide();
                     alert(data.message || 'Snapshot deleted successfully.');
+                    loadSnapshotsMenu();
                 } else {
                     errDiv.textContent = data.message || 'Failed to delete snapshot.';
                     errDiv.style.display = 'block';
@@ -349,6 +355,84 @@
                 errDiv.style.display = 'block';
             });
         });
+
+        function updateRunningSnapshotBadge(runningName) {
+            var container = document.getElementById('runningSnapshotBadgeContainer');
+            if (!container) return;
+            if (runningName) {
+                container.innerHTML = '<span class="badge bg-success text-white" style="font-size: 11px;"><i class="fas fa-history me-1"></i>Active: ' + runningName + '</span>';
+            } else {
+                container.innerHTML = '<span class="badge bg-secondary text-white-50" style="font-size: 11px;"><i class="fas fa-history me-1"></i>Active: None</span>';
+            }
+        }
+
+        function loadSnapshotsMenu() {
+            var listContainer = document.getElementById('dropdownSnapshotsList');
+            if (!listContainer) return;
+            
+            listContainer.innerHTML = '<li><span class="dropdown-item-text text-secondary small py-1">Loading...</span></li>';
+
+            fetch("/guac/direct/vnc/{{ vnc_host }}/snapshots/")
+            .then(response => response.json())
+            .then(data => {
+                listContainer.innerHTML = '';
+                if (data.status === 'success') {
+                    updateRunningSnapshotBadge(data.current_snapshot);
+
+                    if (data.snapshots && data.snapshots.length > 0) {
+                        data.snapshots.forEach(function(snapName) {
+                            var li = document.createElement('li');
+                            li.className = 'px-3 py-1 d-flex justify-content-between align-items-center';
+                            
+                            var spanName = document.createElement('span');
+                            spanName.className = 'text-white small';
+                            spanName.textContent = snapName;
+                            
+                            var badgeContainer = document.createElement('div');
+                            badgeContainer.className = 'd-flex gap-1';
+
+                            if (snapName === data.current_snapshot) {
+                                var badgeActive = document.createElement('span');
+                                badgeActive.className = 'badge bg-success text-white';
+                                badgeActive.style.fontSize = '9px';
+                                badgeActive.innerHTML = '<i class="fas fa-play me-1"></i>Active';
+                                badgeContainer.appendChild(badgeActive);
+                            }
+
+                            if (snapName === data.default_snapshot) {
+                                var badgeDefault = document.createElement('span');
+                                badgeDefault.className = 'badge bg-info text-white';
+                                badgeDefault.style.fontSize = '9px';
+                                badgeDefault.innerHTML = '<i class="fas fa-star me-1"></i>Default';
+                                badgeContainer.appendChild(badgeDefault);
+                            }
+
+                            li.appendChild(spanName);
+                            li.appendChild(badgeContainer);
+                            listContainer.appendChild(li);
+                        });
+                    } else {
+                        listContainer.innerHTML = '<li><span class="dropdown-item-text text-secondary small py-1">No snapshots found</span></li>';
+                    }
+                } else {
+                    listContainer.innerHTML = '<li><span class="dropdown-item-text text-danger small py-1">Error loading</span></li>';
+                }
+            })
+            .catch(error => {
+                console.error('Error loading snapshots menu:', error);
+                listContainer.innerHTML = '<li><span class="dropdown-item-text text-danger small py-1">Network error</span></li>';
+            });
+        }
+
+        var snapshotMenuBtn = document.getElementById('snapshotMenu');
+        if (snapshotMenuBtn) {
+            snapshotMenuBtn.addEventListener('click', function() {
+                loadSnapshotsMenu();
+            });
+        }
+        
+        updateRunningSnapshotBadge("{{ current_snapshot|default:'' }}");
+        loadSnapshotsMenu();
         {% endif %}
 
         {% if not task_id or task_id == 0 or task_id == '0' %}

--- a/web/guac/templates/guac/start.html
+++ b/web/guac/templates/guac/start.html
@@ -28,9 +28,18 @@
                             <div class="card bg-secondary bg-opacity-10 border-secondary p-3 mb-4 text-start">
                                 <div class="form-check mb-3">
                                     <input class="form-check-input" type="radio" name="start_mode" id="modeSnapshot" value="snapshot" checked>
-                                    <label class="form-check-label text-white" for="modeSnapshot">
+                                    <label class="form-check-label text-white w-100" for="modeSnapshot">
                                         <strong>Restore Snapshot</strong>
-                                        <div class="text-muted small">Revert to the clean, configured snapshot state before booting.</div>
+                                        <div class="text-muted small mb-2">Revert to a clean snapshot state before booting.</div>
+                                        {% if snapshots %}
+                                        <select class="form-select form-select-sm bg-dark text-white border-secondary mt-2" name="selected_snapshot" id="snapshotSelect">
+                                            {% for snap in snapshots %}
+                                                <option value="{{ snap }}" {% if default_snapshot == snap %}selected{% endif %}>{{ snap }}{% if default_snapshot == snap %} (configured default){% endif %}</option>
+                                            {% endfor %}
+                                        </select>
+                                        {% else %}
+                                        <div class="text-danger small mt-2"><i class="fas fa-exclamation-circle me-1"></i> No snapshots found for this VM.</div>
+                                        {% endif %}
                                     </label>
                                 </div>
                                 <div class="form-check">
@@ -52,5 +61,17 @@
             </div>
         </div>
     </div>
+    <script>
+        var selectEl = document.getElementById("snapshotSelect");
+        if (selectEl) {
+            var modeSnapshotRadio = document.getElementById("modeSnapshot");
+            selectEl.addEventListener("change", function() {
+                modeSnapshotRadio.checked = true;
+            });
+            selectEl.addEventListener("click", function() {
+                modeSnapshotRadio.checked = true;
+            });
+        }
+    </script>
 </body>
 </html>

--- a/web/guac/templates/guac/start.html
+++ b/web/guac/templates/guac/start.html
@@ -1,0 +1,56 @@
+{% load static %}
+<!DOCTYPE html>
+<html class="datatable-dark" lang="en">
+<head>
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Start VM · CAPE Sandbox</title>
+    <link rel="icon" type="image/png" href="{% static 'img/cape.png' %}">
+    <link href="{% static 'css/bootstrap.min.css' %}" rel="stylesheet">
+    <link href="{% static 'css/style.css' %}" rel="stylesheet">
+    <link href="{% static 'css/atlas.css' %}" rel="stylesheet">
+    <link href="{% static 'css/all.min.css' %}" rel="stylesheet">
+</head>
+<body class="bg-dark text-white">
+    <div class="container mt-5">
+        <div class="row justify-content-center">
+            <div class="col-md-6">
+                <div class="card bg-dark border-secondary text-center py-4">
+                    <div class="card-body">
+                        <div class="mb-4">
+                            <i class="fas fa-desktop fa-3x text-secondary mb-3"></i>
+                        </div>
+                        <h4 class="text-white mb-3">Start VM: {{ vm_name }}</h4>
+                        <p class="text-secondary mb-4 small">This virtual machine is currently powered off. Choose a startup mode to boot the machine and connect via VNC.</p>
+                        
+                        <form action="{% url 'direct_vnc_vm_start' vm_name %}" method="post">
+                            {% csrf_token %}
+                            <div class="card bg-secondary bg-opacity-10 border-secondary p-3 mb-4 text-start">
+                                <div class="form-check mb-3">
+                                    <input class="form-check-input" type="radio" name="start_mode" id="modeSnapshot" value="snapshot" checked>
+                                    <label class="form-check-label text-white" for="modeSnapshot">
+                                        <strong>Restore Snapshot</strong>
+                                        <div class="text-muted small">Revert to the clean, configured snapshot state before booting.</div>
+                                    </label>
+                                </div>
+                                <div class="form-check">
+                                    <input class="form-check-input" type="radio" name="start_mode" id="modeDirty" value="dirty">
+                                    <label class="form-check-label text-white" for="modeDirty">
+                                        <strong>Startup Dirty</strong>
+                                        <div class="text-muted small">Boot the current disk state as-is, without restoring a snapshot.</div>
+                                    </label>
+                                </div>
+                            </div>
+                            
+                            <div class="d-flex justify-content-between">
+                                <a href="/" class="btn btn-outline-secondary"><i class="fas fa-home me-1"></i> Go Home</a>
+                                <button type="submit" class="btn btn-danger"><i class="fas fa-play me-1"></i> Start VM</button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/web/guac/templates/guac/wait.html
+++ b/web/guac/templates/guac/wait.html
@@ -25,7 +25,11 @@
                             <i class="fas fa-desktop fa-3x text-secondary mb-3"></i>
                         </div>
                         <h4 class="text-white mb-2">Hang on...</h4>
+                        {% if vm_name %}
+                        <p class="text-secondary mb-4">The VM {{ vm_name }} is starting. This page will refresh every second.</p>
+                        {% else %}
                         <p class="text-secondary mb-4">The VM is not running yet. This page will refresh every 5 seconds.</p>
+                        {% endif %}
                         <div class="progress mb-4" style="height: 4px;">
                             <div class="progress-bar progress-bar-striped progress-bar-animated bg-danger w-100"></div>
                         </div>
@@ -36,6 +40,11 @@
                         {% else %}
                         <button type="button" id="taskStatus" class="btn btn-outline-secondary">
                             <i class="fas fa-home me-1"></i> Go Home
+                        </button>
+                        {% endif %}
+                        {% if vm_name %}
+                        <button type="button" id="cancelStart" class="btn btn-outline-danger ms-2">
+                            <i class="fas fa-times me-1"></i> Cancel
                         </button>
                         {% endif %}
                     </div>
@@ -52,7 +61,43 @@
             location.replace(location.origin + '/');
             {% endif %}
         });
-        setTimeout(function() { location.reload(true); }, 5000);
+
+        {% if vm_name %}
+        var cancelBtn = document.getElementById("cancelStart");
+        if (cancelBtn) {
+            cancelBtn.addEventListener("click", function() {
+                cancelBtn.disabled = true;
+                cancelBtn.innerHTML = '<i class="fas fa-spinner fa-spin me-1"></i> Cancelling...';
+                
+                fetch('/guac/direct/vnc/{{ vm_name }}/shutdown/', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRFToken': '{{ csrf_token }}'
+                    },
+                    body: JSON.stringify({ force: true })
+                })
+                .then(response => response.json())
+                .then(data => {
+                    if (data.status === 'success') {
+                        location.replace(location.origin + '/guac/direct/vnc/{{ vm_name }}/');
+                    } else {
+                        alert('Error cancelling startup: ' + (data.message || 'Unknown error'));
+                        cancelBtn.disabled = false;
+                        cancelBtn.innerHTML = '<i class="fas fa-times me-1"></i> Cancel';
+                    }
+                })
+                .catch(error => {
+                    console.error('Error:', error);
+                    alert('Error cancelling startup');
+                    cancelBtn.disabled = false;
+                    cancelBtn.innerHTML = '<i class="fas fa-times me-1"></i> Cancel';
+                });
+            });
+        }
+        {% endif %}
+
+        setTimeout(function() { location.reload(true); }, {% if vm_name %}1000{% else %}5000{% endif %});
     </script>
 </body>
 </html>

--- a/web/guac/templates/guac/wait.html
+++ b/web/guac/templates/guac/wait.html
@@ -29,9 +29,15 @@
                         <div class="progress mb-4" style="height: 4px;">
                             <div class="progress-bar progress-bar-striped progress-bar-animated bg-danger w-100"></div>
                         </div>
+                        {% if task_id and task_id != 0 and task_id != '0' %}
                         <button type="button" id="taskStatus" class="btn btn-outline-secondary">
                             <i class="fas fa-tasks me-1"></i> View Task
                         </button>
+                        {% else %}
+                        <button type="button" id="taskStatus" class="btn btn-outline-secondary">
+                            <i class="fas fa-home me-1"></i> Go Home
+                        </button>
+                        {% endif %}
                     </div>
                 </div>
             </div>
@@ -40,7 +46,11 @@
 
     <script>
         document.getElementById("taskStatus").addEventListener("click", function() {
+            {% if task_id and task_id != 0 and task_id != '0' %}
             location.replace(location.origin + '/submit/status/{{ task_id }}/');
+            {% else %}
+            location.replace(location.origin + '/');
+            {% endif %}
         });
         setTimeout(function() { location.reload(true); }, 5000);
     </script>

--- a/web/guac/templates/guac/warn.html
+++ b/web/guac/templates/guac/warn.html
@@ -1,0 +1,39 @@
+{% load static %}
+<!DOCTYPE html>
+<html class="datatable-dark" lang="en">
+<head>
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Active Session Warning · CAPE Sandbox</title>
+    <link rel="icon" type="image/png" href="{% static 'img/cape.png' %}">
+    <link href="{% static 'css/bootstrap.min.css' %}" rel="stylesheet">
+    <link href="{% static 'css/style.css' %}" rel="stylesheet">
+    <link href="{% static 'css/atlas.css' %}" rel="stylesheet">
+    <link href="{% static 'css/all.min.css' %}" rel="stylesheet">
+</head>
+<body class="bg-dark text-white">
+    <div class="container mt-5">
+        <div class="row justify-content-center">
+            <div class="col-md-6">
+                <div class="card bg-dark border-warning text-center py-4">
+                    <div class="card-body">
+                        <div class="mb-4">
+                            <i class="fas fa-exclamation-triangle fa-3x text-warning mb-3"></i>
+                        </div>
+                        <h4 class="text-white mb-3">Active Session Warning</h4>
+                        <p class="text-secondary mb-4">
+                            A VNC connection to VM <strong>{{ vm_name }}</strong> is already active. 
+                            Connecting now will share control or may disrupt the existing session.
+                        </p>
+                        
+                        <div class="d-flex justify-content-between">
+                            <a href="/" class="btn btn-outline-secondary"><i class="fas fa-home me-1"></i> Go Home</a>
+                            <a href="?override=true" class="btn btn-warning"><i class="fas fa-sign-in-alt me-1"></i> Connect Anyway</a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/web/guac/urls.py
+++ b/web/guac/urls.py
@@ -1,7 +1,10 @@
-from django.urls import re_path
+from django.urls import path, re_path
 
 from guac import views
 
 urlpatterns = [
     re_path(r"^(?P<task_id>\d+)/(?P<session_data>[\w=]+)/$", views.index, name="index"),
+    path("direct/vnc/<str:host>/<int:port>/", views.direct_vnc_host_port, name="direct_vnc_host_port"),
+    path("direct/vnc/<str:vm_name>/", views.direct_vnc_vm, name="direct_vnc_vm"),
 ]
+

--- a/web/guac/urls.py
+++ b/web/guac/urls.py
@@ -9,5 +9,8 @@ urlpatterns = [
     path("direct/vnc/<str:vm_name>/start/", views.direct_vnc_vm_start, name="direct_vnc_vm_start"),
     path("direct/vnc/<str:vm_name>/shutdown/", views.direct_vnc_vm_shutdown, name="direct_vnc_vm_shutdown"),
     path("direct/vnc/<str:vm_name>/route/", views.direct_vnc_vm_route, name="direct_vnc_vm_route"),
+    path("direct/vnc/<str:vm_name>/snapshots/", views.direct_vnc_vm_snapshots_list, name="direct_vnc_vm_snapshots_list"),
+    path("direct/vnc/<str:vm_name>/snapshot/create/", views.direct_vnc_vm_snapshot_create, name="direct_vnc_vm_snapshot_create"),
+    path("direct/vnc/<str:vm_name>/snapshot/delete/", views.direct_vnc_vm_snapshot_delete, name="direct_vnc_vm_snapshot_delete"),
 ]
 

--- a/web/guac/urls.py
+++ b/web/guac/urls.py
@@ -8,5 +8,6 @@ urlpatterns = [
     path("direct/vnc/<str:vm_name>/", views.direct_vnc_vm, name="direct_vnc_vm"),
     path("direct/vnc/<str:vm_name>/start/", views.direct_vnc_vm_start, name="direct_vnc_vm_start"),
     path("direct/vnc/<str:vm_name>/shutdown/", views.direct_vnc_vm_shutdown, name="direct_vnc_vm_shutdown"),
+    path("direct/vnc/<str:vm_name>/route/", views.direct_vnc_vm_route, name="direct_vnc_vm_route"),
 ]
 

--- a/web/guac/urls.py
+++ b/web/guac/urls.py
@@ -6,5 +6,7 @@ urlpatterns = [
     re_path(r"^(?P<task_id>\d+)/(?P<session_data>[\w=]+)/$", views.index, name="index"),
     path("direct/vnc/<str:host>/<int:port>/", views.direct_vnc_host_port, name="direct_vnc_host_port"),
     path("direct/vnc/<str:vm_name>/", views.direct_vnc_vm, name="direct_vnc_vm"),
+    path("direct/vnc/<str:vm_name>/start/", views.direct_vnc_vm_start, name="direct_vnc_vm_start"),
+    path("direct/vnc/<str:vm_name>/shutdown/", views.direct_vnc_vm_shutdown, name="direct_vnc_vm_shutdown"),
 ]
 

--- a/web/guac/views.py
+++ b/web/guac/views.py
@@ -302,6 +302,17 @@ def bg_revert_and_start(machinery_dsn, vm_name, start_mode, snapshot_name):
                 dom.revertToSnapshot(snap, flags=0)
             else:
                 dom.create()
+
+            # Enforce 'none' (no internet) route by default
+            try:
+                machine = db.view_machine_by_label(vm_name)
+                if machine:
+                    from utils.router_manager import route_enable
+                    route_enable("none", None, None, machine, None, None)
+                    logger.info("Successfully set default 'none' route for VM '%s'", vm_name)
+            except Exception as routing_err:
+                logger.error(f"Failed to enforce default 'none' route for VM {vm_name}: {routing_err}")
+
     except Exception as e:
         logger.error(f"Error starting VM {vm_name} in background: {e}")
         try:
@@ -381,6 +392,9 @@ def direct_vnc_vm_start(request, vm_name):
                     db.unlock_machine(machine)
                     db.session.commit()
                 return _error(request, 0, f"Failed to restore snapshot: {e}")
+
+        # Initialize route session to 'none' by default
+        request.session[f"route_{vm_name}"] = "none"
 
         # Spawn background thread to start the VM
         threading.Thread(

--- a/web/guac/views.py
+++ b/web/guac/views.py
@@ -219,9 +219,15 @@ def direct_vnc_vm(request, vm_name):
         except Exception as e:
             logger.error(f"Failed to clear stale GuacSession for VM {vm_name}: {e}")
 
-        is_starting = any(t.name == f"start_{vm_name}" for t in threading.enumerate())
-        machine = db.view_machine_by_label(vm_name)
+        is_starting = False
+        machine = db.view_machine_by_label(vm_name) or db.view_machine(vm_name)
         if machine:
+            if machine.locked_changed_on:
+                from datetime import datetime
+                # Check if it was locked within the last 90 seconds (startup window)
+                delta = datetime.utcnow() - machine.locked_changed_on
+                is_starting = delta.total_seconds() < 90
+
             if is_starting:
                 return render(request, "guac/wait.html", {
                     "vm_name": vm_name,
@@ -256,7 +262,7 @@ def direct_vnc_vm(request, vm_name):
                         "task_id": active_task.id if active_task else 0,
                     })
                 else:
-                    # No active task/guest and no console start thread -> stale lock!
+                    # No active task/guest and no active console startup -> stale lock!
                     try:
                         db.unlock_machine(machine)
                         db.session.commit()
@@ -285,8 +291,8 @@ def direct_vnc_vm(request, vm_name):
     recording_name = f"direct_{vm_name}_{str(token)[:8]}"
 
     # Determine if it was started by the VNC Console
-    machine = db.view_machine_by_label(vm_name)
-    started_by_console = machine.locked if machine else False
+    machine = db.view_machine_by_label(vm_name) or db.view_machine(vm_name)
+    started_by_console = True
 
     # Determine configured VPNs and Tor/Internet routing options
     from lib.cuckoo.common.config import Config as CapeConfig

--- a/web/guac/views.py
+++ b/web/guac/views.py
@@ -150,14 +150,6 @@ def direct_vnc_host_port(request, host, port):
 
 @conditional_login_required(login_required, settings.WEB_AUTHENTICATION)
 def direct_vnc_vm(request, vm_name):
-    override = request.GET.get("override") == "true"
-    if not override:
-        from lib.cuckoo.core.data.guac_session import GuacSession
-        session = db.session()
-        active_session = session.query(GuacSession).filter_by(vm_label=vm_name).first()
-        if active_session:
-            return render(request, "guac/warn.html", {"vm_name": vm_name})
-
     if not LIBVIRT_AVAILABLE:
         return _error(request, 0, "Libvirt not available")
 
@@ -201,7 +193,25 @@ def direct_vnc_vm(request, vm_name):
     if not vm_exists:
         return _error(request, 0, f"VM {vm_name} not found")
 
+    # If the VM is running, check for an active Guacamole connection session
+    override = request.GET.get("override") == "true"
+    if is_running and not override:
+        from lib.cuckoo.core.data.guac_session import GuacSession
+        session = db.session()
+        active_session = session.query(GuacSession).filter_by(vm_label=vm_name).first()
+        if active_session:
+            return render(request, "guac/warn.html", {"vm_name": vm_name})
+
+    # If the VM is not running, delete any stale GuacSession entries to prevent lockups
     if not is_running:
+        try:
+            from lib.cuckoo.core.data.guac_session import GuacSession
+            session = db.session()
+            session.query(GuacSession).filter_by(vm_label=vm_name).delete()
+            session.commit()
+        except Exception as e:
+            logger.error(f"Failed to clear stale GuacSession for VM {vm_name}: {e}")
+
         machine = db.view_machine_by_label(vm_name)
         if machine and machine.locked:
             return render(request, "guac/wait.html", {

--- a/web/guac/views.py
+++ b/web/guac/views.py
@@ -149,6 +149,14 @@ def direct_vnc_host_port(request, host, port):
 
 @conditional_login_required(login_required, settings.WEB_AUTHENTICATION)
 def direct_vnc_vm(request, vm_name):
+    override = request.GET.get("override") == "true"
+    if not override:
+        from lib.cuckoo.core.data.guac_session import GuacSession
+        session = db.session()
+        active_session = session.query(GuacSession).filter_by(vm_label=vm_name).first()
+        if active_session:
+            return render(request, "guac/warn.html", {"vm_name": vm_name})
+
     if not LIBVIRT_AVAILABLE:
         return _error(request, 0, "Libvirt not available")
 

--- a/web/guac/views.py
+++ b/web/guac/views.py
@@ -166,6 +166,7 @@ def direct_vnc_vm(request, vm_name):
     is_running = False
     vm_exists = False
     error_msg = ""
+    snapshot_names = []
 
     conn = None
     try:
@@ -177,6 +178,11 @@ def direct_vnc_vm(request, vm_name):
                     vm_exists = True
                     state = dom.state(flags=0)
                     is_running = state and state[0] == 1
+                    if not is_running:
+                        try:
+                            snapshot_names = dom.snapshotListNames(flags=0)
+                        except Exception:
+                            pass
             except Exception as e:
                 error_msg = str(e)
     except Exception as e:
@@ -195,7 +201,13 @@ def direct_vnc_vm(request, vm_name):
         return _error(request, 0, f"VM {vm_name} not found")
 
     if not is_running:
-        return render(request, "guac/start.html", {"vm_name": vm_name})
+        machine = db.view_machine_by_label(vm_name)
+        default_snapshot = machine.snapshot if (machine and machine.snapshot) else None
+        return render(request, "guac/start.html", {
+            "vm_name": vm_name,
+            "snapshots": snapshot_names,
+            "default_snapshot": default_snapshot,
+        })
 
     token = uuid.uuid4()
     try:
@@ -247,6 +259,7 @@ def direct_vnc_vm_start(request, vm_name):
         return _error(request, 0, "Invalid request method")
 
     start_mode = request.POST.get("start_mode", "snapshot")
+    selected_snapshot = request.POST.get("selected_snapshot")
 
     conn = None
     try:
@@ -272,7 +285,7 @@ def direct_vnc_vm_start(request, vm_name):
             db.session.commit()
 
         if start_mode == "snapshot":
-            snapshot_name = machine.snapshot if (machine and machine.snapshot) else None
+            snapshot_name = selected_snapshot or (machine.snapshot if (machine and machine.snapshot) else None)
             if not snapshot_name:
                 try:
                     snapshot_names = dom.snapshotListNames(flags=0)

--- a/web/guac/views.py
+++ b/web/guac/views.py
@@ -1,12 +1,17 @@
 import uuid
 from base64 import urlsafe_b64decode
 
+import json
+import logging
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
-from django.shortcuts import render
+from django.http import JsonResponse
+from django.shortcuts import render, redirect
 
 from lib.cuckoo.common.config import Config
 from lib.cuckoo.core.database import Database
+
+logger = logging.getLogger("guac-session")
 
 
 class conditional_login_required:
@@ -182,7 +187,7 @@ def direct_vnc_vm(request, vm_name):
         return _error(request, 0, f"VM {vm_name} not found")
 
     if not is_running:
-        return render(request, "guac/wait.html", {"task_id": 0})
+        return render(request, "guac/start.html", {"vm_name": vm_name})
 
     token = uuid.uuid4()
     try:
@@ -197,12 +202,17 @@ def direct_vnc_vm(request, vm_name):
 
     recording_name = f"direct_{vm_name}_{str(token)[:8]}"
 
+    # Determine if it was started by the VNC Console
+    machine = db.view_machine_by_label(vm_name)
+    started_by_console = machine.locked if machine else False
+
     response = render(request, "guac/index.html", {
         "session_id": str(token),
         "task_id": 0,
         "recording_name": recording_name,
         "vnc_host": vm_name,
         "vnc_port": "auto",
+        "started_by_console": started_by_console,
     })
 
     response.set_cookie(
@@ -215,4 +225,139 @@ def direct_vnc_vm(request, vm_name):
     )
 
     return response
+
+
+@conditional_login_required(login_required, settings.WEB_AUTHENTICATION)
+def direct_vnc_vm_start(request, vm_name):
+    if not LIBVIRT_AVAILABLE:
+        return _error(request, 0, "Libvirt not available")
+
+    if machinery not in machinery_available:
+        return _error(request, 0, f"Machinery type '{machinery}' is not supported")
+
+    if request.method != "POST":
+        return _error(request, 0, "Invalid request method")
+
+    start_mode = request.POST.get("start_mode", "snapshot")
+
+    conn = None
+    try:
+        conn = libvirt.open(machinery_dsn)
+        if not conn:
+            return _error(request, 0, "Could not connect to hypervisor")
+
+        try:
+            dom = conn.lookupByName(vm_name)
+        except Exception as e:
+            return _error(request, 0, f"VM {vm_name} not found: {e}")
+
+        # Check if already running
+        state = dom.state(flags=0)
+        is_running = state and state[0] == 1
+        if is_running:
+            return redirect("direct_vnc_vm", vm_name=vm_name)
+
+        # Lock the machine in DB
+        machine = db.view_machine_by_label(vm_name)
+        if machine:
+            db.lock_machine(machine)
+            db.session.commit()
+
+        if start_mode == "snapshot":
+            snapshot_name = machine.snapshot if (machine and machine.snapshot) else None
+            if not snapshot_name:
+                try:
+                    snapshot_names = dom.snapshotListNames(flags=0)
+                    if snapshot_names:
+                        snapshot_name = snapshot_names[0]
+                except Exception:
+                    pass
+
+            if not snapshot_name:
+                if machine:
+                    db.unlock_machine(machine)
+                    db.session.commit()
+                return _error(request, 0, f"No snapshot configured or found for VM {vm_name}")
+
+            try:
+                snap = dom.snapshotLookupByName(snapshot_name, flags=0)
+                dom.revertToSnapshot(snap, flags=0)
+            except Exception as e:
+                if machine:
+                    db.unlock_machine(machine)
+                    db.session.commit()
+                return _error(request, 0, f"Failed to restore snapshot: {e}")
+        else:
+            # Start dirty
+            try:
+                dom.create()
+            except Exception as e:
+                if machine:
+                    db.unlock_machine(machine)
+                    db.session.commit()
+                return _error(request, 0, f"Failed to power on VM dirty: {e}")
+
+        return redirect("direct_vnc_vm", vm_name=vm_name)
+
+    finally:
+        if conn:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+
+@conditional_login_required(login_required, settings.WEB_AUTHENTICATION)
+def direct_vnc_vm_shutdown(request, vm_name):
+    if not LIBVIRT_AVAILABLE:
+        return JsonResponse({"status": "error", "message": "Libvirt not available"}, status=500)
+
+    if machinery not in machinery_available:
+        return JsonResponse({"status": "error", "message": f"Machinery type '{machinery}' is not supported"}, status=400)
+
+    if request.method != "POST":
+        return JsonResponse({"status": "error", "message": "Invalid request method"}, status=405)
+
+    try:
+        data = json.loads(request.body.decode("utf-8"))
+    except Exception:
+        data = {}
+
+    force = data.get("force", False)
+
+    conn = None
+    try:
+        conn = libvirt.open(machinery_dsn)
+        if not conn:
+            return JsonResponse({"status": "error", "message": "Could not connect to hypervisor"}, status=500)
+
+        try:
+            dom = conn.lookupByName(vm_name)
+        except Exception as e:
+            return JsonResponse({"status": "error", "message": f"VM {vm_name} not found: {e}"}, status=404)
+
+        try:
+            if force:
+                dom.destroy()
+            else:
+                dom.shutdown()
+        except Exception as e:
+            logger.error("Failed to shutdown VM %s: %s", vm_name, e)
+
+        # Unlock the machine in DB
+        machine = db.view_machine_by_label(vm_name)
+        if machine:
+            db.unlock_machine(machine)
+            db.session.commit()
+
+        return JsonResponse({"status": "success"})
+
+    except Exception as e:
+        return JsonResponse({"status": "error", "message": str(e)}, status=500)
+    finally:
+        if conn:
+            try:
+                conn.close()
+            except Exception:
+                pass
 

--- a/web/guac/views.py
+++ b/web/guac/views.py
@@ -35,6 +35,14 @@ machinery = Config().cuckoo.machinery
 machinery_available = ["kvm", "qemu"]
 machinery_dsn = getattr(Config(machinery), machinery).get("dsn", "qemu:///system")
 db = Database()
+web_cfg = Config("web")
+
+
+def is_vnc_console_enabled():
+    enabled = web_cfg.guacamole.get("vnc_console_enabled", False)
+    if isinstance(enabled, str):
+        return enabled.lower() in ("yes", "true", "on", "1")
+    return bool(enabled)
 
 
 def _error(request, task_id, msg):
@@ -114,6 +122,9 @@ def index(request, task_id, session_data):
 
 @conditional_login_required(login_required, settings.WEB_AUTHENTICATION)
 def direct_vnc_host_port(request, host, port):
+    if not is_vnc_console_enabled():
+        return _error(request, 0, "VNC Console is disabled in configuration")
+
     token = uuid.uuid4()
     try:
         guac_session = db.create_guac_session(
@@ -150,6 +161,9 @@ def direct_vnc_host_port(request, host, port):
 
 @conditional_login_required(login_required, settings.WEB_AUTHENTICATION)
 def direct_vnc_vm(request, vm_name):
+    if not is_vnc_console_enabled():
+        return _error(request, 0, "VNC Console is disabled in configuration")
+
     if not LIBVIRT_AVAILABLE:
         return _error(request, 0, "Libvirt not available")
 
@@ -533,6 +547,9 @@ sys.exit(res.returncode)
 
 @conditional_login_required(login_required, settings.WEB_AUTHENTICATION)
 def direct_vnc_vm_start(request, vm_name):
+    if not is_vnc_console_enabled():
+        return _error(request, 0, "VNC Console is disabled in configuration")
+
     if not LIBVIRT_AVAILABLE:
         return _error(request, 0, "Libvirt not available")
 
@@ -641,6 +658,9 @@ def direct_vnc_vm_start(request, vm_name):
 
 @conditional_login_required(login_required, settings.WEB_AUTHENTICATION)
 def direct_vnc_vm_shutdown(request, vm_name):
+    if not is_vnc_console_enabled():
+        return JsonResponse({"status": "error", "message": "VNC Console is disabled in configuration"}, status=403)
+
     if not LIBVIRT_AVAILABLE:
         return JsonResponse({"status": "error", "message": "Libvirt not available"}, status=500)
 
@@ -739,6 +759,9 @@ def get_route_params(route_name, routing, configured_vpns):
 
 @conditional_login_required(login_required, settings.WEB_AUTHENTICATION)
 def direct_vnc_vm_route(request, vm_name):
+    if not is_vnc_console_enabled():
+        return JsonResponse({"status": "error", "message": "VNC Console is disabled in configuration"}, status=403)
+
     if request.method != "POST":
         return JsonResponse({"status": "error", "message": "Invalid request method"}, status=405)
 
@@ -822,6 +845,9 @@ def direct_vnc_vm_route(request, vm_name):
 
 @conditional_login_required(login_required, settings.WEB_AUTHENTICATION)
 def direct_vnc_vm_snapshots_list(request, vm_name):
+    if not is_vnc_console_enabled():
+        return JsonResponse({"status": "error", "message": "VNC Console is disabled in configuration"}, status=403)
+
     if not LIBVIRT_AVAILABLE:
         return JsonResponse({"status": "error", "message": "Libvirt not available"}, status=500)
 
@@ -879,6 +905,9 @@ def direct_vnc_vm_snapshots_list(request, vm_name):
 
 @conditional_login_required(login_required, settings.WEB_AUTHENTICATION)
 def direct_vnc_vm_snapshot_create(request, vm_name):
+    if not is_vnc_console_enabled():
+        return JsonResponse({"status": "error", "message": "VNC Console is disabled in configuration"}, status=403)
+
     if not LIBVIRT_AVAILABLE:
         return JsonResponse({"status": "error", "message": "Libvirt not available"}, status=500)
 
@@ -957,6 +986,9 @@ def direct_vnc_vm_snapshot_create(request, vm_name):
 
 @conditional_login_required(login_required, settings.WEB_AUTHENTICATION)
 def direct_vnc_vm_snapshot_delete(request, vm_name):
+    if not is_vnc_console_enabled():
+        return JsonResponse({"status": "error", "message": "VNC Console is disabled in configuration"}, status=403)
+
     if not LIBVIRT_AVAILABLE:
         return JsonResponse({"status": "error", "message": "Libvirt not available"}, status=500)
 

--- a/web/guac/views.py
+++ b/web/guac/views.py
@@ -233,6 +233,26 @@ def direct_vnc_vm(request, vm_name):
     machine = db.view_machine_by_label(vm_name)
     started_by_console = machine.locked if machine else False
 
+    # Determine configured VPNs and Tor/Internet routing options
+    from lib.cuckoo.common.config import Config as CapeConfig
+    routing = CapeConfig("routing")
+    tor_enabled = routing.tor.get("enabled", False)
+    internet_interface = routing.routing.get("internet", "none")
+    internet_configured = internet_interface and internet_interface != "none"
+
+    vpns_raw = routing.vpn.get("vpns", "")
+    vpn_list = []
+    if routing.vpn.get("enabled", False) and vpns_raw:
+        for vpn_name in [v.strip() for v in vpns_raw.split(",") if v.strip()]:
+            vpn_section = getattr(routing, vpn_name, None)
+            if vpn_section:
+                vpn_list.append({
+                    "name": vpn_name,
+                    "description": vpn_section.get("description", vpn_name)
+                })
+
+    current_route = request.session.get(f"route_{vm_name}", "none")
+
     response = render(request, "guac/index.html", {
         "session_id": str(token),
         "task_id": 0,
@@ -240,6 +260,10 @@ def direct_vnc_vm(request, vm_name):
         "vnc_host": vm_name,
         "vnc_port": "auto",
         "started_by_console": started_by_console,
+        "tor_enabled": tor_enabled,
+        "internet_configured": internet_configured,
+        "vpns": vpn_list,
+        "current_route": current_route,
     })
 
     response.set_cookie(
@@ -402,8 +426,27 @@ def direct_vnc_vm_shutdown(request, vm_name):
         except Exception as e:
             logger.error("Failed to shutdown VM %s: %s", vm_name, e)
 
+        # Disable active routing if configured
+        current_route = request.session.get(f"route_{vm_name}", "none")
+        if current_route != "none" and machine:
+            try:
+                from lib.cuckoo.common.config import Config as CapeConfig
+                from utils.router_manager import route_disable
+                
+                routing = CapeConfig("routing")
+                vpns_raw = routing.vpn.get("vpns", "")
+                configured_vpns = [v.strip() for v in vpns_raw.split(",") if v.strip()] if vpns_raw else []
+                
+                interface, rt_table, reject_segments, reject_hostports = get_route_params(
+                    current_route, routing, configured_vpns
+                )
+                route_disable(current_route, interface, rt_table, machine, reject_segments, reject_hostports)
+            except Exception as routing_err:
+                logger.error(f"Failed to disable routing for {vm_name} on shutdown: {routing_err}")
+            finally:
+                request.session.pop(f"route_{vm_name}", None)
+
         # Unlock the machine in DB
-        machine = db.view_machine_by_label(vm_name)
         if machine:
             db.unlock_machine(machine)
             db.session.commit()
@@ -418,4 +461,99 @@ def direct_vnc_vm_shutdown(request, vm_name):
                 conn.close()
             except Exception:
                 pass
+
+
+def get_route_params(route_name, routing, configured_vpns):
+    if route_name == "tor":
+        return routing.tor.get("interface"), None, None, None
+    elif route_name == "internet":
+        interface = routing.routing.get("internet", "none")
+        rt_table = routing.routing.get("rt_table", "main")
+        
+        reject_segments = routing.routing.get("reject_segments", "none")
+        if reject_segments == "none":
+            reject_segments = None
+            
+        reject_hostports = routing.routing.get("reject_hostports", "none")
+        if reject_hostports == "none":
+            reject_hostports = None
+        else:
+            reject_hostports = str(reject_hostports)
+            
+        return interface, rt_table, reject_segments, reject_hostports
+    elif route_name in configured_vpns:
+        vpn = routing.get(route_name)
+        return vpn.get("interface"), vpn.get("rt_table"), None, None
+    return None, None, None, None
+
+
+@conditional_login_required(login_required, settings.WEB_AUTHENTICATION)
+def direct_vnc_vm_route(request, vm_name):
+    if request.method != "POST":
+        return JsonResponse({"status": "error", "message": "Invalid request method"}, status=405)
+
+    if not LIBVIRT_AVAILABLE:
+        return JsonResponse({"status": "error", "message": "Libvirt not available"}, status=500)
+
+    try:
+        data = json.loads(request.body.decode("utf-8"))
+    except Exception:
+        data = {}
+
+    target_route = data.get("route", "none")
+
+    # Load machine configuration
+    machine = db.view_machine_by_label(vm_name)
+    if not machine:
+        return JsonResponse({"status": "error", "message": f"VM {vm_name} not found"}, status=404)
+
+    from lib.cuckoo.common.config import Config as CapeConfig
+    routing = CapeConfig("routing")
+    vpns_raw = routing.vpn.get("vpns", "")
+    configured_vpns = [v.strip() for v in vpns_raw.split(",") if v.strip()] if vpns_raw else []
+
+    # Validate target route
+    allowed_routes = ["none"]
+    if routing.tor.get("enabled", False):
+        allowed_routes.append("tor")
+    if routing.routing.get("internet", "none") != "none":
+        allowed_routes.append("internet")
+    if routing.vpn.get("enabled", False):
+        allowed_routes.extend(configured_vpns)
+
+    if target_route not in allowed_routes:
+        return JsonResponse({"status": "error", "message": f"Route '{target_route}' is not configured or enabled"}, status=400)
+
+    current_route = request.session.get(f"route_{vm_name}", "none")
+    if current_route == target_route:
+        return JsonResponse({"status": "success", "current_route": current_route})
+
+    from utils.router_manager import route_disable, route_enable
+
+    try:
+        # Disable previous route
+        if current_route != "none":
+            interface, rt_table, reject_segments, reject_hostports = get_route_params(
+                current_route, routing, configured_vpns
+            )
+            route_disable(current_route, interface, rt_table, machine, reject_segments, reject_hostports)
+
+        # Enable new route
+        if target_route != "none":
+            interface, rt_table, reject_segments, reject_hostports = get_route_params(
+                target_route, routing, configured_vpns
+            )
+            route_enable(target_route, interface, rt_table, machine, reject_segments, reject_hostports)
+
+        # Save route in session
+        request.session[f"route_{vm_name}"] = target_route
+        return JsonResponse({"status": "success", "current_route": target_route})
+
+    except Exception as e:
+        logger.error(f"Failed to change route for VM {vm_name} to {target_route}: {e}")
+        return JsonResponse({
+            "status": "error",
+            "message": str(e),
+            "current_route": current_route
+        }, status=500)
 

--- a/web/guac/views.py
+++ b/web/guac/views.py
@@ -735,3 +735,194 @@ def direct_vnc_vm_route(request, vm_name):
             "current_route": current_route
         }, status=500)
 
+
+@conditional_login_required(login_required, settings.WEB_AUTHENTICATION)
+def direct_vnc_vm_snapshots_list(request, vm_name):
+    if not LIBVIRT_AVAILABLE:
+        return JsonResponse({"status": "error", "message": "Libvirt not available"}, status=500)
+
+    if machinery not in machinery_available:
+        return JsonResponse({"status": "error", "message": f"Machinery type '{machinery}' is not supported"}, status=400)
+
+    conn = None
+    try:
+        conn = libvirt.open(machinery_dsn)
+        if not conn:
+            return JsonResponse({"status": "error", "message": "Could not connect to hypervisor"}, status=500)
+
+        try:
+            dom = conn.lookupByName(vm_name)
+        except Exception as e:
+            return JsonResponse({"status": "error", "message": f"VM {vm_name} not found: {e}"}, status=404)
+
+        try:
+            snapshot_names = dom.snapshotListNames(flags=0)
+        except Exception:
+            snapshot_names = []
+
+        machine = db.view_machine_by_label(vm_name)
+        default_snapshot = machine.snapshot if (machine and machine.snapshot) else None
+
+        return JsonResponse({
+            "status": "success",
+            "snapshots": snapshot_names,
+            "default_snapshot": default_snapshot,
+        })
+    except Exception as e:
+        return JsonResponse({"status": "error", "message": str(e)}, status=500)
+    finally:
+        if conn:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+
+@conditional_login_required(login_required, settings.WEB_AUTHENTICATION)
+def direct_vnc_vm_snapshot_create(request, vm_name):
+    if not LIBVIRT_AVAILABLE:
+        return JsonResponse({"status": "error", "message": "Libvirt not available"}, status=500)
+
+    if machinery not in machinery_available:
+        return JsonResponse({"status": "error", "message": f"Machinery type '{machinery}' is not supported"}, status=400)
+
+    if request.method != "POST":
+        return JsonResponse({"status": "error", "message": "Invalid request method"}, status=405)
+
+    try:
+        data = json.loads(request.body.decode("utf-8"))
+    except Exception:
+        data = {}
+
+    snapshot_name = data.get("name")
+    description = data.get("description", "")
+
+    if not snapshot_name:
+        return JsonResponse({"status": "error", "message": "Snapshot name is required"}, status=400)
+
+    conn = None
+    try:
+        conn = libvirt.open(machinery_dsn)
+        if not conn:
+            return JsonResponse({"status": "error", "message": "Could not connect to hypervisor"}, status=500)
+
+        try:
+            dom = conn.lookupByName(vm_name)
+        except Exception as e:
+            return JsonResponse({"status": "error", "message": f"VM {vm_name} not found: {e}"}, status=404)
+
+        state = dom.state(flags=0)
+        is_running = state and state[0] == 1
+        if not is_running:
+            return JsonResponse({"status": "error", "message": "Snapshot creation failed: The VM must be running for a full state capture."}, status=400)
+
+        try:
+            dom.snapshotLookupByName(snapshot_name, flags=0)
+            return JsonResponse({"status": "error", "message": f"Snapshot '{snapshot_name}' already exists"}, status=400)
+        except libvirt.libvirtError:
+            pass
+
+        xml = f"""<domainsnapshot>
+  <name>{snapshot_name}</name>
+  <description>{description}</description>
+</domainsnapshot>"""
+
+        flags = 0
+        if hasattr(libvirt, "VIR_DOMAIN_SNAPSHOT_CREATE_ATOMIC"):
+            flags |= libvirt.VIR_DOMAIN_SNAPSHOT_CREATE_ATOMIC
+
+        try:
+            dom.snapshotCreateXML(xml, flags=flags)
+        except Exception as e:
+            logger.error("Failed to create snapshot '%s' for VM '%s': %s", snapshot_name, vm_name, e)
+            return JsonResponse({"status": "error", "message": f"Failed to create snapshot: {e}"}, status=500)
+
+        machine = db.view_machine_by_label(vm_name)
+        if machine:
+            try:
+                machine.snapshot = snapshot_name
+                db.session.commit()
+            except Exception as db_err:
+                logger.error("Failed to update default snapshot in database for '%s': %s", vm_name, db_err)
+
+        return JsonResponse({"status": "success", "message": f"Snapshot '{snapshot_name}' created successfully"})
+    except Exception as e:
+        return JsonResponse({"status": "error", "message": str(e)}, status=500)
+    finally:
+        if conn:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+
+@conditional_login_required(login_required, settings.WEB_AUTHENTICATION)
+def direct_vnc_vm_snapshot_delete(request, vm_name):
+    if not LIBVIRT_AVAILABLE:
+        return JsonResponse({"status": "error", "message": "Libvirt not available"}, status=500)
+
+    if machinery not in machinery_available:
+        return JsonResponse({"status": "error", "message": f"Machinery type '{machinery}' is not supported"}, status=400)
+
+    if request.method != "POST":
+        return JsonResponse({"status": "error", "message": "Invalid request method"}, status=405)
+
+    try:
+        data = json.loads(request.body.decode("utf-8"))
+    except Exception:
+        data = {}
+
+    snapshot_name = data.get("name")
+    if not snapshot_name:
+        return JsonResponse({"status": "error", "message": "Snapshot name is required to delete"}, status=400)
+
+    conn = None
+    try:
+        conn = libvirt.open(machinery_dsn)
+        if not conn:
+            return JsonResponse({"status": "error", "message": "Could not connect to hypervisor"}, status=500)
+
+        try:
+            dom = conn.lookupByName(vm_name)
+        except Exception as e:
+            return JsonResponse({"status": "error", "message": f"VM {vm_name} not found: {e}"}, status=404)
+
+        try:
+            snap = dom.snapshotLookupByName(snapshot_name, flags=0)
+        except libvirt.libvirtError:
+            return JsonResponse({"status": "error", "message": f"Snapshot '{snapshot_name}' not found"}, status=404)
+
+        try:
+            snap.delete(flags=0)
+        except Exception as e:
+            logger.error("Failed to delete snapshot '%s' for VM '%s': %s", snapshot_name, vm_name, e)
+            return JsonResponse({"status": "error", "message": f"Failed to delete snapshot: {e}"}, status=500)
+
+        machine = db.view_machine_by_label(vm_name)
+        if machine and machine.snapshot == snapshot_name:
+            try:
+                try:
+                    remaining = dom.snapshotListNames(flags=0)
+                except Exception:
+                    remaining = []
+
+                if remaining:
+                    machine.snapshot = remaining[0]
+                else:
+                    machine.snapshot = None
+
+                db.session.commit()
+            except Exception as db_err:
+                logger.error("Failed to update/clear machine snapshot in DB after deletion: %s", db_err)
+
+        return JsonResponse({"status": "success", "message": f"Snapshot '{snapshot_name}' deleted successfully"})
+    except Exception as e:
+        return JsonResponse({"status": "error", "message": str(e)}, status=500)
+    finally:
+        if conn:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+

--- a/web/guac/views.py
+++ b/web/guac/views.py
@@ -160,6 +160,7 @@ def direct_vnc_vm(request, vm_name):
     vm_exists = False
     error_msg = ""
     snapshot_names = []
+    current_snapshot = None
 
     conn = None
     try:
@@ -174,6 +175,12 @@ def direct_vnc_vm(request, vm_name):
                     if not is_running:
                         try:
                             snapshot_names = dom.snapshotListNames(flags=0)
+                        except Exception:
+                            pass
+                    else:
+                        try:
+                            if dom.hasCurrentSnapshot() == 1:
+                                current_snapshot = dom.currentSnapshot().getName()
                         except Exception:
                             pass
             except Exception as e:
@@ -274,6 +281,7 @@ def direct_vnc_vm(request, vm_name):
         "internet_configured": internet_configured,
         "vpns": vpn_list,
         "current_route": current_route,
+        "current_snapshot": current_snapshot,
     })
 
     response.set_cookie(
@@ -760,6 +768,13 @@ def direct_vnc_vm_snapshots_list(request, vm_name):
         except Exception:
             snapshot_names = []
 
+        current_snapshot = None
+        try:
+            if dom.hasCurrentSnapshot() == 1:
+                current_snapshot = dom.currentSnapshot().getName()
+        except Exception:
+            pass
+
         machine = db.view_machine_by_label(vm_name)
         default_snapshot = machine.snapshot if (machine and machine.snapshot) else None
 
@@ -767,6 +782,7 @@ def direct_vnc_vm_snapshots_list(request, vm_name):
             "status": "success",
             "snapshots": snapshot_names,
             "default_snapshot": default_snapshot,
+            "current_snapshot": current_snapshot,
         })
     except Exception as e:
         return JsonResponse({"status": "error", "message": str(e)}, status=500)

--- a/web/guac/views.py
+++ b/web/guac/views.py
@@ -501,11 +501,15 @@ def direct_vnc_vm_route(request, vm_name):
         data = {}
 
     target_route = data.get("route", "none")
+    logger.info("direct_vnc_vm_route: Received route change request for VM '%s' to target_route: '%s'", vm_name, target_route)
 
     # Load machine configuration
     machine = db.view_machine_by_label(vm_name)
     if not machine:
+        logger.error("direct_vnc_vm_route: VM '%s' not found in database", vm_name)
         return JsonResponse({"status": "error", "message": f"VM {vm_name} not found"}, status=404)
+
+    logger.info("direct_vnc_vm_route: Found machine in DB: name=%s, ip=%s, interface=%s", machine.name, machine.ip, machine.interface)
 
     from lib.cuckoo.common.config import Config as CapeConfig
     routing = CapeConfig("routing")
@@ -521,11 +525,16 @@ def direct_vnc_vm_route(request, vm_name):
     if routing.vpn.get("enabled", False):
         allowed_routes.extend(configured_vpns)
 
+    logger.info("direct_vnc_vm_route: Allowed routes based on routing.conf: %s", allowed_routes)
+
     if target_route not in allowed_routes:
+        logger.error("direct_vnc_vm_route: Target route '%s' is not in allowed_routes list", target_route)
         return JsonResponse({"status": "error", "message": f"Route '{target_route}' is not configured or enabled"}, status=400)
 
     current_route = request.session.get(f"route_{vm_name}", "none")
+    logger.info("direct_vnc_vm_route: Current active route in session: '%s'", current_route)
     if current_route == target_route:
+        logger.info("direct_vnc_vm_route: Current route is already '%s'. No action needed.", target_route)
         return JsonResponse({"status": "success", "current_route": current_route})
 
     from utils.router_manager import route_disable, route_enable
@@ -536,6 +545,7 @@ def direct_vnc_vm_route(request, vm_name):
             interface, rt_table, reject_segments, reject_hostports = get_route_params(
                 current_route, routing, configured_vpns
             )
+            logger.info("direct_vnc_vm_route: Disabling route '%s' (interface=%s, rt_table=%s)", current_route, interface, rt_table)
             route_disable(current_route, interface, rt_table, machine, reject_segments, reject_hostports)
 
         # Enable new route
@@ -543,14 +553,16 @@ def direct_vnc_vm_route(request, vm_name):
             interface, rt_table, reject_segments, reject_hostports = get_route_params(
                 target_route, routing, configured_vpns
             )
+            logger.info("direct_vnc_vm_route: Enabling route '%s' (interface=%s, rt_table=%s)", target_route, interface, rt_table)
             route_enable(target_route, interface, rt_table, machine, reject_segments, reject_hostports)
 
         # Save route in session
         request.session[f"route_{vm_name}"] = target_route
+        logger.info("direct_vnc_vm_route: Successfully updated route for VM '%s' to '%s'", vm_name, target_route)
         return JsonResponse({"status": "success", "current_route": target_route})
 
     except Exception as e:
-        logger.error(f"Failed to change route for VM {vm_name} to {target_route}: {e}")
+        logger.error(f"direct_vnc_vm_route: Failed to change route for VM {vm_name} to {target_route}: {e}")
         return JsonResponse({
             "status": "error",
             "message": str(e),

--- a/web/guac/views.py
+++ b/web/guac/views.py
@@ -219,12 +219,50 @@ def direct_vnc_vm(request, vm_name):
         except Exception as e:
             logger.error(f"Failed to clear stale GuacSession for VM {vm_name}: {e}")
 
+        is_starting = any(t.name == f"start_{vm_name}" for t in threading.enumerate())
         machine = db.view_machine_by_label(vm_name)
-        if machine and machine.locked:
-            return render(request, "guac/wait.html", {
-                "vm_name": vm_name,
-                "task_id": 0,
-            })
+        if machine:
+            if is_starting:
+                return render(request, "guac/wait.html", {
+                    "vm_name": vm_name,
+                    "task_id": 0,
+                })
+            elif machine.locked:
+                # Check if this lock belongs to a legitimate active CAPE analysis task
+                try:
+                    from lib.cuckoo.core.data.guests import Guest
+                    from lib.cuckoo.core.data.task import Task
+                    from lib.cuckoo.common.constants import TASK_RUNNING
+                    
+                    session = db.session()
+                    active_task = session.query(Task).filter(
+                        Task.machine_id == machine.id,
+                        Task.status == TASK_RUNNING
+                    ).first()
+                    
+                    active_guest = session.query(Guest).filter(
+                        Guest.label == vm_name,
+                        Guest.shutdown_on == None
+                    ).first()
+                except Exception as query_err:
+                    logger.error("Failed to query active tasks/guests: %s", query_err)
+                    active_task = None
+                    active_guest = None
+
+                if active_task or active_guest:
+                    # Legitimate task is active, DO NOT unlock! Show wait screen.
+                    return render(request, "guac/wait.html", {
+                        "vm_name": vm_name,
+                        "task_id": active_task.id if active_task else 0,
+                    })
+                else:
+                    # No active task/guest and no console start thread -> stale lock!
+                    try:
+                        db.unlock_machine(machine)
+                        db.session.commit()
+                        logger.info("Automatically unlocked stale machine lock for VM '%s'", vm_name)
+                    except Exception as db_err:
+                        logger.error("Failed to unlock stale machine lock for '%s': %s", vm_name, db_err)
 
         default_snapshot = machine.snapshot if (machine and machine.snapshot) else None
         return render(request, "guac/start.html", {
@@ -514,6 +552,29 @@ def direct_vnc_vm_start(request, vm_name):
         # Lock the machine in DB
         machine = db.view_machine_by_label(vm_name)
         if machine:
+            if machine.locked:
+                try:
+                    from lib.cuckoo.core.data.guests import Guest
+                    from lib.cuckoo.core.data.task import Task
+                    from lib.cuckoo.common.constants import TASK_RUNNING
+                    
+                    session = db.session()
+                    active_task = session.query(Task).filter(
+                        Task.machine_id == machine.id,
+                        Task.status == TASK_RUNNING
+                    ).first()
+                    
+                    active_guest = session.query(Guest).filter(
+                        Guest.label == vm_name,
+                        Guest.shutdown_on == None
+                    ).first()
+                except Exception:
+                    active_task = None
+                    active_guest = None
+
+                if active_task or active_guest:
+                    return _error(request, active_task.id if active_task else 0, f"VM {vm_name} is currently in use by an active analysis task.")
+
             db.lock_machine(machine)
             db.session.commit()
 
@@ -550,6 +611,7 @@ def direct_vnc_vm_start(request, vm_name):
         threading.Thread(
             target=bg_revert_and_start,
             args=(machinery_dsn, vm_name, start_mode, snapshot_name),
+            name=f"start_{vm_name}",
             daemon=True
         ).start()
 

--- a/web/guac/views.py
+++ b/web/guac/views.py
@@ -183,6 +183,13 @@ def direct_vnc_vm(request, vm_name):
                                 current_snapshot = dom.currentSnapshot().getName()
                         except Exception:
                             pass
+
+                        if not current_snapshot:
+                            current_snapshot = request.session.get(f"snapshot_{vm_name}")
+                            if not current_snapshot:
+                                machine = db.view_machine_by_label(vm_name) or db.view_machine(vm_name)
+                                if machine and machine.snapshot:
+                                    current_snapshot = machine.snapshot
             except Exception as e:
                 error_msg = str(e)
     except Exception as e:
@@ -612,6 +619,7 @@ def direct_vnc_vm_start(request, vm_name):
 
         # Initialize route session to 'none' by default
         request.session[f"route_{vm_name}"] = "none"
+        request.session[f"snapshot_{vm_name}"] = snapshot_name if start_mode == "snapshot" else None
 
         # Spawn background thread to start the VM
         threading.Thread(
@@ -843,7 +851,14 @@ def direct_vnc_vm_snapshots_list(request, vm_name):
         except Exception:
             pass
 
-        machine = db.view_machine_by_label(vm_name)
+        if not current_snapshot:
+            current_snapshot = request.session.get(f"snapshot_{vm_name}")
+            if not current_snapshot:
+                machine = db.view_machine_by_label(vm_name) or db.view_machine(vm_name)
+                if machine and machine.snapshot:
+                    current_snapshot = machine.snapshot
+
+        machine = db.view_machine_by_label(vm_name) or db.view_machine(vm_name)
         default_snapshot = machine.snapshot if (machine and machine.snapshot) else None
 
         return JsonResponse({

--- a/web/guac/views.py
+++ b/web/guac/views.py
@@ -1,4 +1,5 @@
 import uuid
+import threading
 from base64 import urlsafe_b64decode
 
 import json
@@ -202,6 +203,12 @@ def direct_vnc_vm(request, vm_name):
 
     if not is_running:
         machine = db.view_machine_by_label(vm_name)
+        if machine and machine.locked:
+            return render(request, "guac/wait.html", {
+                "vm_name": vm_name,
+                "task_id": 0,
+            })
+
         default_snapshot = machine.snapshot if (machine and machine.snapshot) else None
         return render(request, "guac/start.html", {
             "vm_name": vm_name,
@@ -247,6 +254,37 @@ def direct_vnc_vm(request, vm_name):
     return response
 
 
+def bg_revert_and_start(machinery_dsn, vm_name, start_mode, snapshot_name):
+    import libvirt
+    from lib.cuckoo.core.database import Database
+    db = Database()
+    conn = None
+    try:
+        conn = libvirt.open(machinery_dsn)
+        if conn:
+            dom = conn.lookupByName(vm_name)
+            if start_mode == "snapshot":
+                snap = dom.snapshotLookupByName(snapshot_name, flags=0)
+                dom.revertToSnapshot(snap, flags=0)
+            else:
+                dom.create()
+    except Exception as e:
+        logger.error(f"Error starting VM {vm_name} in background: {e}")
+        try:
+            machine = db.view_machine_by_label(vm_name)
+            if machine:
+                db.unlock_machine(machine)
+                db.session.commit()
+        except Exception as db_err:
+            logger.error(f"Failed to unlock machine {vm_name} after background start error: {db_err}")
+    finally:
+        if conn:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+
 @conditional_login_required(login_required, settings.WEB_AUTHENTICATION)
 def direct_vnc_vm_start(request, vm_name):
     if not LIBVIRT_AVAILABLE:
@@ -284,6 +322,7 @@ def direct_vnc_vm_start(request, vm_name):
             db.lock_machine(machine)
             db.session.commit()
 
+        snapshot_name = None
         if start_mode == "snapshot":
             snapshot_name = selected_snapshot or (machine.snapshot if (machine and machine.snapshot) else None)
             if not snapshot_name:
@@ -300,23 +339,21 @@ def direct_vnc_vm_start(request, vm_name):
                     db.session.commit()
                 return _error(request, 0, f"No snapshot configured or found for VM {vm_name}")
 
+            # Verify snapshot exists before starting thread
             try:
-                snap = dom.snapshotLookupByName(snapshot_name, flags=0)
-                dom.revertToSnapshot(snap, flags=0)
+                dom.snapshotLookupByName(snapshot_name, flags=0)
             except Exception as e:
                 if machine:
                     db.unlock_machine(machine)
                     db.session.commit()
                 return _error(request, 0, f"Failed to restore snapshot: {e}")
-        else:
-            # Start dirty
-            try:
-                dom.create()
-            except Exception as e:
-                if machine:
-                    db.unlock_machine(machine)
-                    db.session.commit()
-                return _error(request, 0, f"Failed to power on VM dirty: {e}")
+
+        # Spawn background thread to start the VM
+        threading.Thread(
+            target=bg_revert_and_start,
+            args=(machinery_dsn, vm_name, start_mode, snapshot_name),
+            daemon=True
+        ).start()
 
         return redirect("direct_vnc_vm", vm_name=vm_name)
 

--- a/web/guac/views.py
+++ b/web/guac/views.py
@@ -104,3 +104,115 @@ def index(request, task_id, session_data):
                 conn.close()
             except Exception:
                 pass
+
+
+@conditional_login_required(login_required, settings.WEB_AUTHENTICATION)
+def direct_vnc_host_port(request, host, port):
+    token = uuid.uuid4()
+    try:
+        guac_session = db.create_guac_session(
+            token=token,
+            task_id=0,
+            vm_label=str(port),
+            guest_ip=host,
+        )
+    except Exception as e:
+        return _error(request, 0, f"Failed to create Guacamole session: {e}")
+
+    clean_host = "".join(c for c in host if c.isalnum() or c in ".-_")
+    recording_name = f"direct_{clean_host}_{port}_{str(token)[:8]}"
+
+    response = render(request, "guac/index.html", {
+        "session_id": str(token),
+        "task_id": 0,
+        "recording_name": recording_name,
+        "vnc_host": host,
+        "vnc_port": port,
+    })
+
+    response.set_cookie(
+        "guac_session",
+        str(guac_session.token),
+        httponly=True,
+        secure=request.is_secure(),
+        samesite="Lax",
+        path="/guac/",
+    )
+
+    return response
+
+
+@conditional_login_required(login_required, settings.WEB_AUTHENTICATION)
+def direct_vnc_vm(request, vm_name):
+    if not LIBVIRT_AVAILABLE:
+        return _error(request, 0, "Libvirt not available")
+
+    if machinery not in machinery_available:
+        return _error(request, 0, f"Machinery type '{machinery}' is not supported")
+
+    is_running = False
+    vm_exists = False
+    error_msg = ""
+
+    conn = None
+    try:
+        conn = libvirt.open(machinery_dsn)
+        if conn:
+            try:
+                dom = conn.lookupByName(vm_name)
+                if dom:
+                    vm_exists = True
+                    state = dom.state(flags=0)
+                    is_running = state and state[0] == 1
+            except Exception as e:
+                error_msg = str(e)
+    except Exception as e:
+        error_msg = str(e)
+    finally:
+        if conn:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+    if error_msg and not vm_exists:
+        return _error(request, 0, error_msg)
+
+    if not vm_exists:
+        return _error(request, 0, f"VM {vm_name} not found")
+
+    if not is_running:
+        return render(request, "guac/wait.html", {"task_id": 0})
+
+    token = uuid.uuid4()
+    try:
+        guac_session = db.create_guac_session(
+            token=token,
+            task_id=0,
+            vm_label=vm_name,
+            guest_ip="",
+        )
+    except Exception as e:
+        return _error(request, 0, f"Failed to create Guacamole session: {e}")
+
+    recording_name = f"direct_{vm_name}_{str(token)[:8]}"
+
+    response = render(request, "guac/index.html", {
+        "session_id": str(token),
+        "task_id": 0,
+        "recording_name": recording_name,
+        "vnc_host": vm_name,
+        "vnc_port": "auto",
+    })
+
+    response.set_cookie(
+        "guac_session",
+        str(guac_session.token),
+        httponly=True,
+        secure=request.is_secure(),
+        samesite="Lax",
+        path="/guac/",
+    )
+
+    return response
+

--- a/web/guac/views.py
+++ b/web/guac/views.py
@@ -313,6 +313,148 @@ def bg_revert_and_start(machinery_dsn, vm_name, start_mode, snapshot_name):
             except Exception as routing_err:
                 logger.error(f"Failed to enforce default 'none' route for VM {vm_name}: {routing_err}")
 
+            # Wait for the agent to become available and sync the clock to America/New_York (EST/EDT) zone
+            try:
+                machine = db.view_machine_by_label(vm_name)
+                if machine:
+                    import socket
+                    import time
+                    import requests
+                    import pytz
+                    import datetime
+                    import io
+
+                    ip = machine.ip
+                    port = 8000
+                    agent_ready = False
+                    start_time = time.time()
+                    timeout = 180  # 3 minutes timeout
+
+                    logger.info("Waiting for agent to become available on %s:%d to update guest clock...", ip, port)
+                    while time.time() - start_time < timeout:
+                        # Check if VM is still running
+                        try:
+                            state = dom.state(flags=0)
+                            is_running = state and state[0] == 1
+                            if not is_running:
+                                logger.info("VM '%s' is no longer running. Aborting guest clock update.", vm_name)
+                                break
+                        except Exception:
+                            pass
+
+                        try:
+                            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                            sock.settimeout(2.0)
+                            result = sock.connect_ex((ip, port))
+                            sock.close()
+                            if result == 0:
+                                session = requests.Session()
+                                session.trust_env = False
+                                session.proxies = None
+                                res = session.get(f"http://{ip}:{port}/", timeout=2.0)
+                                if res.status_code == 200:
+                                    agent_ready = True
+                                    break
+                        except Exception:
+                            pass
+                        time.sleep(2.0)
+
+                    if agent_ready:
+                        logger.info("Agent is ready on VM '%s'. Syncing clock...", vm_name)
+                        session = requests.Session()
+                        session.trust_env = False
+                        session.proxies = None
+
+                        # Timezone conversion to EST (America/New_York)
+                        try:
+                            tz = pytz.timezone("America/New_York")
+                            now_est = datetime.datetime.now(tz)
+                        except ImportError:
+                            now_utc = datetime.datetime.utcnow()
+                            if 3 < now_utc.month < 11:
+                                offset = datetime.timedelta(hours=-4)
+                            else:
+                                offset = datetime.timedelta(hours=-5)
+                            tz = datetime.timezone(offset)
+                            now_est = datetime.datetime.now(tz)
+
+                        date_str = now_est.strftime("%Y-%m-%d %H:%M:%S")
+                        platform = (machine.platform or "windows").lower()
+
+                        # Construct guest clock update script
+                        if platform == "windows":
+                            script_content = f"""import ctypes
+import sys
+
+class SYSTEMTIME(ctypes.Structure):
+    _fields_ = [
+        ("wYear", ctypes.c_ushort),
+        ("wMonth", ctypes.c_ushort),
+        ("wDayOfWeek", ctypes.c_ushort),
+        ("wDay", ctypes.c_ushort),
+        ("wHour", ctypes.c_ushort),
+        ("wMinute", ctypes.c_ushort),
+        ("wSecond", ctypes.c_ushort),
+        ("wMilliseconds", ctypes.c_ushort),
+    ]
+
+st = SYSTEMTIME()
+st.wYear = {now_est.year}
+st.wMonth = {now_est.month}
+st.wDay = {now_est.day}
+st.wHour = {now_est.hour}
+st.wMinute = {now_est.minute}
+st.wSecond = {now_est.second}
+st.wMilliseconds = 0
+
+if not ctypes.windll.kernel32.SetLocalTime(ctypes.byref(st)):
+    sys.exit(1)
+"""
+                        else:
+                            script_content = f"""import subprocess
+import sys
+
+res = subprocess.run(["date", "-s", "{date_str}"])
+sys.exit(res.returncode)
+"""
+
+                        # Determine temp path on guest
+                        temp_path = "C:\\Windows\\Temp" if platform == "windows" else "/tmp"
+                        try:
+                            env_res = session.get(f"http://{ip}:{port}/environ", timeout=5.0)
+                            if env_res.status_code == 200:
+                                env_data = env_res.json().get("environ", {})
+                                env_upper = {str(k).upper(): v for k, v in env_data.items()}
+                                if platform == "windows":
+                                    temp_path = env_upper.get("TEMP") or env_upper.get("TMP") or temp_path
+                        except Exception as env_err:
+                            logger.warning(f"Could not query guest environment on VM '{vm_name}': {env_err}")
+
+                        remote_script_path = f"{temp_path}\\set_clock.py" if platform == "windows" else f"{temp_path}/set_clock.py"
+
+                        files = {
+                            "file": ("set_clock.py", io.BytesIO(script_content.encode("utf-8"))),
+                        }
+                        store_res = session.post(f"http://{ip}:{port}/store", files=files, data={"filepath": remote_script_path}, timeout=10.0)
+                        if store_res.status_code == 200:
+                            exec_res = session.post(f"http://{ip}:{port}/execpy", data={"filepath": remote_script_path}, timeout=10.0)
+                            if exec_res.status_code == 200 and exec_res.json().get("status") == "success":
+                                logger.info(f"Successfully updated guest clock for VM '{vm_name}' via /execpy to {date_str} EST")
+                            else:
+                                logger.error(f"Execpy clock sync failed on VM '{vm_name}': {exec_res.text}")
+
+                            try:
+                                session.post(f"http://{ip}:{port}/remove", data={"filepath": remote_script_path}, timeout=5.0)
+                            except Exception:
+                                pass
+                        else:
+                            logger.error(f"Store clock sync script failed on VM '{vm_name}': {store_res.text}")
+                    else:
+                        logger.warning(f"Agent did not become ready within timeout. Skipping clock update for VM '{vm_name}'.")
+
+            except Exception as clock_err:
+                logger.error(f"Error during guest clock update for VM '{vm_name}': {clock_err}")
+
     except Exception as e:
         logger.error(f"Error starting VM {vm_name} in background: {e}")
         try:

--- a/web/guac/views.py
+++ b/web/guac/views.py
@@ -238,7 +238,7 @@ def direct_vnc_vm(request, vm_name):
             session.query(GuacSession).filter_by(vm_label=vm_name).delete()
             session.commit()
         except Exception as e:
-            logger.error(f"Failed to clear stale GuacSession for VM {vm_name}: {e}")
+            logger.error("Failed to clear stale GuacSession for VM %s: %s", vm_name, e)
 
         is_starting = False
         machine = db.view_machine_by_label(vm_name) or db.view_machine(vm_name)
@@ -260,16 +260,16 @@ def direct_vnc_vm(request, vm_name):
                     from lib.cuckoo.core.data.guests import Guest
                     from lib.cuckoo.core.data.task import Task
                     from lib.cuckoo.common.constants import TASK_RUNNING
-                    
+
                     session = db.session()
                     active_task = session.query(Task).filter(
                         Task.machine_id == machine.id,
                         Task.status == TASK_RUNNING
                     ).first()
-                    
+
                     active_guest = session.query(Guest).filter(
                         Guest.label == vm_name,
-                        Guest.shutdown_on == None
+                        Guest.shutdown_on.is_(None)
                     ).first()
                 except Exception as query_err:
                     logger.error("Failed to query active tasks/guests: %s", query_err)
@@ -384,7 +384,7 @@ def bg_revert_and_start(machinery_dsn, vm_name, start_mode, snapshot_name):
                     route_enable("none", None, None, machine, None, None)
                     logger.info("Successfully set default 'none' route for VM '%s'", vm_name)
             except Exception as routing_err:
-                logger.error(f"Failed to enforce default 'none' route for VM {vm_name}: {routing_err}")
+                logger.error("Failed to enforce default 'none' route for VM %s: %s", vm_name, routing_err)
 
             # Wait for the agent to become available and sync the clock to America/New_York (EST/EDT) zone
             try:
@@ -501,7 +501,7 @@ sys.exit(res.returncode)
                                 if platform == "windows":
                                     temp_path = env_upper.get("TEMP") or env_upper.get("TMP") or temp_path
                         except Exception as env_err:
-                            logger.warning(f"Could not query guest environment on VM '{vm_name}': {env_err}")
+                            logger.warning("Could not query guest environment on VM '%s': %s", vm_name, env_err)
 
                         remote_script_path = f"{temp_path}\\set_clock.py" if platform == "windows" else f"{temp_path}/set_clock.py"
 
@@ -512,31 +512,31 @@ sys.exit(res.returncode)
                         if store_res.status_code == 200:
                             exec_res = session.post(f"http://{ip}:{port}/execpy", data={"filepath": remote_script_path}, timeout=10.0)
                             if exec_res.status_code == 200 and exec_res.json().get("status") == "success":
-                                logger.info(f"Successfully updated guest clock for VM '{vm_name}' via /execpy to {date_str} EST")
+                                logger.info("Successfully updated guest clock for VM '%s' via /execpy to %s EST", vm_name, date_str)
                             else:
-                                logger.error(f"Execpy clock sync failed on VM '{vm_name}': {exec_res.text}")
+                                logger.error("Execpy clock sync failed on VM '%s': %s", vm_name, exec_res.text)
 
                             try:
                                 session.post(f"http://{ip}:{port}/remove", data={"filepath": remote_script_path}, timeout=5.0)
                             except Exception:
                                 pass
                         else:
-                            logger.error(f"Store clock sync script failed on VM '{vm_name}': {store_res.text}")
+                            logger.error("Store clock sync script failed on VM '%s': %s", vm_name, store_res.text)
                     else:
-                        logger.warning(f"Agent did not become ready within timeout. Skipping clock update for VM '{vm_name}'.")
+                        logger.warning("Agent did not become ready within timeout. Skipping clock update for VM '%s'.", vm_name)
 
             except Exception as clock_err:
-                logger.error(f"Error during guest clock update for VM '{vm_name}': {clock_err}")
+                logger.error("Error during guest clock update for VM '%s': %s", vm_name, clock_err)
 
     except Exception as e:
-        logger.error(f"Error starting VM {vm_name} in background: {e}")
+        logger.error("Error starting VM %s in background: %s", vm_name, e)
         try:
             machine = db.view_machine_by_label(vm_name)
             if machine:
                 db.unlock_machine(machine)
                 db.session.commit()
         except Exception as db_err:
-            logger.error(f"Failed to unlock machine {vm_name} after background start error: {db_err}")
+            logger.error("Failed to unlock machine %s after background start error: %s", vm_name, db_err)
     finally:
         if conn:
             try:
@@ -587,16 +587,16 @@ def direct_vnc_vm_start(request, vm_name):
                     from lib.cuckoo.core.data.guests import Guest
                     from lib.cuckoo.core.data.task import Task
                     from lib.cuckoo.common.constants import TASK_RUNNING
-                    
+
                     session = db.session()
                     active_task = session.query(Task).filter(
                         Task.machine_id == machine.id,
                         Task.status == TASK_RUNNING
                     ).first()
-                    
+
                     active_guest = session.query(Guest).filter(
                         Guest.label == vm_name,
-                        Guest.shutdown_on == None
+                        Guest.shutdown_on.is_(None)
                     ).first()
                 except Exception:
                     active_task = None
@@ -677,6 +677,7 @@ def direct_vnc_vm_shutdown(request, vm_name):
 
     force = data.get("force", False)
 
+    machine = db.view_machine_by_label(vm_name) or db.view_machine(vm_name)
     conn = None
     try:
         conn = libvirt.open(machinery_dsn)
@@ -702,17 +703,17 @@ def direct_vnc_vm_shutdown(request, vm_name):
             try:
                 from lib.cuckoo.common.config import Config as CapeConfig
                 from utils.router_manager import route_disable
-                
+
                 routing = CapeConfig("routing")
                 vpns_raw = routing.vpn.get("vpns", "")
                 configured_vpns = [v.strip() for v in vpns_raw.split(",") if v.strip()] if vpns_raw else []
-                
+
                 interface, rt_table, reject_segments, reject_hostports = get_route_params(
                     current_route, routing, configured_vpns
                 )
                 route_disable(current_route, interface, rt_table, machine, reject_segments, reject_hostports)
             except Exception as routing_err:
-                logger.error(f"Failed to disable routing for {vm_name} on shutdown: {routing_err}")
+                logger.error("Failed to disable routing for %s on shutdown: %s", vm_name, routing_err)
             finally:
                 request.session.pop(f"route_{vm_name}", None)
 
@@ -739,17 +740,17 @@ def get_route_params(route_name, routing, configured_vpns):
     elif route_name == "internet":
         interface = routing.routing.get("internet", "none")
         rt_table = routing.routing.get("rt_table", "main")
-        
+
         reject_segments = routing.routing.get("reject_segments", "none")
         if reject_segments == "none":
             reject_segments = None
-            
+
         reject_hostports = routing.routing.get("reject_hostports", "none")
         if reject_hostports == "none":
             reject_hostports = None
         else:
             reject_hostports = str(reject_hostports)
-            
+
         return interface, rt_table, reject_segments, reject_hostports
     elif route_name in configured_vpns:
         vpn = routing.get(route_name)
@@ -835,7 +836,7 @@ def direct_vnc_vm_route(request, vm_name):
         return JsonResponse({"status": "success", "current_route": target_route})
 
     except Exception as e:
-        logger.error(f"direct_vnc_vm_route: Failed to change route for VM {vm_name} to {target_route}: {e}")
+        logger.error("direct_vnc_vm_route: Failed to change route for VM %s to %s: %s", vm_name, target_route, e)
         return JsonResponse({
             "status": "error",
             "message": str(e),

--- a/web/guac/views.py
+++ b/web/guac/views.py
@@ -538,6 +538,10 @@ sys.exit(res.returncode)
         except Exception as db_err:
             logger.error("Failed to unlock machine %s after background start error: %s", vm_name, db_err)
     finally:
+        try:
+            db.session.remove()
+        except Exception as db_remove_err:
+            logger.error("Failed to clean up db session in background thread: %s", db_remove_err)
         if conn:
             try:
                 conn.close()
@@ -929,6 +933,10 @@ def direct_vnc_vm_snapshot_create(request, vm_name):
     if not snapshot_name:
         return JsonResponse({"status": "error", "message": "Snapshot name is required"}, status=400)
 
+    import re
+    if not re.match(r"^[a-zA-Z0-9_-]+$", snapshot_name):
+        return JsonResponse({"status": "error", "message": "Invalid snapshot name. Only alphanumeric characters, dashes, and underscores are allowed."}, status=400)
+
     conn = None
     try:
         conn = libvirt.open(machinery_dsn)
@@ -951,10 +959,14 @@ def direct_vnc_vm_snapshot_create(request, vm_name):
         except libvirt.libvirtError:
             pass
 
-        xml = f"""<domainsnapshot>
-  <name>{snapshot_name}</name>
-  <description>{description}</description>
-</domainsnapshot>"""
+        import xml.etree.ElementTree as ET
+        root = ET.Element("domainsnapshot")
+        name_elem = ET.SubElement(root, "name")
+        name_elem.text = snapshot_name
+        if description:
+            desc_elem = ET.SubElement(root, "description")
+            desc_elem.text = description
+        xml = ET.tostring(root, encoding="utf-8").decode("utf-8")
 
         flags = 0
         if hasattr(libvirt, "VIR_DOMAIN_SNAPSHOT_CREATE_ATOMIC"):
@@ -1007,6 +1019,10 @@ def direct_vnc_vm_snapshot_delete(request, vm_name):
     snapshot_name = data.get("name")
     if not snapshot_name:
         return JsonResponse({"status": "error", "message": "Snapshot name is required to delete"}, status=400)
+
+    import re
+    if not re.match(r"^[a-zA-Z0-9_-]+$", snapshot_name):
+        return JsonResponse({"status": "error", "message": "Invalid snapshot name. Only alphanumeric characters, dashes, and underscores are allowed."}, status=400)
 
     conn = None
     try:

--- a/web/static/css/guac-main.css
+++ b/web/static/css/guac-main.css
@@ -42,3 +42,8 @@ html, body {
     box-shadow: 0 0 30px rgba(220, 53, 69, 0.3);
     color: #fff;
 }
+
+.no-close .ui-dialog-titlebar {
+    display: none !important;
+}
+

--- a/web/templates/header.html
+++ b/web/templates/header.html
@@ -42,6 +42,20 @@
               </div>
             </li>
             {% endif %}
+            {% if vnc_console_enabled %}
+            <li class="nav-item dropdown">
+              <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownVNC" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fas fa-desktop me-1"></i> VNC Console</a>
+              <div class="dropdown-menu dropdown-menu-end bg-dark border-secondary" aria-labelledby="navbarDropdownVNC">
+                {% if vnc_console_machines %}
+                  {% for machine_label in vnc_console_machines %}
+                    <a class="dropdown-item text-light" href="{% url 'direct_vnc_vm' machine_label %}"{% if vnc_console_new_tab %} target="_blank"{% endif %}><i class="fas fa-terminal me-2 text-white-50"></i> {{ machine_label }}</a>
+                  {% endfor %}
+                {% else %}
+                  <span class="dropdown-item text-muted small">No machines configured</span>
+                {% endif %}
+              </div>
+            </li>
+            {% endif %}
             <li class="nav-item"><a class="nav-link" href="https://capev2.readthedocs.io/en/latest/" target="_blank"><i class="fas fa-info-circle me-1"></i> Docs</a></li>
             <li class="nav-item"><a class="nav-link" href="https://github.com/kevoreilly/CAPEv2/blob/master/changelog.md" target="_blank"><i class="far fa-newspaper me-1"></i> Changelog</a></li>
            <li class="nav-item">

--- a/web/templates/header.html
+++ b/web/templates/header.html
@@ -12,6 +12,7 @@
           <ul class="navbar-nav">
             <li class="nav-item"><a class="nav-link" href="{% url "dashboard" %}"><i class="fas fa-tachometer-alt me-1"></i> Dashboard</a></li>
             <li class="nav-item"><a class="nav-link" href="{% url "analysis" %}"><i class="fas fa-list me-1"></i> Recent</a></li>
+            <li class="nav-item"><a class="nav-link" href="{% url "submission" %}"><i class="fas fa-upload me-1"></i> Submit</a></li>
             <li class="nav-item"><a class="nav-link" href="{% url "pending" %}"><i class="fas fa-clock me-1"></i> Pending</a></li>
             <li class="nav-item"><a class="nav-link" href="{% url "search" %}"><i class="fas fa-search me-1"></i> Search</a></li>
             {% if settings.HUNT_ENABLED %}

--- a/web/web/guac_settings.py
+++ b/web/web/guac_settings.py
@@ -41,6 +41,20 @@ LOGGING_CONFIG = None
 
 WEB_AUTHENTICATION = getattr(Config("web"), "web_auth", {}).get("enabled", False)
 
+web_cfg = Config("web")
+csfr_list = []
+if web_cfg.security.csrf_trusted_origins:
+    for host in web_cfg.security.csrf_trusted_origins.split(","):
+        host = host.strip()
+        if not host:
+            continue
+        if host.startswith(("http://", "https://")):
+            csfr_list.append(host)
+        else:
+            csfr_list.extend([f"http://{host}", f"https://{host}"])
+
+CSRF_TRUSTED_ORIGINS = csfr_list
+
 ALLOWED_HOSTS = [
     "*",
 ]

--- a/web/web/guac_settings.py
+++ b/web/web/guac_settings.py
@@ -5,6 +5,9 @@ from pathlib import Path
 
 from django.utils.log import DEFAULT_LOGGING
 
+from lib.cuckoo.common.config import Config as _CapeConfig
+from lib.cuckoo.core.database import init_database
+
 CUCKOO_PATH = os.path.join(Path.cwd(), "..")
 sys.path.append(CUCKOO_PATH)
 
@@ -169,13 +172,11 @@ logging.config.dictConfig(
     }
 )
 
-from lib.cuckoo.core.database import init_database
-from lib.cuckoo.common.config import Config as _CapeConfig
 
 _db = init_database(exists_ok=True)
 
 # Create guac_sessions table if guacamole is enabled
-if _CapeConfig('web').guacamole.get('enabled', False):
+if _CapeConfig('web').guacamole.get('vnc_console_enable', False):
     from lib.cuckoo.core.data.guac_session import GuacSession  # noqa: F401
     from lib.cuckoo.core.data.db_common import Base
     Base.metadata.create_all(_db.engine)

--- a/web/web/guac_settings.py
+++ b/web/web/guac_settings.py
@@ -176,7 +176,7 @@ logging.config.dictConfig(
 _db = init_database(exists_ok=True)
 
 # Create guac_sessions table if guacamole is enabled
-if _CapeConfig('web').guacamole.get('vnc_console_enable', False):
+if _CapeConfig("web").guacamole.get("vnc_console_enabled", False):
     from lib.cuckoo.core.data.guac_session import GuacSession  # noqa: F401
     from lib.cuckoo.core.data.db_common import Base
     Base.metadata.create_all(_db.engine)

--- a/web/web/middleware/db_transaction.py
+++ b/web/web/middleware/db_transaction.py
@@ -7,7 +7,13 @@ class DBTransactionMiddleware:
 
     def __call__(self, request):
         db = Database()
-        with db.session.begin():
+        session = db.session()
+        try:
             resp = self.get_response(request)
-        db.session.remove()
+            session.commit()
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            db.session.remove()
         return resp

--- a/web/web/settings.py
+++ b/web/web/settings.py
@@ -197,6 +197,7 @@ TEMPLATES = [
                 "django_settings_export.settings_export",
                 # Surfaces `may_manage_apikeys` for the API Keys link in the user dropdown.
                 "apikey.context_processors.apikey_access",
+                "guac.context_processors.guac_vnc_console",
             ],
             "loaders": [
                 "django.template.loaders.filesystem.Loader",


### PR DESCRIPTION
## Summary
This Pull Request introduces **Direct VNC Hypervisor Console** support to CAPEv2, enabling administrators and analysts to directly interact with virtual machine guests live via the web interface. By integrating Apache Guacamole (`guacd` + WebSockets) and `libvirt`, users can stream the VM's console, control VM power states (start/shutdown), manage XML-based snapshots (list, create, delete, and revert), and configure dynamic network routing (VPNs) directly from their browser.

---

## Key Features

1. **Live VNC Guest Console:**
   * High-performance console stream powered by an ASGI-based `GuacamoleWebSocketConsumer` connecting directly to local `guacd` processes.
   * Dynamic resolution resizing and local cursor handling.
   * Auto-discovery of guest VNC ports from `libvirt` xml dumps.

2. **VM Power Control & Lifecycle Management:**
   * Buttons to start, shut down, or force off VMs directly from the console views.
   * Spawns non-blocking background workers `bg_revert_and_start` to handle hypervisor operations asynchronously.
   * Active WebSocket monitoring `monitor_vm_status` that locks the VM guest in the Cuckoo database during interactive sessions to prevent job execution conflicts, and auto-unlocks/disconnects when the guest goes offline.

3. **Integrated Snapshot Manager:**
   * Fetch, list, create, and delete hypervisor snapshots directly from the UI.
   * Keep the CAPEv2 database machine state synchronized when creating or deleting snapshots.

4. **Dynamic Network Routing:**
   * Select and apply dynamic VPN or internet route configurations to target guests before starting VNC sessions.

5. **Integrated Navigation & UI:**
   * Added a "VNC Console" dropdown list to the main navigation header (`header.html`) utilizing a custom Django template context processor `guac_vnc_console`.
   * Premium styled dark UI views:
     * Interactive console interface: `web/guac/templates/guac/index.html`
     * Power states overlays: `start.html`, `wait.html`, and `warn.html`

---

## Architecture & Implementation Details

* **Database Transaction Middleware:**
  * Refactored `DBTransactionMiddleware` to replace block-level transactional scoping (`with db.session.begin()`) with an explicit try-except-finally `commit`/`rollback` strategy. This ensures multi-thread/async operations during libvirt events don't lock database session lifecycles.
* **WebSocket Port Auto-Discovery:**
  * Auto-discovers VNC ports using XML parsing for the specified virtual machine rather than requiring hardcoded mappings.
* **URL Router Modifications:**
  * Added dedicated endpoints under `web/guac/urls.py` and expanded the channels websocket path regex in `routing.py` to support UUID-style tokens.

---

## Configuration Settings Added
The following settings have been introduced in the `[guacamole]` section of `conf/default/web.conf.default`:
* `vnc_console_enabled`: (boolean) Toggle the visibility of the VNC Console dropdown in the navigation menu.
* `vnc_console_new_tab`: (boolean) Toggle whether VNC Console sessions open in a new tab.

---

## Files Touched
* **Configuration:** `conf/default/web.conf.default`
* **Web UI Templates:**
  * `web/templates/header.html`
  * `web/guac/templates/guac/index.html`
  * `web/guac/templates/guac/start.html`
  * `web/guac/templates/guac/wait.html`
  * `web/guac/templates/guac/warn.html`
* **Django & Channels Logic:**
  * `web/guac/consumers.py`
  * `web/guac/context_processors.py`
  * `web/guac/routing.py`
  * `web/guac/urls.py`
  * `web/guac/views.py`
* **Settings & Middleware:**
  * `web/web/guac_settings.py`
  * `web/web/middleware/db_transaction.py`
  * `web/web/settings.py`
* **Assets:** `web/static/css/guac-main.css`
