### PR TITLE
fix: remove unreachable return after parser.error()

### DIFF
--- a/utils/submit.py
+++ b/utils/submit.py
@@ -201,7 +201,7 @@ def main() -> Optional[bool]:
     try:
         args = parser.parse_args()
     except IOError as e:
-        parser.error(e)
+        print(f"Error: {e}", file=sys.stderr)
         return False
 
     # If the quiet flag has been set, then we also disable the "warning"

--- a/utils/submit.py
+++ b/utils/submit.py
@@ -201,8 +201,7 @@ def main() -> Optional[bool]:
     try:
         args = parser.parse_args()
     except IOError as e:
-        print(f"Error: {e}", file=sys.stderr)
-        return False
+        parser.error(str(e))
 
     # If the quiet flag has been set, then we also disable the "warning"
     # level of the logging module. (E.g., when pydeep has not been installed,


### PR DESCRIPTION
ArgumentParser.error() raises SystemExit, so execution never reaches the subsequent return False statement. This removes the unreachable code.