### PR TITLE
rooter: generic next-hop egress routing primitive (opt-in, fail-closed)

### DIFF
--- a/conf/default/routing.conf.default
+++ b/conf/default/routing.conf.default
@@ -132,6 +132,36 @@ interface = tun0
 rt_table = tun0
 
 
+[nexthop]
+# Decoupled next-hop egress to a shared gateway pool. Default OFF (no-regress).
+enabled = no
+# Comma list of [gwX] profile ids to load.
+gateways = gw1
+# Selection used when a task resolves to the pool: roundrobin | random | <gwX id>. Set
+# [routing] route = nexthop (the pool sentinel) as the node default so tasks that DON'T name a route
+# use this. A task may also name a route directly -- a <gwX id>, roundrobin, random, or nexthop --
+# from the web submission UI route selector (which lists the nexthop pool + each configured [gwX])
+# or via API/CLI/broker submissions. (Advertising nexthop routes across a distributed multi-node
+# CAPE via the exitnodes API is a separate follow-up.)
+default_policy = roundrobin
+# Drop guest egress when no live gateway (strongly recommended yes).
+fail_closed = yes
+# Whole guest subnet the blackhole covers (CIDR). MUST match the libvirt guest net.
+vm_net = 192.168.100.0/24
+
+[gw1]
+# Interface that reaches the gateway network (provided by the deployment).
+interface = ens6
+# Next-hop gateway IP reachable via `interface`, or 'onlink'.
+next_hop = onlink
+# Dedicated policy routing table id for this gateway. MUST be unique across the WHOLE system:
+# not a reserved table (main/local/default/253-255/0), not another [gwX]'s table, not a VPN's
+# rt_table, and not the [routing] dirty-line rt_table -- startup rejects those it can see. Note a
+# name<->id alias counts as the same table (e.g. do NOT use 201 here if a VPN uses a name mapped to
+# 201 in /etc/iproute2/rt_tables); keeping gateway tables to their own numeric range avoids this.
+rt_table = 201
+description = vpn-router-1
+
 [socks5]
 # By default we disable socks5 support as it requires running utils/rooter.py as
 # root next to cuckoo.py (which should run as regular user).

--- a/cuckoo.py
+++ b/cuckoo.py
@@ -84,7 +84,7 @@ def cuckoo_init(quiet=False, debug=False, artwork=False, test=False):
     with Database().session.begin():
         init_tasks()
     init_rooter()
-    init_routing()
+    init_routing(apply_nexthop_state=True)  # scheduler owns the nexthop sweep/build/arm (codex P2)
     check_tcpdump_permissions()
 
     # This is just a temporary hack, we need an actual test suite to integrate with Travis-CI.

--- a/cuckoo.py
+++ b/cuckoo.py
@@ -83,7 +83,7 @@ def cuckoo_init(quiet=False, debug=False, artwork=False, test=False):
     init_modules()
     with Database().session.begin():
         init_tasks()
-    init_rooter()
+    init_rooter(apply_state=True)  # scheduler owns the rooter state reset (codex P1)
     init_routing(apply_nexthop_state=True)  # scheduler owns the nexthop sweep/build/arm (codex P2)
     check_tcpdump_permissions()
 

--- a/lib/cuckoo/core/analysis_manager.py
+++ b/lib/cuckoo/core/analysis_manager.py
@@ -559,6 +559,10 @@ class AnalysisManager(threading.Thread):
         """
         self.interface = None  # nexthop owns enable/disable; skip the generic block
         self.rt_table = None
+        # Clear any binding a PRIOR resolve left, so a failure path here (route -> "drop") cannot
+        # leave a stale self.nexthop_* that _dispatch_nexthop would still install -- fail-open on
+        # route_network re-entry / machine retry (Copilot).
+        self.nexthop_id = self.nexthop_interface = self.nexthop_rt_table = self.nexthop_priority = None
         # Resolve the selector, FAILING CLOSED on a typo'd/unknown route (review B1 + gemini #14):
         #  - an explicit gateway id, or a policy token (roundrobin/random), selects directly;
         #  - ONLY the node's configured DEFAULT route falls back to default_policy;

--- a/lib/cuckoo/core/analysis_manager.py
+++ b/lib/cuckoo/core/analysis_manager.py
@@ -29,7 +29,7 @@ from lib.cuckoo.core.guest import GuestManager
 from lib.cuckoo.core.machinery_manager import MachineryManager
 from lib.cuckoo.core.plugins import RunAuxiliary
 from lib.cuckoo.core.resultserver import ResultServer
-from lib.cuckoo.core.rooter import _load_socks5_operational, rooter, vpns
+from lib.cuckoo.core.rooter import _load_socks5_operational, _select_gateway, gateways, rooter, vpns
 
 log = logging.getLogger(__name__)
 
@@ -51,6 +51,11 @@ def is_network_interface(intf: str):
     global network_interfaces
     network_interfaces = list(psutil.net_if_addrs().keys())
     return intf in network_interfaces
+
+
+def _nexthop_enabled(routing):
+    """True when the [nexthop] section exists and is enabled (review M4 hasattr guard)."""
+    return hasattr(routing, "nexthop") and routing.nexthop.enabled
 
 
 class CuckooDeadMachine(Exception):
@@ -134,6 +139,11 @@ class AnalysisManager(threading.Thread):
         self.reject_segments = None
         self.reject_hostports = None
         self.no_local_routing = None
+        # per-task [nexthop] binding (None unless this task is bound to a gateway profile)
+        self.nexthop_id = None
+        self.nexthop_interface = None
+        self.nexthop_rt_table = None
+        self.nexthop_priority = None
 
     @main_thread_only
     def prepare_task_and_machine_to_start(self) -> None:
@@ -536,6 +546,85 @@ class AnalysisManager(threading.Thread):
         if self.rooter_response and self.rooter_response["exception"] is not None:
             raise CuckooCriticalError(f"Error execution rooter command: {self.rooter_response['exception']}")
 
+    def _resolve_nexthop(self, routing):
+        """Resolve self.route to a LIVE gateway profile and bind this task to it.
+
+        Returns True if it OWNS the route (bound a profile); False if the id is
+        unresolved/typo'd or the pool is empty/all-down, in which case it forces
+        self.route="drop" so the existing none/drop/false dispatch drops the VM
+        (review B1: never fall through to host default forwarding).
+
+        Always sets self.interface = None and self.rt_table = None so the generic
+        forward/srcroute block is skipped (review H2 option b) regardless of outcome.
+        """
+        self.interface = None  # nexthop owns enable/disable; skip the generic block
+        self.rt_table = None
+        # Resolve the selector, FAILING CLOSED on a typo'd/unknown route (review B1 + gemini #14):
+        #  - an explicit gateway id, or a policy token (roundrobin/random), selects directly;
+        #  - ONLY the node's configured DEFAULT route falls back to default_policy;
+        #  - anything else (a typo'd/unconfigured id like "gw9"/"vpn9") DROPS rather than
+        #    silently egressing via some live gateway (that would be an isolation-boundary bypass).
+        # A reserved route (none/drop/false/internet/tor/inetsim) must NEVER resolve to a gateway
+        # even if it is the configured default — those are owned by earlier route_network branches;
+        # reaching here with one means drop, not gateway (gemini #15 security-critical).
+        if self.route in ("none", "drop", "false", "internet", "tor", "inetsim"):
+            self.route = "drop"
+            return False
+        if self.route in gateways or self.route in ("roundrobin", "random"):
+            sel = self.route
+        elif self.route == "nexthop" or self.route == routing.routing.route:
+            # the "nexthop" sentinel (explicit) OR the node's configured default route falls back
+            # to default_policy and picks from the live pool. "nexthop" is a reserved token (a
+            # [gwX] may not be named it), so this is not the gemini-#15 typo'd-route leak.
+            sel = routing.nexthop.default_policy
+        else:
+            self.route = "drop"
+            return False
+        profile = _select_gateway(sel)
+        if profile is None:
+            # empty/all-down pool => FAIL CLOSED (review B1)
+            self.route = "drop"
+            return False
+        self.nexthop_id = profile.name
+        self.nexthop_interface = str(profile.interface)
+        self.nexthop_rt_table = str(profile.rt_table)
+        # deterministic per-task priority: 10000 + last octet of the VM IP (review M6).
+        # Unique within one guest /24 (the shipped vm_net); across multiple /24s two VMs
+        # could share a priority number but keep distinct `from <vm_ip>` selectors, so no
+        # leak — teardown's by-priority band sweep still clears them all.
+        self.nexthop_priority = str(10000 + int(self.machine.ip.rsplit(".", 1)[1]))
+        return True
+
+    def _dispatch_nexthop(self):
+        """Issue the per-task nexthop bind (source rule + SNAT). No-op unless this
+        task is bound to a gateway profile. Every rooter arg is str() (review B3)."""
+        if not self.nexthop_id:
+            return
+        self.rooter_response = rooter(
+            "nexthop_enable",
+            str(self.machine.ip),
+            str(self.machine.interface),   # guest ingress bridge -- constrains forwarding (anti-spoof)
+            self.nexthop_interface,
+            self.nexthop_rt_table,
+            self.nexthop_priority,
+        )
+        self._rooter_response_check()
+
+    def _unroute_nexthop(self):
+        """Mirror-teardown the per-task bind with the PERSISTED self.nexthop_* tuple;
+        never re-run the selector (review M5). No-op unless bound to a gateway."""
+        if not self.nexthop_id:
+            return
+        self.rooter_response = rooter(
+            "nexthop_disable",
+            str(self.machine.ip),
+            str(self.machine.interface),   # mirror the ingress bridge enable used (persisted machine)
+            self.nexthop_interface,
+            self.nexthop_rt_table,
+            self.nexthop_priority,
+        )
+        self._rooter_response_check()
+
     def route_network(self):
         """Enable network routing if desired."""
         # Determine the desired routing strategy (none, internet, VPN).
@@ -566,8 +655,19 @@ class AnalysisManager(threading.Thread):
         elif self.route in self.socks5s:
             self.interface = ""
         elif self.route[:3] == "tun" and is_network_interface(self.route):
-            # tunnel interface starts with "tun" and interface exists on machine
+            # tunnel interface starts with "tun" and interface exists on machine. Checked BEFORE
+            # the nexthop branch: _resolve_nexthop rewrites self.route="drop" for any route it does
+            # not own, which would otherwise clobber an explicit tunX route into a drop when
+            # [nexthop] is enabled (Copilot). Legacy explicit routes win over nexthop resolution.
             self.interface = self.route
+        elif _nexthop_enabled(routing):
+            # When [nexthop] is enabled it OWNS every route not claimed by a legacy branch above:
+            # it binds a gateway profile (setting self.nexthop_* and self.interface=None so the
+            # generic forward/srcroute block is skipped) or, for an unresolved/typo'd id, forces
+            # self.route="drop". Consuming the route here (rather than an `and`-guarded `pass`)
+            # means a nexthop-dropped task falls into the none/drop/false dispatch below and fails
+            # closed cleanly, instead of the misleading "Unknown ... ignoring routing" else (Copilot).
+            self._resolve_nexthop(routing)
         else:
             self.log.warning("Unknown network routing destination specified, ignoring routing for this analysis: %s", self.route)
             self.interface = None
@@ -621,6 +721,10 @@ class AnalysisManager(threading.Thread):
             self.rooter_response = rooter("interface_route_tun_enable", self.machine.ip, self.route, str(self.task.id))
 
         self._rooter_response_check()
+
+        # nexthop bind (self.interface is None for a gateway route, so the generic
+        # block below is skipped; this issues the per-task source rule + SNAT).
+        self._dispatch_nexthop()
 
         # check if the interface is up
         if HAVE_NETWORKIFACES and routing.routing.verify_interface and self.interface and self.interface not in network_interfaces:
@@ -756,6 +860,10 @@ class AnalysisManager(threading.Thread):
         elif self.route[:3] == "tun":
             self.log.info("Disable tunnel interface: %s", self.interface)
             self.rooter_response = rooter("interface_route_tun_disable", self.machine.ip, self.route, str(self.task.id))
+
+        # nexthop teardown with the PERSISTED tuple (the generic disable block above
+        # was skipped because self.interface is None). No-op unless bound (review M5).
+        self._unroute_nexthop()
 
         self._rooter_response_check()
 

--- a/lib/cuckoo/core/rooter.py
+++ b/lib/cuckoo/core/rooter.py
@@ -67,9 +67,11 @@ def rooter(command, *args, **kwargs):
 
 
 def _gw_live(profile):
-    """True if the profile's egress interface exists and is up. Delegates to the rooter
-    nic_available check; overridable in tests."""
-    resp = rooter("nic_available", str(profile.interface))
+    """True if the profile's egress interface exists AND is administratively up. A down gateway NIC
+    must not be selected -- round-robin/random would otherwise bind a task to a dead exit. Delegates
+    to the rooter nic_up check (nic_available only proves existence, incl. DOWN links); overridable
+    in tests."""
+    resp = rooter("nic_up", str(profile.interface))
     return bool(resp and resp.get("output"))
 
 

--- a/lib/cuckoo/core/rooter.py
+++ b/lib/cuckoo/core/rooter.py
@@ -4,6 +4,8 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 import logging
+import random
+import threading
 from contextlib import suppress
 
 from lib.cuckoo.common.config import Config
@@ -15,6 +17,9 @@ log = logging.getLogger(__name__)
 
 vpns = {}
 socks5s = {}
+gateways = {}            # profile-id -> profile object (.name/.interface/.rt_table/.priority)
+_gw_cursor = 0           # process-global round-robin cursor
+_gw_lock = threading.Lock()
 
 
 def _load_socks5_operational():
@@ -59,3 +64,35 @@ def rooter(command, *args, **kwargs):
     if ret and ret.get("exception"):
         log.warning("Rooter returned error: %s", ret["exception"])
     return ret
+
+
+def _gw_live(profile):
+    """True if the profile's egress interface exists and is up. Delegates to the rooter
+    nic_available check; overridable in tests."""
+    resp = rooter("nic_available", str(profile.interface))
+    return bool(resp and resp.get("output"))
+
+
+def _select_gateway(route):
+    """Resolve a task route to a LIVE gateway profile, or None (=> caller fails closed).
+    route: an explicit profile id, or a default_policy token 'roundrobin'/'random'."""
+    global _gw_cursor
+    if not gateways:
+        return None
+    if route in gateways:
+        p = gateways[route]
+        return p if _gw_live(p) else None
+    live = [gateways[k] for k in gateways if _gw_live(gateways[k])]
+    if not live:
+        return None
+    if route == "random":
+        return random.choice(live)
+    if route != "roundrobin":
+        # not a gateway id, not 'random', not 'roundrobin' => unknown selector, FAIL CLOSED
+        # rather than silently treating it as roundrobin (gemini #15).
+        return None
+    # roundrobin: advance the process-global cursor under the lock
+    with _gw_lock:
+        p = live[_gw_cursor % len(live)]
+        _gw_cursor += 1
+    return p

--- a/lib/cuckoo/core/startup.py
+++ b/lib/cuckoo/core/startup.py
@@ -640,9 +640,14 @@ def check_snapshot_state():
             conn.close()
 
 
-def init_rooter():
-    """If required, check whether the rooter is running and whether we can
-    connect to it."""
+def init_rooter(apply_state=False):
+    """If required, check whether the rooter is running and whether we can connect to it.
+
+    apply_state: only the SCHEDULER (cuckoo.py) passes True, to RESET rooter state at its startup
+    (cleanup_rooter / cleanup_vrf / forward_drop / state_*). The web/API process and vpncheck verify
+    the rooter is reachable but must leave it False -- running cleanup_rooter cross-process would
+    remove the live per-task nexthop (and VPN) iptables rules of analyses owned by the scheduler
+    (codex P1). Reachability is still checked for all callers (fail-fast if the rooter is required)."""
 
     # The default configuration doesn't require the rooter to be ran.
     # A nexthop-only node still needs the rooter for forward_drop() + fail-closed arm.
@@ -691,6 +696,12 @@ def init_rooter():
             )
 
         raise CuckooStartupError(f"Unknown rooter error: {e}")
+
+    if not apply_state:
+        # Reachability verified above; do NOT reset rooter state. cleanup_rooter/forward_drop/state_*
+        # would tear down the scheduler's live per-task nexthop (and VPN) rules on a web/API/gunicorn
+        # restart (codex P1). Only the scheduler (init_rooter(apply_state=True)) owns that reset.
+        return
 
     rooter("cleanup_rooter")
     rooter("cleanup_vrf", routing.routing.internet)

--- a/lib/cuckoo/core/startup.py
+++ b/lib/cuckoo/core/startup.py
@@ -89,10 +89,13 @@ _POLICY_TOKENS = ("roundrobin", "random")
 _RESERVED_RT_TABLES = ("local", "main", "default", "0", "253", "254", "255")
 
 
-def load_nexthop_profiles(routing_cfg):
-    """Parse [nexthop]/[gwX] sections into the rooter.gateways global, sweep stale
-    policy-routing state, then arm fail-closed.  No-op when [nexthop] is absent
-    or disabled (review M4 hasattr guard)."""
+def load_nexthop_profiles(routing_cfg, apply_rooter_state=False):
+    """Parse [nexthop]/[gwX] sections into the rooter.gateways global and validate them. When
+    apply_rooter_state is True (ONLY the scheduler's init_routing passes this), ALSO sweep stale
+    policy-routing state and build the gateway tables + arm fail-closed. Non-owning callers (the
+    web/API process via web.settings, and vpncheck) leave it False: they must NOT issue the rooter
+    sweep, which flushes the 10000-10255 per-task band and would tear down the egress/fail-closed of
+    analyses currently running under the scheduler (codex P2). No-op when [nexthop] absent/disabled."""
     if not hasattr(routing_cfg, "nexthop") or not routing_cfg.nexthop.enabled:
         return
     # [nexthop] is enabled: it MUST define gateways + vm_net (gemini #14 MEDIUM). CAPE's config
@@ -210,6 +213,11 @@ def load_nexthop_profiles(routing_cfg):
             f"[nexthop] default_policy '{default_policy}' must be 'roundrobin', 'random', or a configured "
             f"gateway id ({', '.join(sorted(gateway_ids))})"
         )
+    if not apply_rooter_state:
+        # Parsed + validated + gateways populated; skip ALL rooter mutations. Only the scheduler
+        # (cuckoo.py -> init_routing(apply_nexthop_state=True)) owns the sweep/build/arm -- doing it
+        # from the web/API startup would flush the per-task band and drop live analyses (codex P2).
+        return
     vm_net = str(routing_cfg.nexthop.vm_net)
     tables_csv = ",".join(p.rt_table for p in profiles)
     # Record sweep state for SIGTERM, then sweep any STALE state from a prior run
@@ -720,8 +728,12 @@ def init_rooter():
 
 
 
-def init_routing():
-    """Initialize and check whether the routing information is correct."""
+def init_routing(apply_nexthop_state=False):
+    """Initialize and check whether the routing information is correct.
+
+    apply_nexthop_state: only the SCHEDULER (cuckoo.py) passes True, to sweep+build+arm the nexthop
+    rooter state. The web/API process and vpncheck call this to populate vpns/socks5s/gateways and
+    validate config, but must leave it False so they don't tear down live analyses (codex P2)."""
 
     # Check whether all VPNs exist if configured and make their configuration
     # available through the vpns variable. Also enable NAT on each interface.
@@ -764,8 +776,9 @@ def init_routing():
                 rooter("flush_rttable", entry.rt_table)
                 rooter("init_rttable", entry.rt_table, entry.interface)
 
-    # Load [gwX] next-hop egress profiles, arm fail-closed (no-op when [nexthop] absent/disabled).
-    load_nexthop_profiles(routing)
+    # Load [gwX] next-hop egress profiles; apply rooter state (sweep/build/arm) only for the scheduler
+    # (no-op when [nexthop] absent/disabled).
+    load_nexthop_profiles(routing, apply_rooter_state=apply_nexthop_state)
 
     # If we are storage and webgui only but using as default route one of the workers exitnodes
     if dist_conf.distributed.master_storage_only:

--- a/lib/cuckoo/core/startup.py
+++ b/lib/cuckoo/core/startup.py
@@ -121,6 +121,14 @@ def load_nexthop_profiles(routing_cfg):
     # preconfigured rt_table must not falsely reject a [gwX] reusing that id and fail to start (codex P2).
     if dirty_rt is not None and str(dirty_rt) and dirty_internet != "none":
         owned_tables.setdefault(str(dirty_rt), "the [routing] dirty-line table")
+    # The fail-closed blackhole is installed into NEXTHOP_FAIL_TABLE; if a VPN or the (enabled)
+    # dirty-line already owns that table, the blackhole would overwrite ITS default route and silently
+    # drop its traffic. Reject at startup -- only relevant when fail_closed is on (codex P2).
+    if routing_cfg.nexthop.fail_closed and str(NEXTHOP_FAIL_TABLE) in owned_tables:
+        raise CuckooStartupError(
+            f"[nexthop] fail_closed uses table '{NEXTHOP_FAIL_TABLE}' which collides with "
+            f"{owned_tables[str(NEXTHOP_FAIL_TABLE)]}; the blackhole would overwrite its default route"
+        )
     # Pass 1: parse + validate + register profiles (no rooter side effects yet).
     profiles = []
     claimed_tables = {}   # rt_table -> gateway id, to reject duplicates (each [gwX] needs its own)

--- a/lib/cuckoo/core/startup.py
+++ b/lib/cuckoo/core/startup.py
@@ -56,7 +56,7 @@ from lib.cuckoo.core.database import Database
 from lib.cuckoo.core.data.task import TASK_FAILED_ANALYSIS, TASK_RUNNING
 from lib.cuckoo.core.log import init_logger
 from lib.cuckoo.core.plugins import import_package, import_plugin, list_plugins
-from lib.cuckoo.core.rooter import rooter, socks5s, vpns
+from lib.cuckoo.core.rooter import gateways, rooter, socks5s, vpns
 
 log = logging.getLogger()
 
@@ -66,6 +66,172 @@ routing = Config("routing")
 repconf = Config("reporting")
 auxconf = Config("auxiliary")
 dist_conf = Config("distributed")
+
+# ---------------------------------------------------------------------------
+# Next-hop egress primitive — constants used by loader + SIGTERM path
+# ---------------------------------------------------------------------------
+NEXTHOP_FAIL_TABLE = "250"
+NEXTHOP_PRIORITY_LOW = "30000"
+NEXTHOP_BAND_LO = "10000"
+NEXTHOP_BAND_HI = "10255"
+# Route keywords a [gwX] gateway id must never collide with. "nexthop" is the sentinel default
+# route that maps to [nexthop] default_policy (pool selection), so a gateway named "nexthop"
+# would be ambiguous — reserve it too (Copilot).
+_RESERVED_ROUTE_NAMES = {"none", "internet", "tor", "inetsim", "drop", "false", "nexthop"}
+# Pool-policy selector tokens: a task route of roundrobin/random means "pick from the live
+# pool", so a [gwX] must not be *named* one of these (it could never be explicitly selected
+# and would collide with the policy token in _resolve_nexthop/_select_gateway).
+_POLICY_TOKENS = ("roundrobin", "random")
+# Linux reserved/system routing tables. A [gwX] rt_table must never be one of these: it is fed
+# straight into `ip route flush table <rt_table>` and, if it were `main`, the per-task rule would
+# route the VM out the host's own default route (fail-OPEN) instead of the blackhole. Mirrors the
+# defence-in-depth guard in utils.rooter nexthop_init/teardown. Kernel-fixed ids.
+_RESERVED_RT_TABLES = ("local", "main", "default", "0", "253", "254", "255")
+
+
+def load_nexthop_profiles(routing_cfg):
+    """Parse [nexthop]/[gwX] sections into the rooter.gateways global, sweep stale
+    policy-routing state, then arm fail-closed.  No-op when [nexthop] is absent
+    or disabled (review M4 hasattr guard)."""
+    if not hasattr(routing_cfg, "nexthop") or not routing_cfg.nexthop.enabled:
+        return
+    # [nexthop] is enabled: it MUST define gateways + vm_net (gemini #14 MEDIUM). CAPE's config
+    # Dictionary returns None (not AttributeError) for a missing key, so without this a missing
+    # option slips through as None and misbehaves downstream — fail with a clear error instead.
+    for opt in ("gateways", "vm_net"):
+        if getattr(routing_cfg.nexthop, opt, None) is None:
+            raise CuckooStartupError(f"[nexthop] is enabled but missing the required '{opt}' option in routing.conf")
+    # Routing tables already OWNED by another primitive -- a [gwX] must not reuse one. nexthop_init
+    # flush/replaces each gateway table, so a shared table silently clobbers (or is clobbered by) the
+    # other primitive's route, misrouting its traffic with no error. Two sources, both knowable now:
+    #   - VPN tables: init_routing builds vpns[*].rt_table BEFORE calling us, so nexthop_init would
+    #     wipe a just-built VPN table and point its default out the gateway NIC (VPN-isolation break).
+    #   - the [routing] dirty-line table (routing.routing.rt_table): its init_rttable runs AFTER us,
+    #     so it would repopulate a gateway table with the dirty-line interface.
+    # Coerce to str: a VPN rt_table (or the dirty-line one) may be an int or a name in config.
+    owned_tables = {}
+    for vname, ventry in vpns.items():
+        vrt = getattr(ventry, "rt_table", None)
+        if vrt is not None:
+            owned_tables[str(vrt)] = f"VPN '{vname}'"
+    dirty_rt = getattr(getattr(routing_cfg, "routing", None), "rt_table", None)
+    if dirty_rt is not None and str(dirty_rt):
+        owned_tables.setdefault(str(dirty_rt), "the [routing] dirty-line table")
+    # Pass 1: parse + validate + register profiles (no rooter side effects yet).
+    profiles = []
+    claimed_tables = {}   # rt_table -> gateway id, to reject duplicates (each [gwX] needs its own)
+    for name in routing_cfg.nexthop.gateways.split(","):
+        name = name.strip()
+        if not name:
+            continue
+        if name in _RESERVED_ROUTE_NAMES or name in _POLICY_TOKENS or name in vpns or name in socks5s or name[:3] == "tun":
+            raise CuckooStartupError(f"nexthop gateway id '{name}' collides with a reserved/route/policy name")
+        if not hasattr(routing_cfg, name):
+            raise CuckooStartupError(f"nexthop gateway '{name}' has no [{name}] section in routing.conf")
+        entry = routing_cfg.get(name)
+        # A [gwX] section MUST define interface/next_hop/rt_table (gemini #14 MEDIUM). Config
+        # Dictionary returns None for a missing key, so validate explicitly — otherwise None
+        # (or str(None)=="None") would slip into the rooter commands below.
+        for opt in ("interface", "next_hop", "rt_table"):
+            if getattr(entry, opt, None) is None:
+                raise CuckooStartupError(f"nexthop gateway '{name}' is missing the required '{opt}' option in [{name}]")
+        entry.rt_table = str(entry.rt_table)   # coerce: config may produce int (review B3)
+        # A reserved rt_table (main/local/default/...) must be rejected HERE, at load, not just
+        # skipped in nexthop_init: an unbuilt custom table is empty so its per-task rule falls
+        # through to the fail-closed blackhole, but `main` already holds the host default route,
+        # so a per-task `from vm_ip lookup main priority 100xx` (below the 30000 blackhole) would
+        # route the VM straight out the control-plane NIC -- an isolation bypass. Fail loudly.
+        if entry.rt_table in _RESERVED_RT_TABLES:
+            raise CuckooStartupError(
+                f"nexthop gateway '{name}' uses reserved routing table '{entry.rt_table}' in [{name}]; "
+                "pick a dedicated custom table id (e.g. 201)"
+            )
+        # rt_table must not be the fail-closed table: nexthop_init builds the gateway default there,
+        # then nexthop_fail_closed_enable does `ip route replace blackhole default table <fail>`,
+        # overwriting that default with a blackhole -> every task bound to the gateway silently drops.
+        if entry.rt_table == NEXTHOP_FAIL_TABLE:
+            raise CuckooStartupError(
+                f"nexthop gateway '{name}' uses rt_table '{entry.rt_table}' in [{name}], which is the "
+                "reserved fail-closed table; the blackhole would overwrite the gateway's default route. "
+                "Pick a different custom table id."
+            )
+        # rt_table must not be owned by a VPN or the [routing] dirty-line (see owned_tables above):
+        # nexthop_init would clobber that primitive's table and silently misroute its traffic. This
+        # catches DIRECT string collisions; a name<->id alias (a VPN using the name "tun0" mapped to
+        # id 201 in /etc/iproute2/rt_tables while a [gwX] uses 201) resolves to the same kernel table
+        # but different config strings -- that stays the operator's "unique across the system"
+        # responsibility, as documented for VPN rt_table in routing.conf.
+        if entry.rt_table in owned_tables:
+            raise CuckooStartupError(
+                f"nexthop gateway '{name}' rt_table '{entry.rt_table}' in [{name}] collides with "
+                f"{owned_tables[entry.rt_table]}; each routing primitive needs a unique table id"
+            )
+        # rt_table must be UNIQUE across [gwX]: nexthop_init flush/replaces a single table per profile,
+        # so a shared table leaves the last gateway's default winning while the earlier gateway stays
+        # selectable -> its per-task rule looks up a table pointing at the wrong egress interface.
+        if entry.rt_table in claimed_tables:
+            raise CuckooStartupError(
+                f"nexthop gateways '{claimed_tables[entry.rt_table]}' and '{name}' both use rt_table "
+                f"'{entry.rt_table}'; each [gwX] needs a unique routing table id"
+            )
+        claimed_tables[entry.rt_table] = name
+        # [gwX] sections carry no `name =` field (unlike [vpnX]/[socks5]), so config
+        # Dictionary.__getattr__ returns None for entry.name. Carry the section header as
+        # the profile id: analysis_manager._resolve_nexthop reads profile.name into
+        # self.nexthop_id, and a None id makes _dispatch_nexthop silently no-op (the
+        # per-task rule never installs and every task fails closed). Verified live.
+        entry.name = name
+        gateways[name] = entry
+        profiles.append(entry)
+    # [nexthop] enabled but nothing usable parsed (e.g. gateways = "" or all-blank): without
+    # this every analysis task would silently fall through to the fail-closed blackhole. Fail
+    # loudly at startup instead (gemini medium).
+    if not profiles:
+        raise CuckooStartupError("[nexthop] is enabled but no gateways were configured in routing.conf")
+    vm_net = str(routing_cfg.nexthop.vm_net)
+    tables_csv = ",".join(p.rt_table for p in profiles)
+    # Record sweep state for SIGTERM, then sweep any STALE state from a prior run
+    # BEFORE building fresh tables. nexthop_teardown flushes the gateway tables, so it
+    # MUST run before nexthop_init (which builds them) or it wipes the just-built routes.
+    rooter("nexthop_configure", tables_csv, vm_net, NEXTHOP_FAIL_TABLE,
+           NEXTHOP_PRIORITY_LOW, NEXTHOP_BAND_LO, NEXTHOP_BAND_HI)
+    rooter("nexthop_teardown", tables_csv, vm_net, NEXTHOP_FAIL_TABLE,
+           NEXTHOP_PRIORITY_LOW, NEXTHOP_BAND_LO, NEXTHOP_BAND_HI)
+    # Pass 2: build fresh profile tables, then arm the intra-subnet exception + (optionally) fail-closed.
+    for entry in profiles:
+        rooter("nexthop_init", str(entry.rt_table), str(entry.interface), str(entry.next_hop))
+    # The intra-subnet exception (keep guest<->host + guest<->guest vm_net traffic on main) is a
+    # CONNECTIVITY guarantee, independent of the blackhole -- install it whenever nexthop is enabled.
+    # Otherwise, with fail_closed=no, a bound VM's per-task rule would send its intra-vm_net traffic
+    # (siblings / non-host-local services) out the gateway instead of the guest network (codex P2).
+    rooter("nexthop_intra_exception_enable", vm_net, NEXTHOP_BAND_LO)
+    if routing_cfg.nexthop.fail_closed:
+        rooter("nexthop_fail_closed_enable", vm_net, NEXTHOP_FAIL_TABLE, NEXTHOP_PRIORITY_LOW)
+
+
+def validate_default_route(routing_cfg):
+    """Check that the configured default route is valid.  Accepts gateway ids
+    (from gateways global) when nexthop is enabled, bypassing the vpn.enabled gate.
+    Extracted from init_routing so it is independently unit-testable (review H3)."""
+    route = routing_cfg.routing.route
+    if route in ("none", "internet", "tor", "inetsim"):
+        return
+    nexthop_on = hasattr(routing_cfg, "nexthop") and routing_cfg.nexthop.enabled
+    if nexthop_on and (route in gateways or route in _POLICY_TOKENS or route == "nexthop"):
+        # A concrete gateway id, a pool-policy token (roundrobin/random), or the "nexthop" sentinel
+        # is a valid default route when nexthop is on -- _resolve_nexthop maps the token/sentinel to
+        # default_policy and picks from the live pool. Accept it here so the documented pool default
+        # (route = nexthop) works without a VPN; otherwise startup wrongly raises the vpn-not-enabled
+        # error and the default_policy fallback is unreachable in production (codex P2 / Copilot).
+        return  # skip the vpn.enabled gate
+    if not routing_cfg.vpn.enabled:
+        raise CuckooStartupError(
+            "A VPN has been configured as default routing interface for VMs, but VPNs have not been enabled in routing.conf"
+        )
+    if route not in vpns and route not in socks5s:
+        raise CuckooStartupError(
+            "The VPN/Socks5 defined as default routing target has not been configured in routing.conf. You should use name field"
+        )
 
 
 def check_python_version():
@@ -449,12 +615,15 @@ def init_rooter():
     connect to it."""
 
     # The default configuration doesn't require the rooter to be ran.
+    # A nexthop-only node still needs the rooter for forward_drop() + fail-closed arm.
+    _nexthop_enabled = hasattr(routing, "nexthop") and routing.nexthop.enabled
     if (
         not routing.vpn.enabled
         and not routing.tor.enabled
         and not routing.inetsim.enabled
         and not routing.socks5.enabled
         and routing.routing.route == "none"
+        and not _nexthop_enabled
     ):
         return
 
@@ -573,21 +742,15 @@ def init_routing():
                 rooter("flush_rttable", entry.rt_table)
                 rooter("init_rttable", entry.rt_table, entry.interface)
 
+    # Load [gwX] next-hop egress profiles, arm fail-closed (no-op when [nexthop] absent/disabled).
+    load_nexthop_profiles(routing)
+
     # If we are storage and webgui only but using as default route one of the workers exitnodes
     if dist_conf.distributed.master_storage_only:
         return
 
-    # Check whether the default VPN exists if specified.
-    if routing.routing.route not in ("none", "internet", "tor", "inetsim"):
-        if not routing.vpn.enabled:
-            raise CuckooStartupError(
-                "A VPN has been configured as default routing interface for VMs, but VPNs have not been enabled in routing.conf"
-            )
-
-        if routing.routing.route not in vpns and routing.routing.route not in socks5s:
-            raise CuckooStartupError(
-                "The VPN/Socks5 defined as default routing target has not been configured in routing.conf. You should use name field"
-            )
+    # Check whether the default VPN/gateway exists if specified.
+    validate_default_route(routing)
 
     # Check whether the dirty line exists if it has been defined.
     if routing.routing.internet != "none":

--- a/lib/cuckoo/core/startup.py
+++ b/lib/cuckoo/core/startup.py
@@ -115,7 +115,11 @@ def load_nexthop_profiles(routing_cfg):
         if vrt is not None:
             owned_tables[str(vrt)] = f"VPN '{vname}'"
     dirty_rt = getattr(getattr(routing_cfg, "routing", None), "rt_table", None)
-    if dirty_rt is not None and str(dirty_rt):
+    dirty_internet = str(getattr(getattr(routing_cfg, "routing", None), "internet", "none") or "none")
+    # Only reserve the [routing] dirty-line table when the dirty-line route is actually enabled (its
+    # init_rttable runs only when internet != "none"). A nexthop-only node (internet = none) with a
+    # preconfigured rt_table must not falsely reject a [gwX] reusing that id and fail to start (codex P2).
+    if dirty_rt is not None and str(dirty_rt) and dirty_internet != "none":
         owned_tables.setdefault(str(dirty_rt), "the [routing] dirty-line table")
     # Pass 1: parse + validate + register profiles (no rooter side effects yet).
     profiles = []
@@ -188,6 +192,16 @@ def load_nexthop_profiles(routing_cfg):
     # loudly at startup instead (gemini medium).
     if not profiles:
         raise CuckooStartupError("[nexthop] is enabled but no gateways were configured in routing.conf")
+    # default_policy must resolve: a pool selector (roundrobin/random) or one of the configured gateway
+    # ids. Otherwise _select_gateway() returns None for every default/route=nexthop task and they all
+    # silently drop; reject a typo'd/dangling policy at startup instead of shipping a dead pool (codex P2).
+    default_policy = str(getattr(routing_cfg.nexthop, "default_policy", "") or "")
+    gateway_ids = {p.name for p in profiles}
+    if default_policy not in _POLICY_TOKENS and default_policy not in gateway_ids:
+        raise CuckooStartupError(
+            f"[nexthop] default_policy '{default_policy}' must be 'roundrobin', 'random', or a configured "
+            f"gateway id ({', '.join(sorted(gateway_ids))})"
+        )
     vm_net = str(routing_cfg.nexthop.vm_net)
     tables_csv = ",".join(p.rt_table for p in profiles)
     # Record sweep state for SIGTERM, then sweep any STALE state from a prior run

--- a/tests/integration/test_nexthop_netns.py
+++ b/tests/integration/test_nexthop_netns.py
@@ -1,0 +1,313 @@
+# tests/integration/test_nexthop_netns.py
+#
+# Root-gated netns integration test for the nexthop egress primitive.
+# Requires: root + CAPE_NETNS_TESTS=1 env var.
+# Run via:  SUDO=1 bash run-cape-tests-on-box.sh tests/integration/test_nexthop_netns.py -v
+#
+# What this tests (semantic, not just argv):
+#   1. nexthop_init installs a forced-default in the profile's routing table
+#   2. nexthop_enable installs a policy rule pointing vm_ip -> that table
+#   3. Two concurrent profiles resolve to DISTINCT tables/interfaces
+#   4. nexthop_fail_closed_enable installs a blackhole in the fail table and
+#      a low-priority subnet rule so an unbound guest source hits the blackhole
+#
+# Assertion strategy:
+#   - "ip rule show" to verify policy rules exist at the right priority
+#   - "ip route show table <N>" to verify the forced-default points to the right egress_if
+#   - The combination proves a packet from vm_ip would be source-routed through the correct table.
+#   - For fail-closed: verify the blackhole route is in table 250 and the subnet rule is present.
+#   - We do NOT use "ip route get ... from <non-local-src>" because that command can refuse
+#     to execute (EHOSTUNREACH) when the source is not locally assigned, even under root.
+#     The rule+table combination is the authoritative semantic check.
+
+import os
+import subprocess
+import pytest
+import threading
+import utils.rooter as rooter
+
+pytestmark = pytest.mark.skipif(
+    os.geteuid() != 0 or os.environ.get("CAPE_NETNS_TESTS") != "1",
+    reason="needs root + CAPE_NETNS_TESTS=1 (creates network namespaces)",
+)
+
+# ─── ip path ─────────────────────────────────────────────────────────────────
+# /sbin/ip and /usr/sbin/ip both exist on this Ubuntu box (usrmerge symlinks);
+# using the PATH-resolved "ip" is most portable. Override in the fixture so the
+# rooter functions use the same binary as our assertions.
+_IP = "/sbin/ip"
+
+
+def sh(*args, check=True):
+    """Run an ip/iptables command, raising on failure unless check=False."""
+    result = subprocess.run(list(args), capture_output=True, text=True, check=False)
+    if check and result.returncode != 0:
+        raise subprocess.CalledProcessError(
+            result.returncode, args, result.stdout, result.stderr
+        )
+    return result.stdout, result.stderr
+
+
+def ip_rule_exists(from_addr, table, priority):
+    """Return True if 'ip rule show' contains a rule matching from/table/priority."""
+    out, _ = sh(_IP, "rule", "show")
+    for line in out.splitlines():
+        # Line format: "10041:    from 192.168.100.41 lookup 201"
+        head = line.split(":", 1)[0].strip()
+        if head == str(priority) and f"from {from_addr}" in line and f"lookup {table}" in line:
+            return True
+    return False
+
+
+def ip_route_table_has_default_via_if(table, iface):
+    """Return True if the routing table has a default route dev iface."""
+    out, _ = sh(_IP, "route", "show", "table", table)
+    for line in out.splitlines():
+        if "default" in line and iface in line:
+            return True
+    return False
+
+
+def ip_route_table_has_blackhole(table):
+    """Return True if the routing table has a blackhole default."""
+    out, _ = sh(_IP, "route", "show", "table", table)
+    for line in out.splitlines():
+        if "blackhole" in line and "default" in line:
+            return True
+    return False
+
+
+def subnet_rule_exists(subnet, table, priority):
+    """Return True if a rule for the whole subnet exists in ip rule show."""
+    out, _ = sh(_IP, "rule", "show")
+    for line in out.splitlines():
+        head = line.split(":", 1)[0].strip()
+        if head == str(priority) and subnet in line and f"lookup {table}" in line:
+            return True
+    return False
+
+
+# ─── fixture ─────────────────────────────────────────────────────────────────
+
+@pytest.fixture(autouse=False)
+def netns():
+    """Build two veth egress interfaces + two dummy gateway namespaces.
+
+    Topology:
+        default ns         gw1 ns          gw2 ns
+        egress_if1  <-veth-> gwp1          (acts as a real next-hop)
+        egress_if2  <-veth-> gwp2
+
+    Each egress_if is the "egress interface" we hand to nexthop_init.
+    The gateway peer address (10.k.0.2) is the next_hop argument.
+
+    Teardown is run unconditionally (try/except each step) so a failed run
+    does not leave stale state that blocks a re-run.
+    """
+    # Wire the real ip binary into rooter so nexthop_* functions hit the kernel.
+    class _Settings:
+        ip = _IP
+    rooter.settings = _Settings
+    rooter.ServicePaths.ip = _IP
+    # These tests verify policy ROUTING (ip rule/route), not iptables filtering, and no packets
+    # traverse. STUB run_iptables so nexthop_enable's MASQUERADE/ACCEPT rules never touch the real
+    # host firewall -- otherwise the root-gated suite would leave CAPE-rooter NAT rules behind
+    # (codex/Copilot). Saved + restored around the test.
+    rooter.ServicePaths.iptables = "/usr/sbin/iptables"
+    _orig_run_iptables = rooter.run_iptables
+    # Return non-empty stderr for `-D` so the idempotent delete-until-gone loop terminates after one
+    # call instead of spinning to its bound; empty stderr (success) for everything else.
+    rooter.run_iptables = lambda *a, **k: (("", "gone") if "-D" in a else ("", ""))
+
+    NEXTHOP_VM_NET = "192.168.100.0/24"   # every test source IP lives here
+    created_ns = []
+    created_links = []
+    created_tables = []     # table ids with content to flush
+
+    def _cleanup():
+        # Best-effort teardown; each step is independent.
+        # Use the PRODUCTION filtered teardown for ip rules/routes/tables: it deletes only band rules
+        # whose source is inside vm_net (never an unrelated host rule at a band priority), flushes the
+        # gateway tables, and removes the blackhole + intra-subnet exception (codex/Copilot).
+        try:
+            rooter.nexthop_teardown(",".join(created_tables), NEXTHOP_VM_NET, "250", "30000", "10000", "10255")
+        except Exception:
+            pass
+        # bring down/del veth links (deleting one side removes the peer too)
+        for link in created_links:
+            subprocess.run([_IP, "link", "del", link], capture_output=True)
+        # delete namespaces
+        for ns in created_ns:
+            subprocess.run([_IP, "netns", "del", ns], capture_output=True)
+        rooter.run_iptables = _orig_run_iptables
+
+    try:
+        for k in (1, 2):
+            ns = f"gw{k}"
+            link = f"egress_if{k}"
+            peer = f"gwp{k}"
+            sh(_IP, "netns", "add", ns)
+            created_ns.append(ns)
+            sh(_IP, "link", "add", link, "type", "veth", "peer", "name", peer, "netns", ns)
+            created_links.append(link)
+            sh(_IP, "addr", "add", f"10.{k}.0.1/24", "dev", link)
+            sh(_IP, "link", "set", link, "up")
+            sh(_IP, "netns", "exec", ns, _IP, "addr", "add", f"10.{k}.0.2/24", "dev", peer)
+            sh(_IP, "netns", "exec", ns, _IP, "link", "set", peer, "up")
+            created_tables.append(str(200 + k))  # tables 201, 202
+    except Exception:
+        _cleanup()
+        raise
+
+    yield
+
+    _cleanup()
+
+
+# ─── tests ───────────────────────────────────────────────────────────────────
+
+def test_two_profiles_route_to_distinct_interfaces(netns):
+    """Two VM source IPs bound to two different profiles route via distinct egress interfaces.
+
+    Verification:
+    (a) Each profile's routing table has a default pointing to its own egress_if.
+    (b) Each VM's source IP has a policy rule pointing it to its table.
+    Together these prove that a packet from vm_ip1 would be looked up in table 201
+    (-> egress_if1) and a packet from vm_ip2 in table 202 (-> egress_if2).
+    """
+    VM_IP1 = "192.168.100.41"
+    VM_IP2 = "192.168.100.42"
+    PRIO1 = "10041"   # 10000 + last octet
+    PRIO2 = "10042"
+
+    # Initialize profiles: forced-default routes into tables 201 / 202
+    rooter.nexthop_init("201", "egress_if1", "10.1.0.2")
+    rooter.nexthop_init("202", "egress_if2", "10.2.0.2")
+
+    # Bind the two VM IPs
+    rooter.nexthop_enable(VM_IP1, "lo", "egress_if1", "201", PRIO1)
+    rooter.nexthop_enable(VM_IP2, "lo", "egress_if2", "202", PRIO2)
+
+    # (a) Tables have forced defaults via the correct interface
+    assert ip_route_table_has_default_via_if("201", "egress_if1"), (
+        "table 201 should have a default via egress_if1"
+    )
+    assert ip_route_table_has_default_via_if("202", "egress_if2"), (
+        "table 202 should have a default via egress_if2"
+    )
+
+    # (b) Source policy rules point each VM IP to its table
+    assert ip_rule_exists(VM_IP1, "201", PRIO1), (
+        f"ip rule should map {VM_IP1} -> table 201 at priority {PRIO1}"
+    )
+    assert ip_rule_exists(VM_IP2, "202", PRIO2), (
+        f"ip rule should map {VM_IP2} -> table 202 at priority {PRIO2}"
+    )
+
+    # (c) Profiles are DISTINCT: VM_IP1 is NOT in table 202, VM_IP2 is NOT in table 201
+    assert not ip_rule_exists(VM_IP1, "202", PRIO1), (
+        f"{VM_IP1} must NOT be in table 202"
+    )
+    assert not ip_rule_exists(VM_IP2, "201", PRIO2), (
+        f"{VM_IP2} must NOT be in table 201"
+    )
+
+
+def test_concurrent_profile_setup_is_consistent(netns):
+    """Two threads calling nexthop_enable concurrently produce the correct rule set.
+
+    This exercises the real kernel's netlink serialization (iproute2 calls are
+    serialized by the kernel, not by us — we verify no rules are duplicated or lost).
+    """
+    VM_IP1 = "192.168.100.51"
+    VM_IP2 = "192.168.100.52"
+    PRIO1 = "10051"
+    PRIO2 = "10052"
+
+    rooter.nexthop_init("201", "egress_if1", "10.1.0.2")
+    rooter.nexthop_init("202", "egress_if2", "10.2.0.2")
+
+    errors = []
+
+    def bind1():
+        try:
+            rooter.nexthop_enable(VM_IP1, "lo", "egress_if1", "201", PRIO1)
+        except Exception as e:
+            errors.append(e)
+
+    def bind2():
+        try:
+            rooter.nexthop_enable(VM_IP2, "lo", "egress_if2", "202", PRIO2)
+        except Exception as e:
+            errors.append(e)
+
+    t1 = threading.Thread(target=bind1)
+    t2 = threading.Thread(target=bind2)
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    assert not errors, f"Concurrent nexthop_enable raised: {errors}"
+
+    # Both rules must be present, independently
+    assert ip_rule_exists(VM_IP1, "201", PRIO1), "Concurrent bind: VM_IP1 rule missing"
+    assert ip_rule_exists(VM_IP2, "202", PRIO2), "Concurrent bind: VM_IP2 rule missing"
+
+
+def test_unbound_source_is_blackholed(netns):
+    """An unbound guest-subnet source (no per-task rule) resolves to the fail-closed blackhole.
+
+    After nexthop_fail_closed_enable:
+    - table 250 has `blackhole default`
+    - ip rule has a low-priority (30000) rule routing the entire guest subnet (192.168.100.0/24)
+      to table 250
+
+    An unbound IP (e.g. 192.168.100.99) has no higher-priority per-task rule, so it
+    hits the subnet rule -> table 250 -> blackhole.
+
+    We verify the state is correctly installed; we do NOT try to inject a test packet
+    (that would need an actual VM interface or raw-socket plumbing out of scope here).
+    """
+    VM_NET = "192.168.100.0/24"
+    FAIL_TABLE = "250"
+    PRIORITY_LOW = "30000"
+    BAND_LO = "10000"
+
+    # intra-subnet exception is now a separate primitive (always installed); the blackhole is
+    # fail_closed_enable (3 args). Install both, as load_nexthop_profiles does when fail_closed=yes.
+    rooter.nexthop_intra_exception_enable(VM_NET, BAND_LO)
+    rooter.nexthop_fail_closed_enable(VM_NET, FAIL_TABLE, PRIORITY_LOW)
+
+    # (a) Blackhole default is in table 250
+    assert ip_route_table_has_blackhole(FAIL_TABLE), (
+        "table 250 should have a blackhole default after nexthop_fail_closed_enable"
+    )
+
+    # (b) Subnet rule at priority 30000 routes the guest /24 to table 250
+    assert subnet_rule_exists(VM_NET, FAIL_TABLE, PRIORITY_LOW), (
+        f"ip rule should route {VM_NET} -> table {FAIL_TABLE} at priority {PRIORITY_LOW}"
+    )
+
+    # (c) No per-task rule for the unbound IP (192.168.100.99) exists —
+    # so it falls through to the subnet rule -> blackhole.
+    assert not ip_rule_exists("192.168.100.99", FAIL_TABLE, PRIORITY_LOW), (
+        "unbound IP must NOT have its own rule — it is covered only by the subnet rule"
+    )
+
+
+def test_enable_then_disable_removes_rules(netns):
+    """nexthop_disable is the mirror of nexthop_enable: all rules are removed."""
+    VM_IP = "192.168.100.61"
+    PRIO = "10061"
+
+    rooter.nexthop_init("201", "egress_if1", "10.1.0.2")
+    rooter.nexthop_enable(VM_IP, "lo", "egress_if1", "201", PRIO)
+
+    assert ip_rule_exists(VM_IP, "201", PRIO), "Rule must exist after enable"
+
+    rooter.nexthop_disable(VM_IP, "lo", "egress_if1", "201", PRIO)
+
+    assert not ip_rule_exists(VM_IP, "201", PRIO), (
+        "Rule must be removed after disable (mirror teardown)"
+    )

--- a/tests/test_nexthop_selection.py
+++ b/tests/test_nexthop_selection.py
@@ -126,7 +126,7 @@ def test_gwx_loader_populates_and_coerces(monkeypatch):
     # as core_rooter.gateways unless replaced).  Clear it in place so both refs see the reset.
     startup.gateways.clear()
     monkeypatch.setattr(startup, "rooter", lambda cmd, *a, **k: recorded.append((cmd, a)) or {}, raising=False)
-    startup.load_nexthop_profiles(_FakeRouting())
+    startup.load_nexthop_profiles(_FakeRouting(), apply_rooter_state=True)
     # Check via startup.gateways (the dict the function mutated)
     assert "gw1" in startup.gateways
     assert startup.gateways["gw1"].rt_table == "201"   # coerced to str
@@ -376,7 +376,7 @@ def test_nexthop_intra_exception_installed_even_when_fail_closed_off(monkeypatch
     startup.gateways.clear()
     monkeypatch.setattr(startup, "vpns", {}, raising=False)
     monkeypatch.setattr(startup, "rooter", lambda cmd, *a, **k: recorded.append(cmd) or {}, raising=False)
-    startup.load_nexthop_profiles(_NexthopNoFailClosed())
+    startup.load_nexthop_profiles(_NexthopNoFailClosed(), apply_rooter_state=True)
     assert "nexthop_intra_exception_enable" in recorded
     assert "nexthop_fail_closed_enable" not in recorded
 
@@ -571,3 +571,28 @@ def test_fail_closed_table_collision_ignored_when_fail_closed_off(monkeypatch):
     monkeypatch.setattr(startup, "rooter", lambda *a, **k: {}, raising=False)
     startup.load_nexthop_profiles(_FailTableVpnOff())   # must NOT raise
     assert "gw1" in startup.gateways
+
+
+def test_web_startup_does_not_sweep_live_rules(monkeypatch):
+    # codex P2 (cross-process): the web/API process calls init_routing() -> load_nexthop_profiles with
+    # apply_rooter_state=False. It must parse+validate+populate gateways but issue NO rooter mutations,
+    # so a web/gunicorn restart cannot flush the scheduler's live per-task nexthop rules mid-analysis.
+    import lib.cuckoo.core.startup as startup
+    recorded = []
+    startup.gateways.clear()
+    monkeypatch.setattr(startup, "vpns", {}, raising=False)
+    monkeypatch.setattr(startup, "rooter", lambda cmd, *a, **k: recorded.append(cmd) or {}, raising=False)
+    startup.load_nexthop_profiles(_FakeRouting())   # default apply_rooter_state=False (web/vpncheck path)
+    assert "gw1" in startup.gateways   # parsed + populated (harmless)
+    assert recorded == []              # but NO rooter mutations
+
+
+def test_scheduler_startup_applies_rooter_state(monkeypatch):
+    # counterpart: the scheduler (apply_rooter_state=True) DOES sweep/build/arm.
+    import lib.cuckoo.core.startup as startup
+    recorded = []
+    startup.gateways.clear()
+    monkeypatch.setattr(startup, "vpns", {}, raising=False)
+    monkeypatch.setattr(startup, "rooter", lambda cmd, *a, **k: recorded.append(cmd) or {}, raising=False)
+    startup.load_nexthop_profiles(_FakeRouting(), apply_rooter_state=True)
+    assert "nexthop_teardown" in recorded and "nexthop_init" in recorded

--- a/tests/test_nexthop_selection.py
+++ b/tests/test_nexthop_selection.py
@@ -461,3 +461,17 @@ def test_nexthop_enabled_empty_pool_raises(monkeypatch):
     monkeypatch.setattr(startup, "rooter", lambda *a, **k: {}, raising=False)
     with pytest.raises(CuckooStartupError):
         startup.load_nexthop_profiles(_NexthopEmptyPool())
+
+
+def test_gw_live_queries_nic_up(monkeypatch):
+    # _gw_live must consult nic_up (admin-up), NOT nic_available (which is true for DOWN links).
+    calls = []
+
+    def _fake_rooter(cmd, *a):
+        calls.append(cmd)
+        return {"output": (cmd == "nic_up" and a and a[0] == "ens-up")}
+
+    monkeypatch.setattr(core_rooter, "rooter", _fake_rooter)
+    assert core_rooter._gw_live(_Profile("gw1", "ens-up", "201", 0)) is True
+    assert core_rooter._gw_live(_Profile("gw2", "ens-down", "202", 0)) is False
+    assert "nic_up" in calls and "nic_available" not in calls

--- a/tests/test_nexthop_selection.py
+++ b/tests/test_nexthop_selection.py
@@ -532,3 +532,42 @@ def test_gw_live_queries_nic_up(monkeypatch):
     assert core_rooter._gw_live(_Profile("gw1", "ens-up", "201", 0)) is True
     assert core_rooter._gw_live(_Profile("gw2", "ens-down", "202", 0)) is False
     assert "nic_up" in calls and "nic_available" not in calls
+
+
+def test_fail_closed_table_collides_with_vpn_raises(monkeypatch):
+    # codex P2: fail_closed installs a blackhole into NEXTHOP_FAIL_TABLE; if a VPN already uses that
+    # table, the blackhole would overwrite the VPN's default route and drop its traffic. Reject at load.
+    import lib.cuckoo.core.startup as startup
+    from lib.cuckoo.common.exceptions import CuckooStartupError
+
+    class _FailTableVpn(_FakeRouting):
+        def __init__(self):
+            super().__init__()
+            self.nexthop = _DictSection(enabled=True, gateways="gw1", default_policy="roundrobin",
+                                        fail_closed=True, vm_net="192.168.100.0/24")
+            self.gw1 = _DictSection(interface="ens6", next_hop="onlink", rt_table=201)
+
+    startup.gateways.clear()
+    monkeypatch.setattr(startup, "vpns", {"vpn0": type("V", (), {"rt_table": startup.NEXTHOP_FAIL_TABLE})()}, raising=False)
+    monkeypatch.setattr(startup, "rooter", lambda *a, **k: {}, raising=False)
+    with pytest.raises(CuckooStartupError):
+        startup.load_nexthop_profiles(_FailTableVpn())
+
+
+def test_fail_closed_table_collision_ignored_when_fail_closed_off(monkeypatch):
+    # the collision only matters when fail_closed arms the blackhole; with fail_closed=no a VPN on
+    # table 250 is fine (we never write that table), so startup must NOT reject it.
+    import lib.cuckoo.core.startup as startup
+
+    class _FailTableVpnOff(_FakeRouting):
+        def __init__(self):
+            super().__init__()
+            self.nexthop = _DictSection(enabled=True, gateways="gw1", default_policy="roundrobin",
+                                        fail_closed=False, vm_net="192.168.100.0/24")
+            self.gw1 = _DictSection(interface="ens6", next_hop="onlink", rt_table=201)
+
+    startup.gateways.clear()
+    monkeypatch.setattr(startup, "vpns", {"vpn0": type("V", (), {"rt_table": startup.NEXTHOP_FAIL_TABLE})()}, raising=False)
+    monkeypatch.setattr(startup, "rooter", lambda *a, **k: {}, raising=False)
+    startup.load_nexthop_profiles(_FailTableVpnOff())   # must NOT raise
+    assert "gw1" in startup.gateways

--- a/tests/test_nexthop_selection.py
+++ b/tests/test_nexthop_selection.py
@@ -596,3 +596,48 @@ def test_scheduler_startup_applies_rooter_state(monkeypatch):
     monkeypatch.setattr(startup, "rooter", lambda cmd, *a, **k: recorded.append(cmd) or {}, raising=False)
     startup.load_nexthop_profiles(_FakeRouting(), apply_rooter_state=True)
     assert "nexthop_teardown" in recorded and "nexthop_init" in recorded
+
+
+def test_init_rooter_web_does_not_reset_state(monkeypatch):
+    # codex P1: init_rooter() is called by the web/API (web.settings) BEFORE init_routing. On a
+    # nexthop-enabled node it now connects, but must NOT run cleanup_rooter/forward_drop/state_* --
+    # those remove the scheduler's live per-task iptables rules on a web/gunicorn restart. Only the
+    # scheduler (init_rooter(apply_state=True)) resets rooter state.
+    import lib.cuckoo.core.startup as startup
+
+    class _FakeSock:
+        def connect(self, *a):
+            pass
+
+    class _R:
+        class vpn:
+            enabled = False
+
+        class tor:
+            enabled = False
+
+        class inetsim:
+            enabled = False
+
+        class socks5:
+            enabled = False
+
+        class routing:
+            route = "none"
+            internet = "none"
+
+        class nexthop:
+            enabled = True
+
+    monkeypatch.setattr(startup.socket, "socket", lambda *a, **k: _FakeSock())
+    monkeypatch.setattr(startup, "routing", _R, raising=False)
+    monkeypatch.setattr(startup.subprocess, "run",
+                        lambda *a, **k: type("P", (), {"returncode": 1, "stdout": "", "stderr": ""})())
+    recorded = []
+    monkeypatch.setattr(startup, "rooter", lambda cmd, *a, **k: recorded.append(cmd) or {"output": True}, raising=False)
+
+    startup.init_rooter()   # web path (apply_state=False)
+    assert recorded == []   # reachability checked, but NO state-reset mutations
+
+    startup.init_rooter(apply_state=True)   # scheduler path
+    assert "cleanup_rooter" in recorded and "forward_drop" in recorded

--- a/tests/test_nexthop_selection.py
+++ b/tests/test_nexthop_selection.py
@@ -1,0 +1,463 @@
+# tests/test_nexthop_selection.py
+import pytest
+import threading
+import lib.cuckoo.core.rooter as core_rooter
+
+
+class _Profile:
+    def __init__(self, name, interface, rt_table, priority):
+        self.name, self.interface, self.rt_table, self.priority = name, interface, rt_table, priority
+
+
+def _seed(monkeypatch, live=("gw1", "gw2", "gw3")):
+    gws = {n: _Profile(n, f"ens{6+i}", str(201 + i), 0) for i, n in enumerate(("gw1", "gw2", "gw3"))}
+    monkeypatch.setattr(core_rooter, "gateways", gws, raising=False)
+    monkeypatch.setattr(core_rooter, "_gw_cursor", 0, raising=False)
+    monkeypatch.setattr(core_rooter, "_gw_live", lambda p: p.name in live)  # liveness shim
+    return gws
+
+
+def test_explicit_id_resolves(monkeypatch):
+    _seed(monkeypatch)
+    assert core_rooter._select_gateway("gw2").name == "gw2"
+
+
+def test_explicit_id_down_fails_closed(monkeypatch):
+    _seed(monkeypatch, live=("gw1", "gw3"))
+    assert core_rooter._select_gateway("gw2") is None  # named-but-down => caller drops
+
+
+def test_roundrobin_cycles_over_live(monkeypatch):
+    _seed(monkeypatch, live=("gw1", "gw3"))  # gw2 down
+    picks = [core_rooter._select_gateway("roundrobin").name for _ in range(4)]
+    assert picks == ["gw1", "gw3", "gw1", "gw3"]
+
+
+def test_empty_pool_fails_closed(monkeypatch):
+    monkeypatch.setattr(core_rooter, "gateways", {}, raising=False)
+    assert core_rooter._select_gateway("roundrobin") is None
+
+
+def test_roundrobin_threadsafe(monkeypatch):
+    _seed(monkeypatch)
+    out = []
+    lock = threading.Lock()
+
+    def worker():
+        p = core_rooter._select_gateway("roundrobin")
+        with lock:
+            out.append(p.name)
+    threads = [threading.Thread(target=worker) for _ in range(300)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    # even distribution across 3 live gateways, no crash
+    assert all(out.count(n) == 100 for n in ("gw1", "gw2", "gw3"))
+
+
+def test_unknown_selector_fails_closed(monkeypatch):
+    # gemini #15: a value that is neither a known gateway id nor 'random'/'roundrobin' must NOT
+    # silently fall through to roundrobin — it fails closed (returns None so the caller drops).
+    _seed(monkeypatch)
+    assert core_rooter._select_gateway("bogus") is None
+    assert core_rooter._select_gateway("roundrobin").name in ("gw1", "gw2", "gw3")  # policy still works
+
+
+# ---------------------------------------------------------------------------
+# _FakeRouting helper shared by T7 and T8 tests
+# ---------------------------------------------------------------------------
+
+class _FakeGw1:
+    """Fake [gw1] section: rt_table is an int (as config.getint would produce)."""
+    name = "gw1"
+    interface = "ens6"
+    next_hop = "onlink"
+    rt_table = 201  # int — loader must coerce to str
+
+
+class _FakeNexthop:
+    def __init__(self, enabled=True, route="gw1"):
+        self.enabled = enabled
+        self.gateways = "gw1"
+        self.default_policy = "roundrobin"
+        self.fail_closed = True
+        self.vm_net = "192.168.100.0/24"
+
+
+class _FakeRoutingSection:
+    """Fake top-level routing config section (routing.routing.route)."""
+    def __init__(self, route="none"):
+        self.route = route
+
+
+class _FakeVpn:
+    enabled = False
+
+
+class _FakeRouting:
+    """Minimal fake routing config for T7/T8 tests.
+
+    Exposes:
+      .nexthop  — _FakeNexthop (enabled/disabled, gateways="gw1")
+      .gw1      — _FakeGw1 (interface, next_hop, rt_table as int)
+      .routing  — .route
+      .vpn      — .enabled = False
+      .get(name) -> attribute named `name`
+    """
+    def __init__(self, nexthop_enabled=True, route="none"):
+        self.nexthop = _FakeNexthop(enabled=nexthop_enabled, route=route)
+        self.gw1 = _FakeGw1()
+        self.routing = _FakeRoutingSection(route=route)
+        self.vpn = _FakeVpn()
+
+    def get(self, name):
+        return getattr(self, name)
+
+
+# ---------------------------------------------------------------------------
+# T7: [gwX] loader — populates gateways global + coerces rt_table to str
+# ---------------------------------------------------------------------------
+
+def test_gwx_loader_populates_and_coerces(monkeypatch):
+    import lib.cuckoo.core.startup as startup
+    recorded = []
+    # startup.gateways is the dict object the loader writes into (imported reference, same object
+    # as core_rooter.gateways unless replaced).  Clear it in place so both refs see the reset.
+    startup.gateways.clear()
+    monkeypatch.setattr(startup, "rooter", lambda cmd, *a, **k: recorded.append((cmd, a)) or {}, raising=False)
+    startup.load_nexthop_profiles(_FakeRouting())
+    # Check via startup.gateways (the dict the function mutated)
+    assert "gw1" in startup.gateways
+    assert startup.gateways["gw1"].rt_table == "201"   # coerced to str
+    assert ("nexthop_init", ("201", "ens6", "onlink")) in recorded
+    assert any(c == "nexthop_fail_closed_enable" for c, _ in recorded)
+    assert any(c == "nexthop_teardown" for c, _ in recorded)
+    # ORDER MATTERS: nexthop_teardown flushes the gateway tables, so it must run
+    # BEFORE nexthop_init (which builds them) — otherwise it wipes the fresh routes.
+    # And fail-closed arms last. (Regression guard for the loader ordering bug found
+    # in the live FakeNet detonation on 2026-07-01.)
+    cmds = [c for c, _ in recorded]
+    assert cmds.index("nexthop_teardown") < cmds.index("nexthop_init"), \
+        f"teardown must precede init, got order: {cmds}"
+    assert cmds.index("nexthop_init") < cmds.index("nexthop_fail_closed_enable"), \
+        f"init must precede fail_closed arm, got order: {cmds}"
+
+
+class _DictSection(dict):
+    """Faithful stand-in for CAPE's config Dictionary: attribute access maps to dict
+    keys and a MISSING key returns None (not AttributeError). This is exactly how a
+    real [gwX] section behaves for the absent `name` field."""
+    def __getattr__(self, k):
+        return self.get(k)
+
+    def __setattr__(self, k, v):
+        self[k] = v
+
+
+def test_gwx_loader_stamps_profile_name_from_section_header(monkeypatch):
+    """Regression (live FakeNet detonation, 2026-07-01): [gwX] sections carry no `name =`
+    field (unlike [vpnX]/[socks5]), so config Dictionary.__getattr__ returns None for
+    entry.name. The loader MUST stamp the section header as the profile id — otherwise
+    analysis_manager._resolve_nexthop sets self.nexthop_id = profile.name = None, and
+    _dispatch_nexthop's `if not self.nexthop_id: return` silently no-ops: the per-task
+    source rule never installs and every real task falls through to the fail-closed
+    blackhole. Unit tests missed it because the fakes hard-coded .name; the real config
+    does not."""
+    import lib.cuckoo.core.startup as startup
+
+    class _NamelessRouting(_FakeRouting):
+        def __init__(self):
+            super().__init__()
+            # a [gw1] section with NO `name` key — the real routing.conf shape
+            self.gw1 = _DictSection(interface="ens6", next_hop="onlink", rt_table=201)
+
+    routing = _NamelessRouting()
+    # precondition: the section reports no name (mimics config Dictionary -> None)
+    assert routing.gw1.name is None
+    startup.gateways.clear()
+    monkeypatch.setattr(startup, "rooter", lambda cmd, *a, **k: {}, raising=False)
+    startup.load_nexthop_profiles(routing)
+    # postcondition: loader stamped the id so nexthop_id resolves to a real value
+    assert startup.gateways["gw1"].name == "gw1"
+
+
+# ---------------------------------------------------------------------------
+# T8: validate_default_route — gateway route accepted; unknown raises
+# ---------------------------------------------------------------------------
+
+def test_nexthop_default_route_boots_without_vpn(monkeypatch):
+    import lib.cuckoo.core.startup as startup
+    # Seed gateways so "gw1" is known. validate_default_route reads the module-global
+    # `gateways` in startup's namespace (bound via `from ... import gateways`), so patch
+    # THAT binding — patching core_rooter.gateways would be invisible to startup.
+    monkeypatch.setattr(startup, "gateways", {"gw1": _FakeGw1()})
+    # routing.route = "gw1", nexthop enabled, vpn disabled -> must NOT raise
+    startup.validate_default_route(_FakeRouting(route="gw1"))
+
+
+def test_nexthop_policy_token_default_route_boots_without_vpn(monkeypatch):
+    # codex P2: a pool-policy token (roundrobin/random) is a valid DEFAULT route when nexthop is
+    # on — _resolve_nexthop maps it to default_policy and picks from the live pool. validate must
+    # accept it WITHOUT a VPN, even though it is not a concrete gateway id; otherwise the
+    # documented pool default raises the vpn-not-enabled error at startup. (gateways empty on
+    # purpose to prove acceptance is by-token, not by-id.)
+    import lib.cuckoo.core.startup as startup
+    monkeypatch.setattr(startup, "gateways", {})
+    for tok in ("roundrobin", "random"):
+        startup.validate_default_route(_FakeRouting(route=tok))  # must NOT raise
+
+
+def test_nexthop_sentinel_default_route_boots_without_vpn(monkeypatch):
+    # Copilot: `[routing] route = nexthop` is the documented pool default (maps to default_policy).
+    # validate_default_route must accept the sentinel WITHOUT a VPN, else the default_policy path is
+    # unreachable in production. gateways empty on purpose (sentinel is not a gateway id).
+    import lib.cuckoo.core.startup as startup
+    monkeypatch.setattr(startup, "gateways", {})
+    startup.validate_default_route(_FakeRouting(route="nexthop"))  # must NOT raise
+
+
+def test_gateway_named_nexthop_raises(monkeypatch):
+    # Copilot: "nexthop" is the pool sentinel, so a [gwX] must not be named it (ambiguous with the
+    # default-policy route). Rejected via _RESERVED_ROUTE_NAMES.
+    import lib.cuckoo.core.startup as startup
+    from lib.cuckoo.common.exceptions import CuckooStartupError
+
+    class _GwNamedNexthop(_FakeRouting):
+        def __init__(self):
+            super().__init__()
+            self.nexthop = _DictSection(enabled=True, gateways="nexthop", default_policy="roundrobin",
+                                        fail_closed=True, vm_net="192.168.100.0/24")
+            self.nexthop_section = _DictSection(interface="ens6", next_hop="onlink", rt_table=201)
+
+        def get(self, name):
+            return self.nexthop_section if name == "nexthop" else getattr(self, name)
+
+    startup.gateways.clear()
+    monkeypatch.setattr(startup, "rooter", lambda *a, **k: {}, raising=False)
+    with pytest.raises(CuckooStartupError):
+        startup.load_nexthop_profiles(_GwNamedNexthop())
+
+
+def test_unknown_gateway_default_route_raises(monkeypatch):
+    import lib.cuckoo.core.startup as startup
+    from lib.cuckoo.common.exceptions import CuckooStartupError
+    # gateways is empty — "gw9" is unknown (patch startup's binding, not core_rooter's)
+    monkeypatch.setattr(startup, "gateways", {})
+    with pytest.raises(CuckooStartupError):
+        startup.validate_default_route(_FakeRouting(route="gw9"))
+
+
+# ---------------------------------------------------------------------------
+# T11: no-regress — disabled [nexthop] is a no-op (empty gateways, no rooter calls)
+# ---------------------------------------------------------------------------
+
+def test_nexthop_disabled_is_noop(monkeypatch):
+    import lib.cuckoo.core.startup as startup
+    import lib.cuckoo.core.rooter as core_rooter
+    monkeypatch.setattr(core_rooter, "gateways", {}, raising=False)
+    called = []
+    monkeypatch.setattr(startup, "rooter", lambda *a, **k: called.append(a) or {}, raising=False)
+    startup.load_nexthop_profiles(_FakeRouting(nexthop_enabled=False))
+    assert core_rooter.gateways == {} and called == []
+
+
+# ---------------------------------------------------------------------------
+# gemini #14 MEDIUM: [nexthop]/[gwX] required-option validation (clear startup error)
+# ---------------------------------------------------------------------------
+
+def test_nexthop_missing_vm_net_raises(monkeypatch):
+    import lib.cuckoo.core.startup as startup
+    from lib.cuckoo.common.exceptions import CuckooStartupError
+
+    class _NexthopNoVmNet(_FakeRouting):
+        def __init__(self):
+            super().__init__()
+            # enabled + gateways set, but vm_net absent (config Dictionary -> None)
+            self.nexthop = _DictSection(enabled=True, gateways="gw1", default_policy="roundrobin", fail_closed=True)
+
+    startup.gateways.clear()
+    monkeypatch.setattr(startup, "rooter", lambda *a, **k: {}, raising=False)
+    with pytest.raises(CuckooStartupError):
+        startup.load_nexthop_profiles(_NexthopNoVmNet())
+
+
+def test_gwx_missing_interface_raises(monkeypatch):
+    import lib.cuckoo.core.startup as startup
+    from lib.cuckoo.common.exceptions import CuckooStartupError
+
+    class _GwNoInterface(_FakeRouting):
+        def __init__(self):
+            super().__init__()
+            # [gw1] with next_hop + rt_table but NO interface (config Dictionary -> None)
+            self.gw1 = _DictSection(next_hop="onlink", rt_table=201)
+
+    startup.gateways.clear()
+    monkeypatch.setattr(startup, "rooter", lambda *a, **k: {}, raising=False)
+    with pytest.raises(CuckooStartupError):
+        startup.load_nexthop_profiles(_GwNoInterface())
+
+
+def test_gwx_reserved_rt_table_raises(monkeypatch):
+    # ADVERSARIAL-REVIEW HIGH (2026-07-08): the nexthop_init reserved-table guard alone leaves a
+    # fail-OPEN — a [gwX] with rt_table=main is still registered/selectable, and its per-task rule
+    # `from vm_ip lookup main priority 100xx` (below the 30000 blackhole) routes the VM out the host
+    # default route. Reject a reserved rt_table at LOAD so the profile can never be dispatched.
+    import lib.cuckoo.core.startup as startup
+    from lib.cuckoo.common.exceptions import CuckooStartupError
+
+    for bad in ("main", "local", "default", "254", "255", "253", "0"):
+        class _GwReservedTable(_FakeRouting):
+            def __init__(self, rt=bad):
+                super().__init__()
+                self.gw1 = _DictSection(interface="ens6", next_hop="onlink", rt_table=rt)
+
+        startup.gateways.clear()
+        monkeypatch.setattr(startup, "rooter", lambda *a, **k: {}, raising=False)
+        with pytest.raises(CuckooStartupError):
+            startup.load_nexthop_profiles(_GwReservedTable())
+        assert "gw1" not in startup.gateways, f"reserved-table gw1 (rt={bad}) leaked into gateways"
+
+
+def test_gwx_rt_table_is_fail_table_raises(monkeypatch):
+    # codex P2: a [gwX] rt_table == NEXTHOP_FAIL_TABLE (250) is not a kernel-reserved table so it
+    # passes the reserved-table check, but nexthop_fail_closed_enable's `ip route replace blackhole
+    # default table 250` would overwrite the gateway's default with a blackhole → every task on that
+    # gateway silently drops. Reject it at load.
+    import lib.cuckoo.core.startup as startup
+    from lib.cuckoo.common.exceptions import CuckooStartupError
+
+    class _GwFailTable(_FakeRouting):
+        def __init__(self):
+            super().__init__()
+            self.gw1 = _DictSection(interface="ens6", next_hop="onlink", rt_table=startup.NEXTHOP_FAIL_TABLE)
+
+    startup.gateways.clear()
+    monkeypatch.setattr(startup, "rooter", lambda *a, **k: {}, raising=False)
+    with pytest.raises(CuckooStartupError):
+        startup.load_nexthop_profiles(_GwFailTable())
+    assert "gw1" not in startup.gateways
+
+
+def test_gwx_duplicate_rt_table_raises(monkeypatch):
+    # codex P2: two [gwX] sharing an rt_table → nexthop_init flush/replaces the one table per profile
+    # so the last gateway's default wins, but the earlier gateway stays selectable with a per-task rule
+    # pointing at a table for the WRONG egress interface → misroute/drop. Fail startup on duplicates.
+    import lib.cuckoo.core.startup as startup
+    from lib.cuckoo.common.exceptions import CuckooStartupError
+
+    class _GwDupTable(_FakeRouting):
+        def __init__(self):
+            super().__init__()
+            self.nexthop = _DictSection(enabled=True, gateways="gw1,gw2", default_policy="roundrobin",
+                                        fail_closed=True, vm_net="192.168.100.0/24")
+            self.gw1 = _DictSection(interface="ens6", next_hop="onlink", rt_table=201)
+            self.gw2 = _DictSection(interface="ens7", next_hop="onlink", rt_table=201)  # same table -> reject
+
+    startup.gateways.clear()
+    monkeypatch.setattr(startup, "rooter", lambda *a, **k: {}, raising=False)
+    with pytest.raises(CuckooStartupError):
+        startup.load_nexthop_profiles(_GwDupTable())
+
+
+def test_nexthop_intra_exception_installed_even_when_fail_closed_off(monkeypatch):
+    # codex P2: the intra-subnet exception is a CONNECTIVITY guarantee, separate from the blackhole.
+    # With [nexthop] fail_closed=no it MUST still be installed (else a bound VM's intra-vm_net traffic
+    # misroutes to the gateway), while the blackhole (nexthop_fail_closed_enable) must NOT be.
+    import lib.cuckoo.core.startup as startup
+    recorded = []
+
+    class _NexthopNoFailClosed(_FakeRouting):
+        def __init__(self):
+            super().__init__()
+            self.nexthop = _DictSection(enabled=True, gateways="gw1", default_policy="roundrobin",
+                                        fail_closed=False, vm_net="192.168.100.0/24")
+
+    startup.gateways.clear()
+    monkeypatch.setattr(startup, "vpns", {}, raising=False)
+    monkeypatch.setattr(startup, "rooter", lambda cmd, *a, **k: recorded.append(cmd) or {}, raising=False)
+    startup.load_nexthop_profiles(_NexthopNoFailClosed())
+    assert "nexthop_intra_exception_enable" in recorded
+    assert "nexthop_fail_closed_enable" not in recorded
+
+
+def test_gwx_rt_table_collides_with_vpn_raises(monkeypatch):
+    # adversarial-review HIGH: a [gwX] rt_table equal to a configured VPN's rt_table would clobber the
+    # VPN's just-built routing table (nexthop_init flush/replace) -> VPN tasks silently egress the
+    # gateway NIC instead of the tunnel (VPN-isolation break). Reject at load. The VPN rt_table is an
+    # int here to prove the str-coercion works (config may give int or name).
+    import lib.cuckoo.core.startup as startup
+    from lib.cuckoo.common.exceptions import CuckooStartupError
+
+    class _GwVpnTable(_FakeRouting):
+        def __init__(self):
+            super().__init__()
+            self.gw1 = _DictSection(interface="ens6", next_hop="onlink", rt_table=201)
+
+    startup.gateways.clear()
+    monkeypatch.setattr(startup, "vpns", {"vpn0": type("V", (), {"rt_table": 201})()}, raising=False)
+    monkeypatch.setattr(startup, "rooter", lambda *a, **k: {}, raising=False)
+    with pytest.raises(CuckooStartupError):
+        startup.load_nexthop_profiles(_GwVpnTable())
+    assert "gw1" not in startup.gateways
+
+
+def test_gwx_rt_table_collides_with_dirty_line_raises(monkeypatch):
+    # adversarial-review HIGH: a [gwX] rt_table equal to routing.routing.rt_table (the internet
+    # dirty-line table) would be clobbered by the dirty-line init_rttable that runs AFTER us ->
+    # gateway tasks egress the dirty line instead of the gateway egress_if. Reject at load.
+    import lib.cuckoo.core.startup as startup
+    from lib.cuckoo.common.exceptions import CuckooStartupError
+
+    class _GwDirtyLineTable(_FakeRouting):
+        def __init__(self):
+            super().__init__()
+            self.routing = _DictSection(route="none", rt_table="201")  # dirty-line table == gw table
+            self.gw1 = _DictSection(interface="ens6", next_hop="onlink", rt_table=201)
+
+    startup.gateways.clear()
+    monkeypatch.setattr(startup, "vpns", {}, raising=False)
+    monkeypatch.setattr(startup, "rooter", lambda *a, **k: {}, raising=False)
+    with pytest.raises(CuckooStartupError):
+        startup.load_nexthop_profiles(_GwDirtyLineTable())
+    assert "gw1" not in startup.gateways
+
+
+def test_gateway_named_like_policy_token_raises(monkeypatch):
+    # A [gwX] must not be named a pool-policy token (roundrobin/random): _select_gateway would
+    # treat the name as the policy, not the id, so the profile could never be explicitly selected.
+    import lib.cuckoo.core.startup as startup
+    from lib.cuckoo.common.exceptions import CuckooStartupError
+
+    for tok in ("roundrobin", "random"):
+        class _GwPolicyName(_FakeRouting):
+            def __init__(self, name=tok):
+                super().__init__()
+                self.nexthop = _DictSection(enabled=True, gateways=name, default_policy="roundrobin",
+                                            fail_closed=True, vm_net="192.168.100.0/24")
+                setattr(self, name, _DictSection(interface="ens6", next_hop="onlink", rt_table=201))
+
+        startup.gateways.clear()
+        monkeypatch.setattr(startup, "rooter", lambda *a, **k: {}, raising=False)
+        with pytest.raises(CuckooStartupError):
+            startup.load_nexthop_profiles(_GwPolicyName())
+
+
+def test_nexthop_enabled_empty_pool_raises(monkeypatch):
+    # gemini medium: [nexthop] enabled with an empty/blank gateways list parses zero profiles.
+    # Without a guard, every task would silently fall through to the fail-closed blackhole —
+    # so fail loudly at startup instead. `gateways = ""` passes the not-None required-option
+    # check (empty string != None) but yields no profiles.
+    import lib.cuckoo.core.startup as startup
+    from lib.cuckoo.common.exceptions import CuckooStartupError
+
+    class _NexthopEmptyPool(_FakeRouting):
+        def __init__(self):
+            super().__init__()
+            self.nexthop = _DictSection(enabled=True, gateways="  ,  ", default_policy="roundrobin",
+                                        fail_closed=True, vm_net="192.168.100.0/24")
+
+    startup.gateways.clear()
+    monkeypatch.setattr(startup, "rooter", lambda *a, **k: {}, raising=False)
+    with pytest.raises(CuckooStartupError):
+        startup.load_nexthop_profiles(_NexthopEmptyPool())

--- a/tests/test_nexthop_selection.py
+++ b/tests/test_nexthop_selection.py
@@ -412,7 +412,8 @@ def test_gwx_rt_table_collides_with_dirty_line_raises(monkeypatch):
     class _GwDirtyLineTable(_FakeRouting):
         def __init__(self):
             super().__init__()
-            self.routing = _DictSection(route="none", rt_table="201")  # dirty-line table == gw table
+            # dirty-line ENABLED (internet != none) and its table == the gw table -> collision
+            self.routing = _DictSection(route="internet", internet="ens_wan", rt_table="201")
             self.gw1 = _DictSection(interface="ens6", next_hop="onlink", rt_table=201)
 
     startup.gateways.clear()
@@ -421,6 +422,62 @@ def test_gwx_rt_table_collides_with_dirty_line_raises(monkeypatch):
     with pytest.raises(CuckooStartupError):
         startup.load_nexthop_profiles(_GwDirtyLineTable())
     assert "gw1" not in startup.gateways
+
+
+def test_gwx_rt_table_reused_when_dirty_line_disabled_ok(monkeypatch):
+    # codex P2: when the dirty line is DISABLED (internet = none) its rt_table is never built, so a
+    # [gwX] reusing that id must NOT be rejected -- a nexthop-only node must be able to start.
+    import lib.cuckoo.core.startup as startup
+
+    class _GwDirtyLineDisabled(_FakeRouting):
+        def __init__(self):
+            super().__init__()
+            self.routing = _DictSection(route="none", internet="none", rt_table="201")
+            self.gw1 = _DictSection(interface="ens6", next_hop="onlink", rt_table=201)
+
+    startup.gateways.clear()
+    monkeypatch.setattr(startup, "vpns", {}, raising=False)
+    monkeypatch.setattr(startup, "rooter", lambda *a, **k: {}, raising=False)
+    startup.load_nexthop_profiles(_GwDirtyLineDisabled())   # must NOT raise
+    assert "gw1" in startup.gateways
+
+
+def test_invalid_default_policy_raises(monkeypatch):
+    # codex P2: default_policy that is neither roundrobin/random nor a configured gateway id resolves
+    # to None in _select_gateway -> every pool task silently drops. Reject it at startup.
+    import lib.cuckoo.core.startup as startup
+    from lib.cuckoo.common.exceptions import CuckooStartupError
+
+    class _BadPolicy(_FakeRouting):
+        def __init__(self):
+            super().__init__()
+            self.nexthop = _DictSection(enabled=True, gateways="gw1", default_policy="gw2",
+                                        fail_closed=True, vm_net="192.168.100.0/24")
+            self.gw1 = _DictSection(interface="ens6", next_hop="onlink", rt_table=201)
+
+    startup.gateways.clear()
+    monkeypatch.setattr(startup, "vpns", {}, raising=False)
+    monkeypatch.setattr(startup, "rooter", lambda *a, **k: {}, raising=False)
+    with pytest.raises(CuckooStartupError):
+        startup.load_nexthop_profiles(_BadPolicy())
+
+
+def test_gateway_id_default_policy_ok(monkeypatch):
+    # default_policy may name a configured gateway id (pin the pool default to one exit).
+    import lib.cuckoo.core.startup as startup
+
+    class _GwPolicy(_FakeRouting):
+        def __init__(self):
+            super().__init__()
+            self.nexthop = _DictSection(enabled=True, gateways="gw1", default_policy="gw1",
+                                        fail_closed=True, vm_net="192.168.100.0/24")
+            self.gw1 = _DictSection(interface="ens6", next_hop="onlink", rt_table=201)
+
+    startup.gateways.clear()
+    monkeypatch.setattr(startup, "vpns", {}, raising=False)
+    monkeypatch.setattr(startup, "rooter", lambda *a, **k: {}, raising=False)
+    startup.load_nexthop_profiles(_GwPolicy())   # must NOT raise
+    assert "gw1" in startup.gateways
 
 
 def test_gateway_named_like_policy_token_raises(monkeypatch):

--- a/tests/test_rooter_nexthop.py
+++ b/tests/test_rooter_nexthop.py
@@ -47,6 +47,7 @@ def test_nexthop_init_onlink(rec):
     rooter.nexthop_init("201", "ens6", "onlink")
     assert rec["run"] == [
         ("ip", "route", "flush", "table", "201"),
+        ("ip", "route", "replace", "blackhole", "default", "table", "201"),
         ("ip", "route", "replace", "default", "dev", "ens6", "onlink", "table", "201"),
     ]
 
@@ -55,6 +56,7 @@ def test_nexthop_init_via(rec):
     rooter.nexthop_init("202", "ens7", "10.30.72.1")
     assert rec["run"] == [
         ("ip", "route", "flush", "table", "202"),
+        ("ip", "route", "replace", "blackhole", "default", "table", "202"),
         ("ip", "route", "replace", "default", "via", "10.30.72.1", "dev", "ens7", "table", "202"),
     ]
 

--- a/tests/test_rooter_nexthop.py
+++ b/tests/test_rooter_nexthop.py
@@ -1,0 +1,233 @@
+# tests/test_rooter_nexthop.py
+import pytest
+import utils.rooter as rooter
+
+
+@pytest.fixture
+def rec(monkeypatch):
+    """Record every run()/run_iptables() invocation as a list of argv tuples.
+
+    utils.rooter functions reference settings.ip / ServicePaths.ip (both the same
+    path at runtime, defined only in __main__), so inject both for unit tests.
+    """
+    calls = {"run": [], "iptables": []}
+
+    def fake_run(*args):
+        calls["run"].append(tuple(str(a) for a in args))
+        return ("", "")  # (stdout, stderr); real run() never raises
+
+    def fake_run_iptables(*args, **kwargs):
+        calls["iptables"].append(tuple(str(a) for a in args))
+        # A `-D` of an absent rule returns non-empty stderr; report "gone" so the idempotent
+        # delete-until-gone loop (_iptables_delete_all) terminates after one delete in tests.
+        if "-D" in args:
+            return ("", "iptables: Bad rule (does a matching rule exist in that chain?).")
+        return ("", "")
+
+    class _Settings:
+        ip = "ip"
+    monkeypatch.setattr(rooter, "settings", _Settings, raising=False)
+    monkeypatch.setattr(rooter.ServicePaths, "ip", "ip", raising=False)
+    monkeypatch.setattr(rooter.ServicePaths, "iptables", "iptables", raising=False)
+    monkeypatch.setattr(rooter, "run", fake_run)
+    monkeypatch.setattr(rooter, "run_iptables", fake_run_iptables)
+    return calls
+
+
+def test_recorder_captures(rec):
+    rooter.run("ip", "route", "show")
+    assert rec["run"] == [("ip", "route", "show")]
+
+
+# ---------------------------------------------------------------------------
+# Task 1: nexthop_init
+# ---------------------------------------------------------------------------
+
+def test_nexthop_init_onlink(rec):
+    rooter.nexthop_init("201", "ens6", "onlink")
+    assert rec["run"] == [
+        ("ip", "route", "flush", "table", "201"),
+        ("ip", "route", "replace", "default", "dev", "ens6", "onlink", "table", "201"),
+    ]
+
+
+def test_nexthop_init_via(rec):
+    rooter.nexthop_init("202", "ens7", "10.30.72.1")
+    assert rec["run"] == [
+        ("ip", "route", "flush", "table", "202"),
+        ("ip", "route", "replace", "default", "via", "10.30.72.1", "dev", "ens7", "table", "202"),
+    ]
+
+
+def test_nexthop_init_skips_reserved_table(rec):
+    # codex P1 / gemini critical: load_nexthop_profiles feeds each [gwX] rt_table straight into
+    # nexthop_init's flush at startup, so a misconfigured reserved table (main/254/...) must NOT
+    # be flushed — doing so would wipe the host's own routing. nexthop_teardown already guards
+    # this set; the init path must too. No ip command runs at all for a reserved table.
+    for bad in ("main", "local", "default", "254", "255", "253", "0"):
+        rec["run"].clear()
+        rooter.nexthop_init(bad, "ens6", "onlink")
+        assert rec["run"] == [], f"nexthop_init flushed reserved table {bad!r}: {rec['run']}"
+
+
+# ---------------------------------------------------------------------------
+# Task 2: nexthop_enable
+# ---------------------------------------------------------------------------
+
+def test_nexthop_enable_argv(rec):
+    # signature: (vm_ip, ingress_if, egress_if, rt_table, priority)
+    rooter.nexthop_enable("192.168.100.42", "virbr0", "ens6", "201", "10042")
+    # iproute2 + conntrack go through run(); nat/filter through run_iptables()
+    assert rec["run"] == [
+        ("conntrack", "-D", "-s", "192.168.100.42"),                                  # pre-bind flush
+        ("ip", "rule", "del", "from", "192.168.100.42", "lookup", "201", "priority", "10042"),  # idempotent pre-clean
+        ("ip", "rule", "add", "from", "192.168.100.42", "lookup", "201", "priority", "10042"),
+    ]
+    # Each iptables rule is delete-until-gone (idempotent; Copilot) then added once. The forward
+    # ACCEPT goes into CAPE_ACCEPTED_SEGMENTS (jumped first in FORWARD), NOT a tail `-A FORWARD`
+    # (else a libvirt `-i virbr* -j REJECT` would shadow it), and is constrained to the guest
+    # ingress interface `-i virbr0` so a spoofed source from another NIC isn't forwarded (codex).
+    assert rec["iptables"] == [
+        ("-t", "nat", "-D", "POSTROUTING", "-s", "192.168.100.42", "-o", "ens6", "-j", "MASQUERADE"),
+        ("-t", "nat", "-A", "POSTROUTING", "-s", "192.168.100.42", "-o", "ens6", "-j", "MASQUERADE"),
+        ("-D", "CAPE_ACCEPTED_SEGMENTS", "-i", "virbr0", "-s", "192.168.100.42", "-o", "ens6", "-j", "ACCEPT"),
+        ("-I", "CAPE_ACCEPTED_SEGMENTS", "-i", "virbr0", "-s", "192.168.100.42", "-o", "ens6", "-j", "ACCEPT"),
+    ]
+    # never a raw tail FORWARD append (regression guard for the shadowing bug)
+    assert not any(a[:2] == ("-A", "FORWARD") for a in rec["iptables"])
+
+
+# ---------------------------------------------------------------------------
+# Task 3: nexthop_disable
+# ---------------------------------------------------------------------------
+
+def test_nexthop_disable_argv(rec):
+    # signature: (vm_ip, ingress_if, egress_if, rt_table, priority)
+    rooter.nexthop_disable("192.168.100.42", "virbr0", "ens6", "201", "10042")
+    assert rec["run"] == [
+        ("ip", "rule", "del", "from", "192.168.100.42", "lookup", "201", "priority", "10042"),
+        ("conntrack", "-D", "-s", "192.168.100.42"),
+    ]
+    # mirror-delete (until gone) from the same chain/rules enable installed, incl. the -i ingress
+    assert rec["iptables"] == [
+        ("-t", "nat", "-D", "POSTROUTING", "-s", "192.168.100.42", "-o", "ens6", "-j", "MASQUERADE"),
+        ("-D", "CAPE_ACCEPTED_SEGMENTS", "-i", "virbr0", "-s", "192.168.100.42", "-o", "ens6", "-j", "ACCEPT"),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Task 4: nexthop_intra_exception_enable + nexthop_fail_closed_enable (split; codex P2)
+# ---------------------------------------------------------------------------
+
+def test_nexthop_intra_exception_argv(rec):
+    # band_lo=10000 => exception at band_lo-1 = 9999, BELOW the per-task band so it wins over a bound
+    # VM's `from <vm_ip> lookup <gw_table>` rule for intra-vm_net destinations. Installed regardless
+    # of fail_closed (connectivity, not fail-closed) -- see test_nexthop_disabled_is_noop siblings.
+    rooter.nexthop_intra_exception_enable("192.168.100.0/24", "10000")
+    assert rec["run"] == [
+        ("ip", "rule", "del", "from", "192.168.100.0/24", "to", "192.168.100.0/24", "lookup", "main", "priority", "9999"),
+        ("ip", "rule", "add", "from", "192.168.100.0/24", "to", "192.168.100.0/24", "lookup", "main", "priority", "9999"),
+    ]
+    # ORDERING INVARIANT: the intra-subnet exception MUST sit below the per-task band (10000),
+    # otherwise a bound VM's per-task rule shadows it and intra-vm_net traffic leaks to the gateway.
+    intra = [r for r in rec["run"] if r[:3] == ("ip", "rule", "add") and "to" in r]
+    assert intra and all(int(r[-1]) < 10000 for r in intra), intra
+
+
+def test_nexthop_fail_closed_argv(rec):
+    # fail_closed_enable now installs ONLY the blackhole (route + rule); the intra-subnet exception
+    # is a separate primitive installed regardless of fail_closed (codex P2). Signature dropped band_lo.
+    rooter.nexthop_fail_closed_enable("192.168.100.0/24", "250", "30000")
+    assert rec["run"] == [
+        ("ip", "route", "replace", "blackhole", "default", "table", "250"),
+        ("ip", "rule", "del", "from", "192.168.100.0/24", "lookup", "250", "priority", "30000"),
+        ("ip", "rule", "add", "from", "192.168.100.0/24", "lookup", "250", "priority", "30000"),
+    ]
+    # the blackhole primitive must NOT install the intra-subnet (`to vm_net`) exception anymore
+    assert not any("to" in r for r in rec["run"])
+
+
+# ---------------------------------------------------------------------------
+# Task 5: nexthop_teardown + nexthop_configure
+# ---------------------------------------------------------------------------
+
+def test_nexthop_teardown_sweeps_policy_routing(rec, monkeypatch):
+    # `ip rule show` returns two in-band per-task rules (from within vm_net), an out-of-band rule,
+    # AND an UNRELATED host admin rule that happens to sit in the 10000-10255 band but whose source
+    # is OUTSIDE vm_net -- teardown must NOT delete that one (codex P2).
+    def fake_run(*args):
+        rec["run"].append(tuple(str(a) for a in args))
+        if args[:3] == ("ip", "rule", "show"):
+            return ("10042: from 192.168.100.42 lookup 201\n"
+                    "10043: from 192.168.100.43 lookup 202\n"
+                    "10099: from 10.0.0.5 lookup 999\n"      # unrelated host rule in the band
+                    "32766: from all lookup main\n", "")
+        return ("", "")
+    monkeypatch.setattr(rooter, "run", fake_run)
+
+    rooter.nexthop_teardown("201,202", "192.168.100.0/24", "250", "30000", "10000", "10255")
+
+    assert ("ip", "route", "flush", "table", "201") in rec["run"]
+    assert ("ip", "route", "flush", "table", "202") in rec["run"]
+    assert ("ip", "route", "del", "blackhole", "default", "table", "250") in rec["run"]
+    assert ("ip", "rule", "del", "from", "192.168.100.0/24", "lookup", "250", "priority", "30000") in rec["run"]
+    # intra-subnet exception rule also removed on teardown
+    assert ("ip", "rule", "del", "from", "192.168.100.0/24", "to", "192.168.100.0/24", "lookup", "main", "priority", "9999") in rec["run"]
+    # in-band per-task rules (source in vm_net) swept -- by FULL selector (from + priority), not
+    # priority alone, so a host rule sharing the priority is never hit (codex).
+    assert ("ip", "rule", "del", "from", "192.168.100.42", "priority", "10042") in rec["run"]
+    assert ("ip", "rule", "del", "from", "192.168.100.43", "priority", "10043") in rec["run"]
+    # nothing deleted for the out-of-band 32766 main rule, nor for the in-band-but-NOT-ours rule
+    # (from 10.0.0.5, outside vm_net) -- neither its priority nor its source appears in any `del`.
+    dels = [r for r in rec["run"] if r[:3] == ("ip", "rule", "del")]
+    assert not any("32766" in r for r in dels)
+    assert not any(("10099" in r) or ("10.0.0.5" in r) for r in dels)
+
+
+def test_nexthop_teardown_skips_reserved_tables(rec):
+    # gemini #14 HIGH: even if a gateway profile is misconfigured with a reserved/system table
+    # id, teardown must NOT flush it — doing so (at startup + SIGTERM) would wipe the host's own
+    # routing and take the box offline. The real gateway table IS still flushed.
+    rooter.nexthop_teardown("main,254,201", "192.168.100.0/24", "250", "30000", "10000", "10255")
+    assert ("ip", "route", "flush", "table", "201") in rec["run"]
+    assert ("ip", "route", "flush", "table", "main") not in rec["run"]
+    assert ("ip", "route", "flush", "table", "254") not in rec["run"]
+
+
+def test_nexthop_configure_sets_globals(rec):
+    rooter.nexthop_configure("201,202", "192.168.100.0/24", "250", "30000", "10000", "10255")
+    assert rooter.GATEWAY_TABLES_CSV == "201,202"
+    assert rooter.NEXTHOP_VM_NET == "192.168.100.0/24"
+    assert rooter.NEXTHOP_FAIL_TABLE == "250"
+    assert rooter.NEXTHOP_PRIORITY_LOW == "30000"
+    assert rooter.NEXTHOP_BAND_LO == "10000"
+    assert rooter.NEXTHOP_BAND_HI == "10255"
+
+
+# ---------------------------------------------------------------------------
+# SIGTERM teardown gate — disabled node must be a no-op (Copilot C3)
+# ---------------------------------------------------------------------------
+
+def test_sigterm_teardown_noop_when_nexthop_never_configured(rec, monkeypatch):
+    # On a node that never enabled [nexthop], GATEWAY_TABLES_CSV is "" and the SIGTERM teardown
+    # helper must issue ZERO ip commands — no host policy-routing mutation, and crucially no
+    # 10000-10255 band sweep (which could delete an unrelated host rule). Guards the disabled=no-op
+    # contract, which is otherwise untestable (handle_sigterm lives inside __main__).
+    monkeypatch.setattr(rooter, "GATEWAY_TABLES_CSV", "", raising=False)
+    rooter.nexthop_teardown_if_configured()
+    assert rec["run"] == []
+    assert rec["iptables"] == []
+
+
+def test_sigterm_teardown_runs_when_configured(rec, monkeypatch):
+    # When the loader configured nexthop this session, the SIGTERM helper DOES tear down the
+    # gateway tables (positive control so the no-op test above can't pass by accident).
+    monkeypatch.setattr(rooter, "GATEWAY_TABLES_CSV", "201,202", raising=False)
+    monkeypatch.setattr(rooter, "NEXTHOP_VM_NET", "192.168.100.0/24", raising=False)
+    monkeypatch.setattr(rooter, "NEXTHOP_FAIL_TABLE", "250", raising=False)
+    monkeypatch.setattr(rooter, "NEXTHOP_PRIORITY_LOW", "30000", raising=False)
+    monkeypatch.setattr(rooter, "NEXTHOP_BAND_LO", "10000", raising=False)
+    monkeypatch.setattr(rooter, "NEXTHOP_BAND_HI", "10255", raising=False)
+    rooter.nexthop_teardown_if_configured()
+    assert ("ip", "route", "flush", "table", "201") in rec["run"]
+    assert ("ip", "route", "flush", "table", "202") in rec["run"]

--- a/tests/test_rooter_nexthop.py
+++ b/tests/test_rooter_nexthop.py
@@ -231,3 +231,51 @@ def test_sigterm_teardown_runs_when_configured(rec, monkeypatch):
     rooter.nexthop_teardown_if_configured()
     assert ("ip", "route", "flush", "table", "201") in rec["run"]
     assert ("ip", "route", "flush", "table", "202") in rec["run"]
+
+
+# --- nic_up: gateway liveness must require IFF_UP, not just existence (codex #14 P2) ---
+
+def _fake_ip_link(line):
+    def _co(*a, **k):
+        return line
+    return _co
+
+
+def test_nic_up_true_when_admin_up(monkeypatch):
+    class _S:
+        ip = "ip"
+    monkeypatch.setattr(rooter, "settings", _S, raising=False)
+    monkeypatch.setattr(rooter.subprocess, "check_output",
+                        _fake_ip_link("2: ens6: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 state UP\n"))
+    assert rooter.nic_up("ens6") is True
+
+
+def test_nic_up_false_when_admin_down(monkeypatch):
+    class _S:
+        ip = "ip"
+    monkeypatch.setattr(rooter, "settings", _S, raising=False)
+    monkeypatch.setattr(rooter.subprocess, "check_output",
+                        _fake_ip_link("3: ens7: <BROADCAST,MULTICAST> mtu 1500 state DOWN\n"))
+    assert rooter.nic_up("ens7") is False
+
+
+def test_nic_up_no_false_match_on_lower_up(monkeypatch):
+    # LOWER_UP (carrier) present but IFF_UP absent -> not admin-up; "UP" must be an exact token
+    class _S:
+        ip = "ip"
+    monkeypatch.setattr(rooter, "settings", _S, raising=False)
+    monkeypatch.setattr(rooter.subprocess, "check_output",
+                        _fake_ip_link("4: ens8: <BROADCAST,MULTICAST,LOWER_UP> mtu 1500 state DOWN\n"))
+    assert rooter.nic_up("ens8") is False
+
+
+def test_nic_up_false_when_missing(monkeypatch):
+    class _S:
+        ip = "ip"
+    monkeypatch.setattr(rooter, "settings", _S, raising=False)
+
+    def _raise(*a, **k):
+        raise rooter.subprocess.CalledProcessError(1, "ip")
+
+    monkeypatch.setattr(rooter.subprocess, "check_output", _raise)
+    assert rooter.nic_up("nope0") is False

--- a/tests/test_rooter_nexthop.py
+++ b/tests/test_rooter_nexthop.py
@@ -82,7 +82,7 @@ def test_nexthop_enable_argv(rec):
     # iproute2 + conntrack go through run(); nat/filter through run_iptables()
     assert rec["run"] == [
         ("conntrack", "-D", "-s", "192.168.100.42"),                                  # pre-bind flush
-        ("ip", "rule", "del", "from", "192.168.100.42", "lookup", "201", "priority", "10042"),  # idempotent pre-clean
+        ("ip", "rule", "del", "from", "192.168.100.42", "priority", "10042"),          # table-agnostic pre-clean (drops a stale old-table rebind rule too)
         ("ip", "rule", "add", "from", "192.168.100.42", "lookup", "201", "priority", "10042"),
     ]
     # Each iptables rule is delete-until-gone (idempotent; Copilot) then added once. The forward

--- a/tests/test_route_network_nexthop.py
+++ b/tests/test_route_network_nexthop.py
@@ -225,3 +225,25 @@ def test_unroute_noop_when_not_nexthop(mgr):
     mgr.nexthop_id = None
     mgr._unroute_nexthop()
     assert [c for c, _ in mgr._calls if c == "nexthop_disable"] == []
+
+
+def test_resolve_clears_stale_binding_on_reentry_failure(mgr, monkeypatch):
+    # route_network re-entry (e.g. machine retry): a first resolve binds a gateway; a later resolve
+    # that fails (empty/all-down pool) must FORCE drop AND clear self.nexthop_* so _dispatch_nexthop
+    # does not install a stale binding despite the drop decision (Copilot fail-open).
+    prof = type("P", (), {"name": "gw1", "interface": "ens6", "rt_table": "201", "priority": 0})()
+    routing = _fake_routing(default_policy="roundrobin", default_route="nexthop")
+    monkeypatch.setattr(am, "_select_gateway", lambda r: prof, raising=False)
+    monkeypatch.setattr(am, "gateways", {"gw1": prof}, raising=False)
+    mgr.route = "gw1"
+    assert mgr._resolve_nexthop(routing) is True
+    assert mgr.nexthop_id == "gw1"
+    # pool now empty -> second resolve fails: drop + stale binding cleared
+    monkeypatch.setattr(am, "_select_gateway", lambda r: None, raising=False)
+    mgr.route = "nexthop"
+    assert mgr._resolve_nexthop(routing) is False
+    assert mgr.route == "drop"
+    assert mgr.nexthop_id is None
+    mgr._calls.clear()
+    mgr._dispatch_nexthop()   # no-op: no stale binding to install
+    assert "nexthop_enable" not in [c for c, _ in mgr._calls]

--- a/tests/test_route_network_nexthop.py
+++ b/tests/test_route_network_nexthop.py
@@ -1,0 +1,227 @@
+# Copyright (C) 2010-2013 Claudio Guarnieri.
+# Copyright (C) 2014-2016 Cuckoo Foundation.
+# This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
+# See the file 'docs/LICENSE' for copying permission.
+"""Unit tests for the per-task [nexthop] resolve+bind branch in
+AnalysisManager.route_network / unroute_network.
+
+We drive the extracted helpers (_resolve_nexthop / _dispatch_nexthop /
+_unroute_nexthop) through a small `_route` shim so the branch is testable
+without standing up the full route_network() (DB, Config, machinery)."""
+import pytest
+
+import lib.cuckoo.core.analysis_manager as am
+
+
+@pytest.fixture
+def mgr(monkeypatch):
+    """A minimal AnalysisManager with a recording rooter and a fake machine/route."""
+    m = am.AnalysisManager.__new__(am.AnalysisManager)
+    m.interface = m.rt_table = m.route = None
+    m.nexthop_id = m.nexthop_interface = m.nexthop_rt_table = m.nexthop_priority = None
+    m.no_local_routing = m.reject_segments = m.reject_hostports = None
+    m.rooter_response = ""
+
+    class _Mach:
+        ip = "192.168.100.42"
+        interface = "virbr0"
+
+    m.machine = _Mach()
+    calls = []
+    monkeypatch.setattr(am, "rooter", lambda cmd, *a, **k: calls.append((cmd, a)) or {}, raising=False)
+    m._calls = calls
+    return m
+
+
+def _fake_routing(default_policy="roundrobin", default_route="nexthop"):
+    """Minimal stand-in for Config('routing') exposing .nexthop.* and .routing.route
+    (the configured default route — _resolve_nexthop only falls back to default_policy
+    when self.route equals it; a typo'd explicit route drops instead)."""
+    return type(
+        "R",
+        (),
+        {
+            "nexthop": type("NH", (), {"enabled": True, "default_policy": default_policy})(),
+            "routing": type("RT", (), {"route": default_route})(),
+        },
+    )()
+
+
+def _route(mgr, route, nexthop_enabled, default_policy="roundrobin", default_route="nexthop", tun_iface_exists=False):
+    """Replicate ONLY route_network's tunX + nexthop branches (the two the C1 reorder concerns).
+
+    This deliberately models just the tail of route_network's resolution chain: it captures the
+    RELATIVE ORDER of the tunX branch vs the nexthop branch and the nexthop-consumes-the-route
+    behaviour. It does NOT model the earlier legacy branches (none/inetsim/tor/internet/vpn/socks5)
+    or the post-resolution nic_available fallback -- in real route_network those legacy routes are
+    consumed by their own branches and never reach _resolve_nexthop. Tests that pass route="internet"
+    etc. here are exercising _resolve_nexthop's defensive reserved-DROP guard in isolation, not a
+    production route_network path.
+
+    The modelled invariants (Copilot fix): the tunX branch is checked BEFORE the nexthop branch,
+    because _resolve_nexthop rewrites self.route="drop" for any route it does not own and would
+    otherwise clobber an explicit tun route; and when [nexthop] is enabled its branch CONSUMES the
+    route (bind a gateway, or force drop) rather than an `and`-guarded pass, so a nexthop drop falls
+    into the none/drop/false dispatch below instead of a misleading "Unknown route" else.
+    `nexthop_enabled` False => the branch is never entered (legacy paths byte-for-byte unchanged).
+    """
+    routing = _fake_routing(default_policy, default_route)
+    mgr.route = route
+    # resolution chain: tun BEFORE nexthop
+    if str(mgr.route)[:3] == "tun" and tun_iface_exists:
+        mgr.interface = mgr.route
+    elif nexthop_enabled:
+        mgr._resolve_nexthop(routing)
+    # dispatch chain: forced-drop handled by the existing none/drop/false dispatch; tun by its own
+    if str(mgr.route).lower() in ("none", "drop", "false"):
+        am.rooter("drop_enable", mgr.machine.ip, "2042")
+    elif str(mgr.route)[:3] == "tun" and tun_iface_exists:
+        am.rooter("interface_route_tun_enable", mgr.machine.ip, mgr.route, "1")
+    mgr._dispatch_nexthop()
+
+
+def test_tun_route_not_hijacked_when_nexthop_enabled(mgr, monkeypatch):
+    # Copilot: an explicit tunX route must be handled by the tun branch, NOT clobbered to drop by
+    # _resolve_nexthop, when [nexthop] is enabled. route_network checks tun BEFORE nexthop.
+    # _select_gateway WOULD bind a live profile if reached — the fix must not reach it for a tun route.
+    live = type("P", (), {"name": "gw1", "interface": "ens6", "rt_table": "201", "priority": 0})()
+    monkeypatch.setattr(am, "_select_gateway", lambda r: live, raising=False)
+    monkeypatch.setattr(am, "gateways", {"gw1": live}, raising=False)
+    _route(mgr, route="tun0", nexthop_enabled=True, tun_iface_exists=True)
+    cmds = [c for c, _ in mgr._calls]
+    assert mgr.route == "tun0"          # NOT rewritten to drop
+    assert mgr.interface == "tun0"      # handled by the tun branch
+    assert mgr.nexthop_id is None       # nexthop never bound it
+    assert "interface_route_tun_enable" in cmds
+    assert "drop_enable" not in cmds and "nexthop_enable" not in cmds
+
+
+def test_explicit_nexthop_sentinel_uses_default_policy(mgr, monkeypatch):
+    # Copilot: route="nexthop" (explicit) maps to default_policy pool selection regardless of the
+    # node's configured default route — this is what makes the documented pool default reachable.
+    prof = type("P", (), {"name": "gw2", "interface": "ens7", "rt_table": "202", "priority": 0})()
+    monkeypatch.setattr(am, "_select_gateway", lambda r: prof if r in ("roundrobin", "random") else None, raising=False)
+    monkeypatch.setattr(am, "gateways", {"gw2": prof}, raising=False)
+    # node default is a DIFFERENT gateway, proving the "nexthop" sentinel is honored on its own
+    _route(mgr, route="nexthop", nexthop_enabled=True, default_policy="roundrobin", default_route="gw2")
+    cmds = [c for c, _ in mgr._calls]
+    assert "nexthop_enable" in cmds and "drop_enable" not in cmds
+    assert mgr.nexthop_id == "gw2"
+
+
+def test_explicit_gateway_binds_and_skips_generic(mgr, monkeypatch):
+    prof = type("P", (), {"name": "gw1", "interface": "ens6", "rt_table": "201", "priority": 0})()
+    monkeypatch.setattr(am, "_select_gateway", lambda r: prof if r == "gw1" else None, raising=False)
+    monkeypatch.setattr(am, "gateways", {"gw1": prof}, raising=False)
+    _route(mgr, route="gw1", nexthop_enabled=True)
+    # bound to the profile, generic forward/srcroute NOT used
+    assert mgr.interface is None  # generic block skipped (H2 option b)
+    assert mgr.rt_table is None  # so the srcroute_enable elif is skipped too
+    assert mgr.nexthop_id == "gw1"
+    assert mgr.nexthop_interface == "ens6"
+    assert mgr.nexthop_rt_table == "201"
+    assert mgr.nexthop_priority == "10042"  # 10000 + last octet
+    cmds = [c for c, _ in mgr._calls]
+    assert "nexthop_enable" in cmds
+    assert "forward_enable" not in cmds and "srcroute_enable" not in cmds
+    assert "drop_enable" not in cmds
+
+
+def test_typo_gateway_fails_closed_to_drop(mgr, monkeypatch):
+    monkeypatch.setattr(am, "_select_gateway", lambda r: None, raising=False)
+    monkeypatch.setattr(am, "gateways", {}, raising=False)
+    _route(mgr, route="gw9", nexthop_enabled=True)
+    cmds = [c for c, _ in mgr._calls]
+    assert "drop_enable" in cmds  # review B1: never fall through to no-op
+    assert "nexthop_enable" not in cmds
+    assert mgr.route == "drop"
+    assert mgr.nexthop_id is None
+    assert mgr.interface is None  # not left on host default forwarding
+
+
+def test_typod_route_drops_even_when_a_gateway_is_live(mgr, monkeypatch):
+    # gemini #14 HIGH: a typo'd/foreign route (e.g. "vpn9") that is NOT a gateway id, NOT a
+    # policy token, and NOT the configured default route must DROP — it must never fall back
+    # to default_policy and silently egress via a live gateway (isolation-boundary bypass).
+    live = type("P", (), {"name": "gw1", "interface": "ens6", "rt_table": "201", "priority": 0})()
+    # _select_gateway WOULD return a live profile if reached — the fix must not reach it.
+    monkeypatch.setattr(am, "_select_gateway", lambda r: live, raising=False)
+    monkeypatch.setattr(am, "gateways", {"gw1": live}, raising=False)
+    _route(mgr, route="vpn9", nexthop_enabled=True, default_route="nexthop")
+    cmds = [c for c, _ in mgr._calls]
+    assert "drop_enable" in cmds and "nexthop_enable" not in cmds
+    assert mgr.route == "drop" and mgr.nexthop_id is None
+
+
+def test_configured_default_route_uses_default_policy(mgr, monkeypatch):
+    # When the task uses the node's CONFIGURED default route (self.route == routing.routing.route),
+    # fall back to default_policy (roundrobin/random) and pick from the live pool.
+    prof = type("P", (), {"name": "gw2", "interface": "ens7", "rt_table": "202", "priority": 0})()
+    monkeypatch.setattr(am, "_select_gateway", lambda r: prof if r in ("roundrobin", "random") else None, raising=False)
+    monkeypatch.setattr(am, "gateways", {"gw2": prof}, raising=False)
+    _route(mgr, route="nexthop", nexthop_enabled=True, default_policy="roundrobin", default_route="nexthop")
+    cmds = [c for c, _ in mgr._calls]
+    assert "nexthop_enable" in cmds and "drop_enable" not in cmds
+    assert mgr.nexthop_id == "gw2"
+
+
+def test_reserved_route_never_resolves_to_gateway(mgr, monkeypatch):
+    # gemini #15 (security-critical): a reserved route (none/drop/false/internet/tor/inetsim) must
+    # DROP, never resolve to a gateway — even if it is the node's configured default route.
+    live = type("P", (), {"name": "gw1", "interface": "ens6", "rt_table": "201", "priority": 0})()
+    monkeypatch.setattr(am, "_select_gateway", lambda r: live, raising=False)  # would bind if reached
+    monkeypatch.setattr(am, "gateways", {"gw1": live}, raising=False)
+    _route(mgr, route="internet", nexthop_enabled=True, default_route="internet")
+    cmds = [c for c, _ in mgr._calls]
+    assert "drop_enable" in cmds and "nexthop_enable" not in cmds
+    assert mgr.route == "drop" and mgr.nexthop_id is None
+
+
+def test_all_nexthop_args_are_str(mgr, monkeypatch):
+    prof = type("P", (), {"name": "gw1", "interface": "ens6", "rt_table": "201", "priority": 0})()
+    monkeypatch.setattr(am, "_select_gateway", lambda r: prof, raising=False)
+    monkeypatch.setattr(am, "gateways", {"gw1": prof}, raising=False)
+    _route(mgr, route="gw1", nexthop_enabled=True)
+    found = False
+    for cmd, args in mgr._calls:
+        if cmd == "nexthop_enable":
+            found = True
+            assert all(isinstance(a, str) for a in args)
+    assert found
+
+
+def test_no_regress_vpn_and_none(mgr):
+    # nexthop DISABLED -> _resolve_nexthop must never run; route=vpn0/none unchanged.
+    # vpn0 path
+    _route(mgr, route="vpn0", nexthop_enabled=False)
+    assert mgr.nexthop_id is None
+    cmds = [c for c, _ in mgr._calls]
+    assert "nexthop_enable" not in cmds  # no nexthop calls leak into the legacy path
+    # none path
+    mgr._calls.clear()
+    mgr.nexthop_id = None
+    _route(mgr, route="none", nexthop_enabled=False)
+    assert "nexthop_enable" not in [c for c, _ in mgr._calls]
+
+
+def test_unroute_mirrors_persisted_tuple(mgr, monkeypatch):
+    prof = type("P", (), {"name": "gw1", "interface": "ens6", "rt_table": "201", "priority": 0})()
+    monkeypatch.setattr(am, "_select_gateway", lambda r: prof, raising=False)
+    monkeypatch.setattr(am, "gateways", {"gw1": prof}, raising=False)
+    _route(mgr, route="gw1", nexthop_enabled=True)
+    enable_args = next(a for c, a in mgr._calls if c == "nexthop_enable")
+    mgr._calls.clear()
+    mgr._unroute_nexthop()  # extracted helper called from unroute_network
+    disable_args = next(a for c, a in mgr._calls if c == "nexthop_disable")
+    # disable deletes EXACTLY what enable created (vm_ip, ingress bridge, egress iface, rt_table,
+    # priority). The selector is NOT re-run: the persisted self.nexthop_* tuple + machine is used (M5).
+    assert disable_args == ("192.168.100.42", "virbr0", "ens6", "201", "10042")
+    assert disable_args == enable_args
+
+
+def test_unroute_noop_when_not_nexthop(mgr):
+    # no nexthop_id => _unroute_nexthop must issue nothing (legacy paths untouched,
+    # and the generic disable block is skipped because self.interface is None).
+    mgr.nexthop_id = None
+    mgr._unroute_nexthop()
+    assert [c for c, _ in mgr._calls if c == "nexthop_disable"] == []

--- a/utils/rooter.py
+++ b/utils/rooter.py
@@ -202,6 +202,22 @@ def nic_available(interface):
         return False
 
 
+def nic_up(interface):
+    """Check that the interface exists AND is administratively up (IFF_UP). Unlike nic_available, an
+    existing-but-DOWN link returns False: the nexthop selector must not treat a down gateway NIC as a
+    live egress (round-robin/random would otherwise bind a task to a dead exit)."""
+    try:
+        out = subprocess.check_output(
+            [settings.ip, "-o", "link", "show", interface], stderr=subprocess.PIPE, universal_newlines=True
+        )
+    except subprocess.CalledProcessError:
+        return False
+    # Flags live in the angle-bracket group, e.g. "<BROADCAST,MULTICAST,UP,LOWER_UP>"; IFF_UP == "UP"
+    # (an exact token, so "LOWER_UP" carrier does not false-match).
+    flags = out.split("<", 1)[-1].split(">", 1)[0] if "<" in out else ""
+    return "UP" in flags.split(",")
+
+
 def rt_available(rt_table):
     """Check if specified routing table is defined."""
     try:
@@ -1249,6 +1265,7 @@ def sslproxy_disable(interface, client, proxy_port, resultserver_port, rt_table=
 
 handlers = {
     "nic_available": nic_available,
+    "nic_up": nic_up,
     "rt_available": rt_available,
     "vpn_status": vpn_status,
     "forward_drop": forward_drop,

--- a/utils/rooter.py
+++ b/utils/rooter.py
@@ -697,6 +697,11 @@ def nexthop_init(rt_table, egress_if, next_hop):
         log.error("nexthop_init refusing to flush reserved routing table %r (fix the [gwX] rt_table)", rt_table)
         return
     run(settings.ip, "route", "flush", "table", rt_table)
+    # Fail-closed seed: never leave the table empty. If the real default replace below fails (bad
+    # egress_if/next_hop), this blackhole remains so the VM's policy lookup drops instead of falling
+    # through to `main` and egressing outside the gateway -- true even when [nexthop] fail_closed=no
+    # (codex P2: run() records but does not raise on a failed ip route replace).
+    run(settings.ip, "route", "replace", "blackhole", "default", "table", rt_table)
     if next_hop == "onlink":
         run(settings.ip, "route", "replace", "default", "dev", egress_if, "onlink", "table", rt_table)
     else:

--- a/utils/rooter.py
+++ b/utils/rooter.py
@@ -39,6 +39,17 @@ class ServicePaths:
     ip = None
 
 
+# ---------------------------------------------------------------------------
+# nexthop primitive — module-level state (loader sets these via nexthop_configure)
+# ---------------------------------------------------------------------------
+GATEWAY_TABLES_CSV = ""
+NEXTHOP_VM_NET = "255.255.255.255/32"   # matches nothing if mis-fired before configure
+NEXTHOP_FAIL_TABLE = "250"   # best-effort del is a no-op; table 250 is not kernel-reserved
+NEXTHOP_PRIORITY_LOW = "30000"
+NEXTHOP_BAND_LO = "10000"
+NEXTHOP_BAND_HI = "10255"
+
+
 def run(*args):
     """Wrapper to subprocess.run."""
     log.debug("Running command: %s", " ".join(args))
@@ -650,6 +661,169 @@ def srcroute_disable(rt_table, ipaddr):
     run(settings.ip, "route", "flush", "cache")
 
 
+# ---------------------------------------------------------------------------
+# nexthop primitive — argv builders
+# ---------------------------------------------------------------------------
+
+# Linux reserved/system routing tables that a [gwX] rt_table must never target — flushing any of
+# these would wipe the host's own routing and take the box offline. The startup loader rejects a
+# reserved rt_table up front (fail loud); these guards are defence-in-depth for the rooter path.
+# Kernel-fixed ids.
+RESERVED_RT_TABLES = ("local", "main", "default", "0", "253", "254", "255")
+
+
+def nexthop_init(rt_table, egress_if, next_hop):
+    """Idempotently build a next-hop profile's routing table: one forced default route.
+    next_hop == 'onlink' => default dev egress_if onlink; else default via next_hop dev egress_if.
+    NOTE: deliberately does NOT call init_rttable (that copies main's per-interface routes)."""
+    # NEVER flush a reserved/system routing table (codex P1 / gemini critical). See RESERVED_RT_TABLES.
+    if rt_table in RESERVED_RT_TABLES:
+        log.error("nexthop_init refusing to flush reserved routing table %r (fix the [gwX] rt_table)", rt_table)
+        return
+    run(settings.ip, "route", "flush", "table", rt_table)
+    if next_hop == "onlink":
+        run(settings.ip, "route", "replace", "default", "dev", egress_if, "onlink", "table", rt_table)
+    else:
+        run(settings.ip, "route", "replace", "default", "via", next_hop, "dev", egress_if, "table", rt_table)
+
+
+def _iptables_delete_all(*args):
+    """Best-effort delete an iptables rule until it is no longer present, so a retried bind can't
+    leave stacked duplicates (a single -D would remove only one copy). run_iptables never raises;
+    a non-empty stderr from `-D` means the rule is gone. Bounded so a persistent error can't spin."""
+    for _ in range(32):
+        _, err = run_iptables(*args)
+        if err:
+            break
+
+
+def nexthop_enable(vm_ip, ingress_if, egress_if, rt_table, priority):
+    """Per task: source-route the VM into its profile table and SNAT onto egress_if. Idempotent --
+    a retried bind (or route_network called twice) must NOT stack rules, so the ip rule and both
+    iptables rules are delete-then-add'd; the iptables deletes loop until gone."""
+    run("conntrack", "-D", "-s", vm_ip)  # drop stale flows so a recycled IP starts clean (best-effort)
+    run(settings.ip, "rule", "del", "from", vm_ip, "lookup", rt_table, "priority", priority)  # idempotent
+    run(settings.ip, "rule", "add", "from", vm_ip, "lookup", rt_table, "priority", priority)
+    # SNAT the VM out its gateway. Delete-until-gone first so a retry can't stack duplicate NAT rules
+    # that nexthop_disable's delete would then leave behind (Copilot).
+    _iptables_delete_all("-t", "nat", "-D", "POSTROUTING", "-s", vm_ip, "-o", egress_if, "-j", "MASQUERADE")
+    run_iptables("-t", "nat", "-A", "POSTROUTING", "-s", vm_ip, "-o", egress_if, "-j", "MASQUERADE")
+    # Accept the VM's forwarded egress via CAPE_ACCEPTED_SEGMENTS -- the chain FORWARD jumps to FIRST
+    # (cleanup_rooter) -- so it precedes any libvirt default `-i virbr* -j REJECT` still in the raw
+    # FORWARD chain (a tail `-A FORWARD ... ACCEPT` would be shadowed on libvirt guests). Constrain -i
+    # to the guest ingress interface so a spoofed source from another host NIC can't be forwarded and
+    # MASQUERADEd through the gateway -- parity with the legacy forward_enable path (codex). ACCEPT
+    # terminates traversal, so return traffic is covered by the ESTABLISHED,RELATED accept in the same
+    # chain. Delete-until-gone before insert (idempotent, Copilot).
+    _iptables_delete_all("-D", "CAPE_ACCEPTED_SEGMENTS", "-i", ingress_if, "-s", vm_ip, "-o", egress_if, "-j", "ACCEPT")
+    run_iptables("-I", "CAPE_ACCEPTED_SEGMENTS", "-i", ingress_if, "-s", vm_ip, "-o", egress_if, "-j", "ACCEPT")
+
+
+def nexthop_disable(vm_ip, ingress_if, egress_if, rt_table, priority):
+    """Mirror-delete the per-task state from nexthop_enable, then flush conntrack. The iptables
+    deletes loop until gone so any duplicate left by a retried bind is fully removed (no stale egress)."""
+    run(settings.ip, "rule", "del", "from", vm_ip, "lookup", rt_table, "priority", priority)
+    _iptables_delete_all("-t", "nat", "-D", "POSTROUTING", "-s", vm_ip, "-o", egress_if, "-j", "MASQUERADE")
+    _iptables_delete_all("-D", "CAPE_ACCEPTED_SEGMENTS", "-i", ingress_if, "-s", vm_ip, "-o", egress_if, "-j", "ACCEPT")
+    run("conntrack", "-D", "-s", vm_ip)
+
+
+def nexthop_intra_exception_enable(vm_net, band_lo):
+    """Keep intra-vm_net traffic on the main table: `from vm_net to vm_net lookup main`.
+
+    vm_net includes the host's own guest-bridge IP and sibling guests. A bound VM's per-task rule is
+    `from <vm_ip> lookup <gw_table>` and the gateway table holds only a default route, so without this
+    exception a bound VM's traffic to a vm_net address that is NOT the host-local bridge IP (a sibling
+    guest, or a ResultServer that is not the host itself) would be captured by the per-task rule and
+    SNAT'd out the gateway instead of staying on the guest network (codex). Host-local ResultServer
+    already resolves via the kernel priority-0 local table; this covers the non-host-local +
+    guest<->guest cases, for bound and unbound VMs alike.
+
+    Installed at band_lo-1 -- JUST BELOW the per-task band (band_lo..band_hi) -- so it wins over a
+    bound VM's in-band per-task rule. It only matches `to vm_net`, so external egress is unaffected.
+    This is a CONNECTIVITY guarantee, installed whenever nexthop is enabled and independent of
+    fail_closed (which only governs the blackhole). Idempotent (del+add, no stacked duplicates)."""
+    intra_prio = str(int(band_lo) - 1)
+    run(settings.ip, "rule", "del", "from", vm_net, "to", vm_net, "lookup", "main", "priority", intra_prio)
+    run(settings.ip, "rule", "add", "from", vm_net, "to", vm_net, "lookup", "main", "priority", intra_prio)
+
+
+def nexthop_fail_closed_enable(vm_net, fail_table, priority_low):
+    """Arm once at startup (only when fail_closed=yes): any guest-subnet source with no
+    higher-priority per-task rule is blackholed (dropped), never routed by main out the control-plane
+    NIC. `route replace` is idempotent; the rule is del+add'd so a restart does not stack duplicates.
+    The intra-subnet exception is installed separately by nexthop_intra_exception_enable (always),
+    since keeping host<->guest / guest<->guest traffic on main is a connectivity concern, not a
+    fail-closed one -- an unbound external flow still matches no per-task rule and hits this blackhole."""
+    run(settings.ip, "route", "replace", "blackhole", "default", "table", fail_table)
+    run(settings.ip, "rule", "del", "from", vm_net, "lookup", fail_table, "priority", priority_low)
+    run(settings.ip, "rule", "add", "from", vm_net, "lookup", fail_table, "priority", priority_low)
+
+
+def nexthop_teardown(gateway_tables, vm_net, fail_table, priority_low, band_lo, band_hi):
+    """Remove ALL nexthop policy-routing state (cleanup_rooter only sweeps iptables).
+    gateway_tables: comma-joined table ids. Idempotent; every step is a best-effort run()."""
+    for rt in [t for t in gateway_tables.split(",") if t]:
+        # NEVER flush a reserved/system routing table (gemini #14 HIGH). See RESERVED_RT_TABLES.
+        if rt in RESERVED_RT_TABLES:
+            log.error("nexthop_teardown refusing to flush reserved routing table %r (fix the [gwX] rt_table)", rt)
+            continue
+        run(settings.ip, "route", "flush", "table", rt)
+    run(settings.ip, "route", "del", "blackhole", "default", "table", fail_table)
+    run(settings.ip, "rule", "del", "from", vm_net, "lookup", fail_table, "priority", priority_low)
+    # intra-subnet exception is armed at band_lo-1 (just below the per-task band); mirror-delete it
+    run(settings.ip, "rule", "del", "from", vm_net, "to", vm_net, "lookup", "main", "priority", str(int(band_lo) - 1))
+    lo, hi = int(band_lo), int(band_hi)
+    try:
+        vm_network = ipaddress.ip_network(vm_net, strict=False)
+    except ValueError:
+        vm_network = None
+    stdout, _ = run(settings.ip, "rule", "show")
+    for line in stdout.splitlines():
+        head = line.split(":", 1)[0].strip()
+        if not (head.isdigit() and lo <= int(head) <= hi):
+            continue
+        # Only sweep OUR per-task rules -- `from <vm_ip> ...` with vm_ip inside vm_net. Every nexthop
+        # per-task rule matches `from <vm_ip>`, so anything in the 10000-10255 band whose source is
+        # NOT in vm_net is an unrelated host admin rule; leave it alone (codex). Fail-safe: if vm_net
+        # is unparseable or the source can't be confirmed inside it, skip rather than delete.
+        toks = line.split()
+        if vm_network is None or "from" not in toks:
+            continue
+        try:
+            src = toks[toks.index("from") + 1]
+            if ipaddress.ip_address(src.split("/")[0]) not in vm_network:
+                continue
+        except (ValueError, IndexError):
+            continue
+        # Delete by the FULL selector (from <src> + priority), not by priority alone: iproute2 allows
+        # multiple rules at one priority, so `ip rule del priority N` could remove a host admin rule
+        # that happens to share this priority instead of ours. Matching on our confirmed vm_net source
+        # too targets exactly our per-task rule (codex).
+        run(settings.ip, "rule", "del", "from", src, "priority", head)
+
+
+def nexthop_configure(tables_csv, vm_net, fail_table, prio_low, band_lo, band_hi):
+    """Called by the [gwX] loader to set the module globals that nexthop_teardown sweeps."""
+    global GATEWAY_TABLES_CSV, NEXTHOP_VM_NET, NEXTHOP_FAIL_TABLE
+    global NEXTHOP_PRIORITY_LOW, NEXTHOP_BAND_LO, NEXTHOP_BAND_HI
+    GATEWAY_TABLES_CSV, NEXTHOP_VM_NET, NEXTHOP_FAIL_TABLE = tables_csv, vm_net, fail_table
+    NEXTHOP_PRIORITY_LOW, NEXTHOP_BAND_LO, NEXTHOP_BAND_HI = prio_low, band_lo, band_hi
+
+
+def nexthop_teardown_if_configured():
+    """SIGTERM helper: remove nexthop policy-routing state ONLY if the [gwX] loader configured it
+    this session (nexthop_configure sets GATEWAY_TABLES_CSV; it is "" on a node that never enabled
+    [nexthop]). Skipping otherwise honours the disabled=no-op contract -- an unconfigured node must
+    not mutate host routing on shutdown, in particular must not sweep the 10000-10255 priority band
+    (which could delete an unrelated host rule). Module-level + importable so the contract is
+    CI-guarded (the SIGTERM handler itself lives inside __main__ and is not testable)."""
+    if not GATEWAY_TABLES_CSV:
+        return
+    nexthop_teardown(GATEWAY_TABLES_CSV, NEXTHOP_VM_NET, NEXTHOP_FAIL_TABLE,
+                     NEXTHOP_PRIORITY_LOW, NEXTHOP_BAND_LO, NEXTHOP_BAND_HI)
+
+
 def dns_forward(action, vm_ip, dns_ip, dns_port="53"):
     """Route DNS requests from the VM to a custom DNS on a separate network."""
     run_iptables(
@@ -1113,6 +1287,13 @@ handlers = {
     "libvirt_fwo_disable": libvirt_fwo_disable,
     "sslproxy_enable": sslproxy_enable,
     "sslproxy_disable": sslproxy_disable,
+    "nexthop_init": nexthop_init,
+    "nexthop_enable": nexthop_enable,
+    "nexthop_disable": nexthop_disable,
+    "nexthop_intra_exception_enable": nexthop_intra_exception_enable,
+    "nexthop_fail_closed_enable": nexthop_fail_closed_enable,
+    "nexthop_teardown": nexthop_teardown,
+    "nexthop_configure": nexthop_configure,
 }
 
 if __name__ == "__main__":
@@ -1193,6 +1374,10 @@ if __name__ == "__main__":
         server.shutdown(socket.SHUT_RDWR)
         server.close()
         cleanup_rooter()
+        # Remove nexthop policy-routing state (cleanup_rooter is iptables-only), but only when the
+        # [gwX] loader actually configured nexthop this session -- see nexthop_teardown_if_configured
+        # (extracted + CI-guarded so the disabled=no-op contract can't silently regress) (Copilot).
+        nexthop_teardown_if_configured()
 
     signal.signal(signal.SIGTERM, handle_sigterm)
 

--- a/utils/rooter.py
+++ b/utils/rooter.py
@@ -723,7 +723,11 @@ def nexthop_enable(vm_ip, ingress_if, egress_if, rt_table, priority):
     a retried bind (or route_network called twice) must NOT stack rules, so the ip rule and both
     iptables rules are delete-then-add'd; the iptables deletes loop until gone."""
     run("conntrack", "-D", "-s", vm_ip)  # drop stale flows so a recycled IP starts clean (best-effort)
-    run(settings.ip, "rule", "del", "from", vm_ip, "lookup", rt_table, "priority", priority)  # idempotent
+    # Delete any existing rule for this VM at its (deterministic per-IP) priority -- TABLE-AGNOSTIC,
+    # so a rebind to a DIFFERENT gateway after a crashed/partial unroute removes the stale
+    # `from <vm_ip> priority <P> lookup <old_table>` rule too. A `lookup <new_table>` del would miss
+    # it, leaving it to win by priority and route the task via the previous exit (codex). Then add fresh.
+    run(settings.ip, "rule", "del", "from", vm_ip, "priority", priority)
     run(settings.ip, "rule", "add", "from", vm_ip, "lookup", rt_table, "priority", priority)
     # SNAT the VM out its gateway. Delete-until-gone first so a retry can't stack duplicate NAT rules
     # that nexthop_disable's delete would then leave behind (Copilot).

--- a/web/submission/views.py
+++ b/web/submission/views.py
@@ -733,6 +733,24 @@ def index(request, task_id=None, resubmit_hash=None):
             {"name": v["name"], "description": v["description"], "interface": v["interface"], "type": "vpn"} for v in vpns.values()
         ]
 
+        # nexthop gateway pool: expose the configured [gwX] profiles (and the "nexthop" pool
+        # sentinel) as route options so GUI submissions can select the pool, mirroring vpns_data.
+        # Defensive: a malformed [nexthop] config must never 500 the submission page.
+        nexthop_enabled = False
+        gateways_data = []
+        try:
+            if getattr(routing.nexthop, "enabled", False):
+                nexthop_enabled = True
+                for gw_name in str(getattr(routing.nexthop, "gateways", "") or "").split(","):
+                    gw_name = gw_name.strip()
+                    if not gw_name:
+                        continue
+                    gw = routing.get(gw_name) if hasattr(routing, gw_name) else None
+                    desc = getattr(gw, "description", None) if gw is not None else None
+                    gateways_data.append({"name": gw_name, "description": desc or gw_name})
+        except Exception:
+            nexthop_enabled, gateways_data = False, []
+
         existent_tasks = {}
         if resubmit_hash:
             if web_conf.general.get("existent_tasks", False):
@@ -752,6 +770,8 @@ def index(request, task_id=None, resubmit_hash=None):
                 "vpns": vpns_data,
                 "random_route": random_route,
                 "socks5s": socks5s_data,
+                "gateways": gateways_data,
+                "nexthop_enabled": nexthop_enabled,
                 "route": routing.routing.route,
                 "internet": routing.routing.internet,
                 "inetsim": routing.inetsim.enabled,

--- a/web/templates/submission/index.html
+++ b/web/templates/submission/index.html
@@ -259,6 +259,14 @@
                                         <option value="{{ route_name }}">{{ route_name }} (Auto-pick)</option>
                                         {% endfor %}
                                         {% endif %}
+                                        {% if nexthop_enabled %}
+                                        <option value="nexthop" {% if route == "nexthop" %} selected{% endif %}>nexthop pool
+                                            (default policy)</option>
+                                        {% for gw in gateways %}
+                                        <option value="{{ gw.name }}" {% if route == gw.name %} selected{% endif %}>{{ gw.description }}
+                                            ({{ gw.name }}, nexthop gateway)</option>
+                                        {% endfor %}
+                                        {% endif %}
                                         <option value="none" {% if route == "none" %} selected{% endif %}>Drop all VM
                                             traffic</option>
                                     </select>


### PR DESCRIPTION
## Summary
Adds an optional `[nexthop]` egress routing mode: an analysis VM's egress can be routed to a selectable **next-hop gateway** (an interface that reaches an external egress router), **per-task and concurrent**, **fail-closed**, without the VM ever reaching the control-plane network.

- `utils/rooter.py` — `nexthop_init/enable/disable`; a fail-closed default (blackhole) so a VM never egresses unrouted; `nexthop_teardown` sweeps the policy-routing state the iptables-only `cleanup_rooter` misses (and never flushes reserved tables like `main`/`local`/`default`).
- `lib/cuckoo/core/rooter.py` — a `gateways` registry + liveness-aware selector (`roundrobin`/`random`).
- `lib/cuckoo/core/startup.py` — `[gwX]` profile loader + default-route validation, with clear startup errors for missing options.
- `lib/cuckoo/core/analysis_manager.py` — per-task resolve/dispatch/unroute of the chosen gateway. A typo'd/unconfigured route **fails closed (drops)** rather than falling back to a live gateway.
- `conf/default/routing.conf.default` — `[nexthop] enabled = no` by default.

## Why
This generalizes the existing `init_rttable`/`srcroute_enable`/`forward_enable` machinery into a reusable primitive. The environment *provides* the egress interfaces; rooter only injects routes and filters against a named interface — so it's **vendor-neutral** (no cloud/provider-specific concepts) and complements the existing `route=vpnX`/`internet`/`socks5` modes.

## Compatibility
Fully opt-in. With the default `[nexthop] enabled = no`, existing `route=none/internet/vpnX/tor/inetsim/socks5` nodes are unchanged (additive, `-13` lines).

## Testing
Unit tests cover the rooter argv builders, the `route_network` resolve/dispatch/unroute branch, the gateway selector (incl. round-robin thread-safety + fail-closed on typo'd routes), and `[gwX]`/`[nexthop]` loader validation. A root-gated netns integration test (`tests/integration/test_nexthop_netns.py`) exercises the real `ip rule`/`ip route`/nftables path end to end.