### PR TITLE
resultserver: spawn (not fork) the multiworker per-VM worker processes

### DIFF
--- a/lib/cuckoo/core/resultserver.py
+++ b/lib/cuckoo/core/resultserver.py
@@ -695,7 +695,19 @@ class SingleVMResultServerWorker(GeventResultServerWorker):
             task_log_stop_force(task_id)
 
 
-class ResultServerWorkerProcess(multiprocessing.Process):
+# Use a SPAWN context (not the default fork) for the per-VM ResultServer worker
+# processes. cape monkey-patches threading with gevent, and gevent's Thread lacks
+# CPython's _reset_internal_locks; forking a running gevent-patched process makes
+# threading._after_fork raise AttributeError on every live aux Thread (Mitmdump,
+# QEMUScreenshots, ...) in the child, leaving locks unreset -> intermittent
+# deadlocks (e.g. a later sniffer subprocess fork wedging an analysis). spawn
+# starts a fresh interpreter with NO inherited threads, so _after_fork never runs
+# on them. (2026-07-02: a 12-job multiworker load test wedged a task and logged
+# _after_fork AttributeErrors for Mitmdump + QEMUScreenshots.)
+_rs_spawn_ctx = multiprocessing.get_context("spawn")
+
+
+class ResultServerWorkerProcess(_rs_spawn_ctx.Process):
     """Dedicated ResultServer process for a single VM.
 
     Each worker runs its own gevent event loop and StreamServer,
@@ -709,8 +721,10 @@ class ResultServerWorkerProcess(multiprocessing.Process):
         self.ip = ip
         self.port = port
         self.listen_ip = listen_ip
-        self._task_id = multiprocessing.Value("i", 0)
-        self._ready = multiprocessing.Event()
+        # Value/Event must come from the same spawn context as the Process so they
+        # are shared correctly across the spawn boundary (pickled into the child).
+        self._task_id = _rs_spawn_ctx.Value("i", 0)
+        self._ready = _rs_spawn_ctx.Event()
 
     def run(self):
         """Entry point for the worker process. Sets up a standalone


### PR DESCRIPTION
## Problem

In multiworker ResultServer mode (`[resultserver] multiworker = yes`), each per-VM worker is launched via `multiprocessing.Process`, which defaults to the **fork** start method on Linux.

CAPE monkey-patches `threading` with gevent at startup, and gevent's `Thread` does not implement CPython's `Thread._reset_internal_locks`. When a process that has live gevent-patched threads (e.g. the Mitmdump and QEMUScreenshots auxiliary threads) forks, CPython's `threading._after_fork` runs in the child and calls `_reset_internal_locks` on every enumerated `Thread`, raising `AttributeError` on each gevent Thread. The affected locks are left unreset in the child, which intermittently deadlocks — e.g. a later sniffer-subprocess fork wedges the analysis and the task never completes.

## Fix

Create the per-VM worker processes (and their shared `Value`/`Event`) from a `multiprocessing.get_context("spawn")` context. `spawn` starts a fresh interpreter with **no inherited threads**, so `threading._after_fork` never runs against the gevent Threads and the locks-unreset deadlock cannot occur. The `Value`/`Event` are created from the same spawn context so they marshal correctly across the spawn boundary.

## Testing

A 12-job concurrent multiworker load test (10 VMs) reproduced the wedge and logged `_after_fork` `AttributeError`s for Mitmdump + QEMUScreenshots under fork. With the spawn context: all 12 tasks complete and report, no `_after_fork` errors are logged, and there is one ResultServer worker process per VM (one listener per per-VM port) as expected.
