### PR TITLE
central-mode: optional object-store artifact seam + job->worker directory (default OFF)

### DIFF
--- a/conf/default/cuckoo.conf.default
+++ b/conf/default/cuckoo.conf.default
@@ -246,3 +246,40 @@ analysis = 0
 mongo = no
 # Clean orphan files in mongodb
 unused_files_in_mongodb = no
+
+[central_mode]
+# Central control-plane mode (off = current single-node behavior; analyses stay on the local
+# storage/analyses tree). When on, analysis artifacts are pushed to a shared object store and
+# interactive Guac routing resolves job->worker via a directory backend.
+enabled = no
+# Artifact storage backend when central mode is ON: "s3" (any S3-compatible store — AWS S3, MinIO,
+# Ceph RGW — via boto3, which is an optional/lazy import: pip install boto3 to use it) or "local"
+# (a shared local/NFS mount, no extra deps).
+storage_backend = s3
+# S3-compatible object store (storage_backend=s3). endpoint blank = AWS default; creds blank =
+# boto3 default credential chain (e.g. an instance role). Point endpoint/creds at MinIO/Ceph/etc.
+s3_bucket =
+s3_region = us-east-1
+s3_prefix = results
+s3_endpoint_url =
+s3_access_key =
+s3_secret_key =
+# storage_backend=local: root the per-job artifact trees live under (blank = local analyses tree).
+central_local_root =
+# Job->worker directory for interactive Guac routing: "broker_http" (default; vendor-neutral —
+# resolves via the broker's GET /api/status/<job_id>) or "dynamodb" (AWS; reads broker_table).
+job_directory = broker_http
+# job_directory=broker_http: broker base URL + optional Bearer API token.
+broker_url =
+broker_api_token =
+# job_directory=dynamodb: the broker job-tracking DynamoDB table name.
+broker_table =
+# Interactive-Guac worker access: how the central node reaches the worker that hosts a live task's
+# VM. Defaults match the standard CAPE deb layout; override for other topologies.
+# File holding the worker apiv2 Token (blank/absent => requests go unauthenticated).
+worker_api_token_file = /etc/cape/api-token
+# The worker's apiv2/web port.
+worker_api_port = 8000
+# The central node's libvirt-over-SSH identity onto workers (must be authorized on the workers).
+worker_ssh_user = cape
+worker_ssh_keyfile = /home/cape/.ssh/id_ed25519

--- a/conf/default/reporting.conf.default
+++ b/conf/default/reporting.conf.default
@@ -105,6 +105,12 @@ index_filenames = no
 
 # Set this value if you are using mongodb with TLS enabled
 # tlscafile =
+# Enable TLS on the connection. Required for managed backends like Amazon DocumentDB
+# (a tlscafile alone does NOT enable TLS in pymongo). Default off = today's behavior.
+# tls = no
+# Retryable writes. Amazon DocumentDB rejects them, so set this to no when pointing at
+# DocumentDB. Default yes = pymongo's own default (unchanged for stock MongoDB).
+# retrywrites = yes
 
 # Automatically delete large dict values that exceed mongos 16MB limitation
 # Note: This only deletes dict keys from data stored in MongoDB. You would

--- a/dev_utils/mongodb.py
+++ b/dev_utils/mongodb.py
@@ -13,6 +13,15 @@ repconf = Config("reporting")
 mdb = repconf.mongodb.get("db", "cuckoo")
 
 
+def _truthy(val, default=False):
+    """Coerce a conf value (bool or 'yes'/'no'/'on'/'off'/...) to bool."""
+    if isinstance(val, bool):
+        return val
+    if val is None:
+        return default
+    return str(val).strip().lower() in ("1", "true", "yes", "on")
+
+
 if repconf.mongodb.enabled:
     from pymongo import MongoClient, version_tuple
     from pymongo.errors import AutoReconnect, ConnectionFailure, OperationFailure, ServerSelectionTimeoutError
@@ -30,7 +39,13 @@ if repconf.mongodb.enabled:
                 username=repconf.mongodb.get("username"),
                 password=repconf.mongodb.get("password"),
                 authSource=repconf.mongodb.get("authsource", "cuckoo"),
+                # DocumentDB (central mode) needs TLS explicitly on (a CA file alone
+                # does NOT enable TLS in pymongo) and retryWrites OFF (DocumentDB
+                # rejects retryable writes). Both default to today's single-node
+                # behavior: tls off, retryWrites on (pymongo's own default).
+                tls=_truthy(repconf.mongodb.get("tls", False), False),
                 tlsCAFile=repconf.mongodb.get("tlscafile", None),
+                retryWrites=_truthy(repconf.mongodb.get("retrywrites", True), True),
                 connect=True, # Force connection now to catch issues
                 serverSelectionTimeoutMS=5000,
                 socketTimeoutMS=30000,

--- a/lib/cuckoo/common/artifact_storage.py
+++ b/lib/cuckoo/common/artifact_storage.py
@@ -1,0 +1,205 @@
+"""FS->object-store artifact seam. central_mode OFF -> local storage/analyses/<task_id>/
+<relpath>; ON -> the configured backend (S3-compatible or shared local mount) at
+<prefix>/<job_id>/<relpath>. The single-node vs central decision + the CAPE-specific bits
+(task_id->job_id resolution, tenant scope, traversal guard) live here; the raw object I/O
+is delegated to a pluggable ArtifactStore (lib/cuckoo/common/storage_backend.py) so central
+mode runs on any S3-compatible store (AWS/MinIO/Ceph) or a shared mount, with AWS purely
+config. Validated live on a CAPE box; the branch/seam logic here is the unit-testable part.
+"""
+import os
+
+from lib.cuckoo.common.constants import CUCKOO_ROOT
+from lib.cuckoo.common.central_mode import central_mode_config
+from lib.cuckoo.common.storage_backend import get_artifact_store, ArtifactNotFound
+
+
+def _local_analysis_path(task_id, relpath):
+    return os.path.join(CUCKOO_ROOT, "storage", "analyses", str(task_id), relpath)
+
+
+def _safe_relpath(relpath):
+    """Reject traversal/absolute/backslash before a relpath becomes an object key or a
+    local path segment. Callers today pass regex-constrained (\\w+) or fixed relpaths, but
+    this keeps the seam safe independent of caller discipline (audit MEDIUM-1)."""
+    from django.http import Http404
+
+    if not relpath or relpath.startswith("/") or "\\" in relpath or ".." in relpath.split("/"):
+        raise Http404(f"invalid artifact path: {relpath!r}")
+    return relpath
+
+
+def _job_id_for_task(task_id, scope=None):
+    """Central mode keys the store by the global job_id (the broker passes it in custom,
+    stamped into info.job_id at reporting; centralstore re-keys info.id to the unique
+    central task id). Resolve task_id -> job_id via mongo.
+
+    `scope` is the requesting viewer's tenant filter (e.g. entitled_scope_filter):
+    info.id is a per-worker sequence and collides across workers in a central
+    deployment, so the lookup is ANDed with the viewer's scope to guarantee the
+    resolved doc is one the viewer may actually see — not another tenant's analysis
+    that happens to share the numeric id (audit HIGH: cross-store id collision)."""
+    from dev_utils.mongodb import mongo_find_one
+    from django.http import Http404
+
+    # filereport/full_memory routes capture task_id/analysis_number as \w+ (not \d+),
+    # so a non-numeric segment must raise Http404 (the views catch it -> clean error),
+    # not an uncaught ValueError -> HTTP 500.
+    try:
+        tid = int(task_id)
+    except (TypeError, ValueError):
+        raise Http404("invalid task id")
+    query = {"info.id": tid}
+    if scope:
+        query = {"$and": [query, scope]}
+    doc = mongo_find_one("analysis", query, {"info.job_id": 1})
+    job_id = (doc or {}).get("info", {}).get("job_id")
+    if not job_id:
+        raise Http404("no job_id mapping for task")
+    return job_id
+
+
+def _store_and_container(task_id, scope=None):
+    """Return (ArtifactStore, container) for an analysis. Single-node: the local-FS store
+    over storage/analyses, container=<task_id>. Central: the configured backend (S3/local
+    mount), container="<s3_prefix>/<job_id>" (raises Http404 if the job_id can't resolve)."""
+    cfg = central_mode_config()
+    store, is_central = get_artifact_store(cfg)
+    if not is_central:
+        return store, str(task_id)
+    return store, f"{cfg.s3_prefix}/{_job_id_for_task(task_id, scope)}"
+
+
+def artifact_response(task_id, relpath, content_type, filename, chunk=8192, scope=None):
+    """Return a Django streaming response for an analysis artifact from any backend.
+
+    `scope`: the requesting viewer's tenant filter, threaded into the central
+    task_id->job_id lookup so a viewer can't pull another tenant's artifact via an
+    id collision (see _job_id_for_task)."""
+    from django.http import StreamingHttpResponse, Http404
+
+    _safe_relpath(relpath)
+    store, container = _store_and_container(task_id, scope)  # may raise Http404 (no job_id)
+    try:
+        body_iter, length = store.stream(container, relpath, chunk)
+    except ArtifactNotFound:
+        raise Http404(f"artifact not found: {relpath}")
+    resp = StreamingHttpResponse(body_iter, content_type=content_type)
+    if length is not None:
+        resp["Content-Length"] = length
+    resp["Content-Disposition"] = f"attachment; filename={filename}"
+    return resp
+
+
+def _stage_tree(task_id, scope, want):
+    """Shared staging core for central mode: copy artifacts from the central store into the
+    local storage/analyses/<task_id>/ tree so the MANY report features that read the local
+    filesystem work centrally without rewriting each reader. `want(rel) -> bool` selects which
+    relpaths to stage. Returns True iff the .centralstore.done completion marker was seen.
+    Best-effort: never raises. No-op single-node (caller guards)."""
+    store, container = _store_and_container(task_id, scope)
+    local = _local_analysis_path(task_id, "")
+    os.makedirs(local, exist_ok=True)
+    local_real = os.path.realpath(local)
+    complete = False
+    for rel in store.iter_relpaths(container):
+        if rel == ".centralstore.done":
+            complete = True
+            continue  # completion marker is a control object, not an artifact — don't stage it
+        if not rel or rel.endswith("/") or not want(rel):
+            continue
+        # Defence-in-depth: an object key suffix must never escape the analysis dir when it
+        # becomes a LOCAL destination (centralstore only emits in-tree keys today).
+        try:
+            _safe_relpath(rel)
+        except Exception:
+            continue
+        dest = os.path.join(local, rel)
+        dest_real = os.path.realpath(dest)
+        if dest_real != local_real and not dest_real.startswith(local_real + os.sep):
+            continue
+        if os.path.exists(dest):
+            continue
+        store.download(container, rel, dest)
+    return complete
+
+
+def ensure_local_analysis(task_id, scope=None, exclude_prefixes=("memory/", "memory.dmp")):
+    """Central mode: lazily materialize the central results/<job_id>/ tree into the local
+    storage/analyses/<task_id>/ dir so the report features that read the local filesystem
+    (json report, evtx, ETW aux/*.json, sysmon, process.log, behavior feeds, dropped files,
+    …) work centrally without rewriting each reader. Cached via a .central_staged marker
+    (subsequent calls are a cheap stat) — written only after the .centralstore.done marker is
+    seen, so a listing taken mid-upload isn't cached as complete. Excludes the large on-demand
+    memory dumps (memory/ subtree + the root memory.dmp[.zip/.strings] full-RAM image) which
+    would otherwise bloat every report view by GBs; they stage on demand via ensure_local_
+    memory / stream via materialize_artifact. No-op single-node. Best-effort: never raises."""
+    cfg = central_mode_config()
+    if not cfg.enabled:
+        return
+    marker = os.path.join(_local_analysis_path(task_id, ""), ".central_staged")
+    if os.path.exists(marker):
+        return
+    try:
+        complete = _stage_tree(
+            task_id, scope, want=lambda rel: not any(rel.startswith(p) for p in exclude_prefixes)
+        )
+        if complete:
+            with open(marker, "w") as f:
+                f.write("staged")
+    except Exception:
+        # leave whatever was staged; the per-file seam still covers downloads
+        pass
+
+
+def ensure_local_memory(task_id, scope=None):
+    """Central mode: stage the memory dumps (the memory/ per-process subtree AND the root
+    memory.dmp[.zip/.strings] full-RAM image) — which ensure_local_analysis EXCLUDES from the
+    bulk stage because they are large — to the local analysis dir, on EXPLICIT demand (the
+    memory-download endpoints). Idempotent per-file; not marker-gated. Best-effort."""
+    cfg = central_mode_config()
+    if not cfg.enabled:
+        return
+    try:
+        _stage_tree(task_id, scope, want=lambda rel: rel.startswith("memory/") or rel.startswith("memory.dmp"))
+    except Exception:
+        pass
+
+
+def artifact_exists(task_id, relpath, scope=None):
+    """True iff an analysis artifact exists — local (single-node) or via the central store's
+    existence check. Used to gate optional UI download links (decrypted/mixed pcap, tlskeys,
+    mitmdump) the worker may or may not have produced; a local-FS check returns False for
+    central-backed artifacts, hiding links for files that actually exist."""
+    try:
+        _safe_relpath(relpath)
+        store, container = _store_and_container(task_id, scope)
+        return store.exists(container, relpath)
+    except Exception:
+        return False
+
+
+def materialize_artifact(task_id, relpath, scope=None):
+    """Return (local_path, is_temp) for an artifact a caller must open as a real file —
+    random-access slicing (procdump), filtering/regeneration (pcap), or handing to an external
+    tool (VT upload). Single-node: the real local path, is_temp=False (DO NOT delete it).
+    Central: the object streamed to a temp file, is_temp=True (caller deletes it in a finally).
+    Returns (None, False) if absent."""
+    try:
+        _safe_relpath(relpath)
+        store, container = _store_and_container(task_id, scope)
+        return store.materialize(container, relpath)
+    except Exception:
+        return (None, False)
+
+
+def read_artifact_text(task_id, relpath, max_bytes=100000, scope=None):
+    """Read a text artifact (e.g. process.log) from any backend, truncated to max_bytes."""
+    try:
+        _safe_relpath(relpath)
+        store, container = _store_and_container(task_id, scope)
+        data = store.read_text(container, relpath, max_bytes)
+    except Exception:
+        return ""
+    if len(data) > max_bytes:
+        return data[:max_bytes] + "\n... [TRUNCATED] ..."
+    return data

--- a/lib/cuckoo/common/artifact_storage.py
+++ b/lib/cuckoo/common/artifact_storage.py
@@ -6,11 +6,15 @@ is delegated to a pluggable ArtifactStore (lib/cuckoo/common/storage_backend.py)
 mode runs on any S3-compatible store (AWS/MinIO/Ceph) or a shared mount, with AWS purely
 config. Validated live on a CAPE box; the branch/seam logic here is the unit-testable part.
 """
+import logging
 import os
+from collections import OrderedDict
 
 from lib.cuckoo.common.constants import CUCKOO_ROOT
 from lib.cuckoo.common.central_mode import central_mode_config
 from lib.cuckoo.common.storage_backend import get_artifact_store, ArtifactNotFound
+
+log = logging.getLogger(__name__)
 
 
 def _local_analysis_path(task_id, relpath):
@@ -33,8 +37,9 @@ def _safe_relpath(relpath):
 # the see-all path avoids N identical mongo lookups. We deliberately do NOT cache a tenant-SCOPED
 # resolution: that lookup is authorization-sensitive (a task's tenant/visibility can be reassigned),
 # so a process-lifetime cache could keep serving a job_id the caller may no longer see. Scoped lookups
-# always re-query. Only successful resolutions are cached; bounded so it can't grow unbounded.
-_JOB_ID_CACHE = {}
+# always re-query. Only successful resolutions are cached; a bounded LRU so the hot (recently viewed)
+# tasks stay cached and we evict one-at-a-time instead of dumping the whole cache at the threshold.
+_JOB_ID_CACHE = OrderedDict()  # most-recently-used at the end
 _JOB_ID_CACHE_MAX = 1024
 
 
@@ -57,6 +62,7 @@ def _job_id_for_task(task_id, scope=None):
     if use_cache:
         cached = _JOB_ID_CACHE.get(str(task_id))
         if cached is not None:
+            _JOB_ID_CACHE.move_to_end(str(task_id))  # mark most-recently-used
             return cached
 
     # filereport/full_memory routes capture task_id/analysis_number as \w+ (not \d+),
@@ -76,9 +82,10 @@ def _job_id_for_task(task_id, scope=None):
         raise Http404("no job_id mapping for task")
 
     if use_cache:
-        if len(_JOB_ID_CACHE) >= _JOB_ID_CACHE_MAX:
-            _JOB_ID_CACHE.clear()
         _JOB_ID_CACHE[str(task_id)] = job_id
+        _JOB_ID_CACHE.move_to_end(str(task_id))
+        if len(_JOB_ID_CACHE) > _JOB_ID_CACHE_MAX:
+            _JOB_ID_CACHE.popitem(last=False)  # evict least-recently-used
     return job_id
 
 
@@ -183,6 +190,8 @@ def ensure_local_analysis(task_id, scope=None, exclude_prefixes=("memory/", "mem
         # Everything else stays best-effort: leave whatever staged; the per-file seam still serves.
         if isinstance(e, Http404):
             raise
+        # ...but don't stay SILENT — S3 creds/permission/network failures otherwise vanish.
+        log.warning("central mode: failed to stage analysis %s: %s", task_id, e)
 
 
 def ensure_local_memory(task_id, scope=None):
@@ -199,9 +208,11 @@ def ensure_local_memory(task_id, scope=None):
     except Exception as e:
         from django.http import Http404
 
-        # Let a clean not-found propagate (view -> 404); swallow everything else (best-effort).
+        # Let a clean not-found propagate (view -> 404); log-then-swallow everything else so a
+        # staging failure (S3 creds/permission/network) is diagnosable rather than silent.
         if isinstance(e, Http404):
             raise
+        log.warning("central mode: failed to stage memory for analysis %s: %s", task_id, e)
 
 
 def artifact_exists(task_id, relpath, scope=None):

--- a/lib/cuckoo/common/artifact_storage.py
+++ b/lib/cuckoo/common/artifact_storage.py
@@ -28,6 +28,14 @@ def _safe_relpath(relpath):
     return relpath
 
 
+# task_id -> job_id is immutable once a task is dispatched, and a single report/tab view resolves it
+# several times (each artifact_exists / stream call). Cache the resolution to avoid N identical mongo
+# lookups. Keyed by (task_id, scope) so a viewer's tenant filter can't leak another tenant's mapping.
+# Only successful resolutions are cached (failures re-query); bounded so it can't grow unbounded.
+_JOB_ID_CACHE = {}
+_JOB_ID_CACHE_MAX = 1024
+
+
 def _job_id_for_task(task_id, scope=None):
     """Central mode keys the store by the global job_id (the broker passes it in custom,
     stamped into info.job_id at reporting; centralstore re-keys info.id to the unique
@@ -41,6 +49,11 @@ def _job_id_for_task(task_id, scope=None):
     from dev_utils.mongodb import mongo_find_one
     from django.http import Http404
 
+    cache_key = (str(task_id), str(scope))
+    cached = _JOB_ID_CACHE.get(cache_key)
+    if cached is not None:
+        return cached
+
     # filereport/full_memory routes capture task_id/analysis_number as \w+ (not \d+),
     # so a non-numeric segment must raise Http404 (the views catch it -> clean error),
     # not an uncaught ValueError -> HTTP 500.
@@ -52,9 +65,14 @@ def _job_id_for_task(task_id, scope=None):
     if scope:
         query = {"$and": [query, scope]}
     doc = mongo_find_one("analysis", query, {"info.job_id": 1})
-    job_id = (doc or {}).get("info", {}).get("job_id")
+    # info may be missing OR explicitly None ({"info": None}); coalesce both to {} before .get.
+    job_id = ((doc or {}).get("info") or {}).get("job_id")
     if not job_id:
         raise Http404("no job_id mapping for task")
+
+    if len(_JOB_ID_CACHE) >= _JOB_ID_CACHE_MAX:
+        _JOB_ID_CACHE.clear()
+    _JOB_ID_CACHE[cache_key] = job_id
     return job_id
 
 
@@ -132,7 +150,9 @@ def ensure_local_analysis(task_id, scope=None, exclude_prefixes=("memory/", "mem
     seen, so a listing taken mid-upload isn't cached as complete. Excludes the large on-demand
     memory dumps (memory/ subtree + the root memory.dmp[.zip/.strings] full-RAM image) which
     would otherwise bloat every report view by GBs; they stage on demand via ensure_local_
-    memory / stream via materialize_artifact. No-op single-node. Best-effort: never raises."""
+    memory / stream via materialize_artifact. No-op single-node. Best-effort: swallows transient
+    errors (the per-file seam still serves downloads), but a clean Http404 propagates so a direct
+    view caller returns 404 rather than a broken page."""
     cfg = central_mode_config()
     if not cfg.enabled:
         return
@@ -146,23 +166,33 @@ def ensure_local_analysis(task_id, scope=None, exclude_prefixes=("memory/", "mem
         if complete:
             with open(marker, "w") as f:
                 f.write("staged")
-    except Exception:
-        # leave whatever was staged; the per-file seam still covers downloads
-        pass
+    except Exception as e:
+        from django.http import Http404
+
+        # A clean not-found (bad task id / no job_id mapping / out-of-scope) must propagate so a
+        # direct view caller (report/load_files) returns a 404 instead of rendering a broken page.
+        # Everything else stays best-effort: leave whatever staged; the per-file seam still serves.
+        if isinstance(e, Http404):
+            raise
 
 
 def ensure_local_memory(task_id, scope=None):
     """Central mode: stage the memory dumps (the memory/ per-process subtree AND the root
     memory.dmp[.zip/.strings] full-RAM image) — which ensure_local_analysis EXCLUDES from the
     bulk stage because they are large — to the local analysis dir, on EXPLICIT demand (the
-    memory-download endpoints). Idempotent per-file; not marker-gated. Best-effort."""
+    memory-download endpoints). Idempotent per-file; not marker-gated. Best-effort (a clean Http404
+    propagates so the view 404s; other errors are swallowed)."""
     cfg = central_mode_config()
     if not cfg.enabled:
         return
     try:
         _stage_tree(task_id, scope, want=lambda rel: rel.startswith("memory/") or rel.startswith("memory.dmp"))
-    except Exception:
-        pass
+    except Exception as e:
+        from django.http import Http404
+
+        # Let a clean not-found propagate (view -> 404); swallow everything else (best-effort).
+        if isinstance(e, Http404):
+            raise
 
 
 def artifact_exists(task_id, relpath, scope=None):

--- a/lib/cuckoo/common/artifact_storage.py
+++ b/lib/cuckoo/common/artifact_storage.py
@@ -28,10 +28,12 @@ def _safe_relpath(relpath):
     return relpath
 
 
-# task_id -> job_id is immutable once a task is dispatched, and a single report/tab view resolves it
-# several times (each artifact_exists / stream call). Cache the resolution to avoid N identical mongo
-# lookups. Keyed by (task_id, scope) so a viewer's tenant filter can't leak another tenant's mapping.
-# Only successful resolutions are cached (failures re-query); bounded so it can't grow unbounded.
+# Cache ONLY the unscoped resolution. task_id -> job_id is immutable once a task is dispatched, and a
+# single report/tab view resolves it several times (each artifact_exists / stream call), so caching
+# the see-all path avoids N identical mongo lookups. We deliberately do NOT cache a tenant-SCOPED
+# resolution: that lookup is authorization-sensitive (a task's tenant/visibility can be reassigned),
+# so a process-lifetime cache could keep serving a job_id the caller may no longer see. Scoped lookups
+# always re-query. Only successful resolutions are cached; bounded so it can't grow unbounded.
 _JOB_ID_CACHE = {}
 _JOB_ID_CACHE_MAX = 1024
 
@@ -49,10 +51,13 @@ def _job_id_for_task(task_id, scope=None):
     from dev_utils.mongodb import mongo_find_one
     from django.http import Http404
 
-    cache_key = (str(task_id), str(scope))
-    cached = _JOB_ID_CACHE.get(cache_key)
-    if cached is not None:
-        return cached
+    # Only the unscoped (see-all / MT-absent / break-glass) path is cache-safe — see the note on
+    # _JOB_ID_CACHE. A present scope is authorization-sensitive, so never cache/serve it.
+    use_cache = not scope
+    if use_cache:
+        cached = _JOB_ID_CACHE.get(str(task_id))
+        if cached is not None:
+            return cached
 
     # filereport/full_memory routes capture task_id/analysis_number as \w+ (not \d+),
     # so a non-numeric segment must raise Http404 (the views catch it -> clean error),
@@ -70,9 +75,10 @@ def _job_id_for_task(task_id, scope=None):
     if not job_id:
         raise Http404("no job_id mapping for task")
 
-    if len(_JOB_ID_CACHE) >= _JOB_ID_CACHE_MAX:
-        _JOB_ID_CACHE.clear()
-    _JOB_ID_CACHE[cache_key] = job_id
+    if use_cache:
+        if len(_JOB_ID_CACHE) >= _JOB_ID_CACHE_MAX:
+            _JOB_ID_CACHE.clear()
+        _JOB_ID_CACHE[str(task_id)] = job_id
     return job_id
 
 
@@ -113,7 +119,10 @@ def _stage_tree(task_id, scope, want):
     local storage/analyses/<task_id>/ tree so the MANY report features that read the local
     filesystem work centrally without rewriting each reader. `want(rel) -> bool` selects which
     relpaths to stage. Returns True iff the .centralstore.done completion marker was seen.
-    Best-effort: never raises. No-op single-node (caller guards)."""
+    Per-file copy errors are swallowed (best-effort), BUT _store_and_container() may raise Http404
+    (bad task id / no job_id mapping / out-of-scope) and that PROPAGATES so a caller can return a
+    clean 404; callers that want pure best-effort must catch it (ensure_local_* do). No-op
+    single-node (caller guards)."""
     store, container = _store_and_container(task_id, scope)
     local = _local_analysis_path(task_id, "")
     os.makedirs(local, exist_ok=True)

--- a/lib/cuckoo/common/central_guac.py
+++ b/lib/cuckoo/common/central_guac.py
@@ -1,0 +1,155 @@
+"""Central-mode interactive-Guacamole worker routing.
+
+Single-node: a task's live analysis VM is in local libvirt and guacd is on
+localhost. In the broker/autoscaling topology the VM runs on an ephemeral ASG
+worker, so the central guac consumer must target THAT worker's guacd + VM.
+
+worker_ip_for_task() resolves task_id (info.id) -> info.job_id -> the broker job
+record's sandbox_worker_ip (recorded by the dispatcher at dispatch time) -> the
+worker's private IP. The job record is fetched via a pluggable JobDirectory
+(job_directory.py): the broker's HTTP status API by default (vendor-neutral), or
+DynamoDB (opt-in, AWS) — so the fork carries no hard DynamoDB/boto3 dependency. Returns None for box-local /
+single-node tasks (no broker record), so the consumer/view keep their localhost
+path unchanged when central mode is off or the task ran locally.
+"""
+import logging
+
+log = logging.getLogger(__name__)
+
+
+def _worker_api_token(token_file):
+    """Read the worker apiv2 Token from token_file; '' if unset/unreadable (=> no auth header).
+    Never raises — a missing token file just means unauthenticated requests."""
+    try:
+        with open(token_file) as f:
+            return f.read().strip()
+    except Exception:
+        return ""
+
+
+def _worker_task_view_url(worker_ip, port, cape_task_id):
+    """The worker's apiv2 task-view URL. port comes from [central_mode] worker_api_port."""
+    return "http://%s:%d/apiv2/tasks/view/%d/" % (worker_ip, int(port), int(cape_task_id))
+
+
+def _libvirt_ssh_dsn(ip, ssh_user, keyfile):
+    """qemu+ssh libvirt DSN to a worker. ssh_user/keyfile come from [central_mode]
+    (worker_ssh_user/worker_ssh_keyfile) so the deb defaults aren't hardcoded. keyfile is
+    URL-quoted (safe='/') so a configured path with a '&'/'?'/space can't corrupt the query."""
+    from urllib.parse import quote
+
+    return "qemu+ssh://%s@%s/system?keyfile=%s&no_verify=1" % (ssh_user, ip, quote(keyfile, safe="/"))
+
+
+def _job_id_for_task(task_id):
+    """Resolve the broker job_id for a task. Prefer the RDS task.custom stamp
+    ('job_id=ui-<id>', set by the submit-bridge at enqueue) — it exists DURING the
+    live run, which is exactly when interactive guac is needed. The DocumentDB
+    analysis doc is only written at reporting (after the VM is gone), so it can't be
+    relied on here; fall back to it only for non-bridged/seeded tasks."""
+    try:
+        from lib.cuckoo.core.database import Database
+
+        t = Database().view_task(int(task_id))
+        custom = getattr(t, "custom", None) if t else None
+        if custom:
+            # comma-separated k=v pairs — take ONLY the job_id= value (not the rest of the
+            # string), matching centralstore.resolve_job_id; a trailing ',foo=bar' would
+            # otherwise corrupt the DynamoDB key / S3 prefix lookup.
+            for part in str(custom).split(","):
+                part = part.strip()
+                if part.startswith("job_id="):
+                    v = part.split("=", 1)[1].strip()
+                    if v:
+                        return v
+    except Exception:
+        pass
+    try:
+        from dev_utils.mongodb import mongo_find_one
+
+        doc = mongo_find_one("analysis", {"info.id": int(task_id)}, {"info.job_id": 1})
+        return (doc or {}).get("info", {}).get("job_id")
+    except Exception:
+        return None
+
+
+def _worker_ip(cfg, task_id):
+    """Resolve task_id -> the hosting worker's private IP using an ALREADY-loaded cfg, so
+    worker_ip_for_task and libvirt_dsn_for_task parse [central_mode] once per call instead of
+    twice. Returns None (local/unresolvable). The IP is validated in job_directory.loc_from_item."""
+    from lib.cuckoo.common.job_directory import get_job_directory
+
+    directory = get_job_directory(cfg)
+    if directory is None:
+        return None
+    try:
+        job_id = _job_id_for_task(task_id)
+        if not job_id:
+            return None
+        loc = directory.lookup(job_id)
+        return loc.worker_ip if loc else None
+    except Exception as e:
+        log.warning("central guac: worker resolution failed for task %s: %s", task_id, e)
+        return None
+
+
+def worker_ip_for_task(task_id):
+    """Private IP of the worker hosting this task's live VM, or None (local)."""
+    from lib.cuckoo.common.central_mode import central_mode_config
+
+    return _worker_ip(central_mode_config(), task_id)
+
+
+def worker_vm_for_task(task_id):
+    """For a live broker-dispatched interactive task, return (vm_label, guest_ip) of the
+    VM on the worker — needed to build the guac session_data on the central node, where
+    the local machines table is empty (the VM lives on the worker). Resolves the broker
+    record (job_id -> worker IP + the worker-local cape_task_id) then asks that worker's
+    apiv2 for the task's machine. Returns (None, None) for non-bridged/local tasks."""
+    from lib.cuckoo.common.central_mode import central_mode_config
+    from lib.cuckoo.common.job_directory import get_job_directory
+
+    cfg = central_mode_config()
+    directory = get_job_directory(cfg)
+    if directory is None:
+        return (None, None)
+    try:
+        job_id = _job_id_for_task(task_id)
+        if not job_id:
+            return (None, None)
+        loc = directory.lookup(job_id)
+        if not loc:
+            return (None, None)
+        worker_ip = loc.worker_ip
+        cape_task_id = loc.cape_task_id
+        if not worker_ip or cape_task_id is None:
+            return (None, None)
+
+        import requests
+
+        token = _worker_api_token(cfg.worker_api_token_file)
+        headers = {"Authorization": f"Token {token}"} if token else {}
+        r = requests.get(_worker_task_view_url(worker_ip, cfg.worker_api_port, cape_task_id),
+                         headers=headers, timeout=10)
+        data = (r.json() or {}).get("data", {})
+        return (data.get("machine"), None)  # central guac uses the worker's localhost for VNC
+    except Exception as e:
+        log.warning("central guac: worker VM lookup failed for task %s: %s", task_id, e)
+        return (None, None)
+
+
+def libvirt_dsn_for_task(task_id, local_dsn):
+    """libvirt DSN to query the VM's VNC port: the worker's libvirt over SSH for a
+    worker-hosted task, else the local DSN. (Requires the central node's worker_ssh_user
+    to hold worker_ssh_keyfile, authorized on workers — deploy-time plumbing.)"""
+    from lib.cuckoo.common.central_mode import central_mode_config
+
+    cfg = central_mode_config()  # loaded once; shared with the worker-IP resolution below
+    ip = _worker_ip(cfg, task_id)
+    if not ip:
+        return (local_dsn, None)
+    # The central node's libvirt-over-SSH identity onto workers comes from [central_mode]
+    # (worker_ssh_user/worker_ssh_keyfile); no_verify skips host-key prompts for ephemeral
+    # in-VPC workers.
+    dsn = _libvirt_ssh_dsn(ip, cfg.worker_ssh_user, cfg.worker_ssh_keyfile)
+    return (dsn, ip)

--- a/lib/cuckoo/common/central_guac.py
+++ b/lib/cuckoo/common/central_guac.py
@@ -56,19 +56,26 @@ def _job_id_for_task(task_id):
             # comma-separated k=v pairs — take ONLY the job_id= value (not the rest of the
             # string), matching centralstore.resolve_job_id; a trailing ',foo=bar' would
             # otherwise corrupt the DynamoDB key / S3 prefix lookup.
-            for part in str(custom).split(","):
+            text = str(custom)
+            for part in text.split(","):
                 part = part.strip()
                 if part.startswith("job_id="):
                     v = part.split("=", 1)[1].strip()
                     if v:
                         return v
+            # Bare-token form (custom is just the job id) — kept in sync with
+            # centralstore.resolve_job_id, which also accepts a bare token for non-bridged tasks.
+            token = text.strip()
+            if token and "=" not in token and "," not in token:
+                return token
     except Exception:
         pass
     try:
         from dev_utils.mongodb import mongo_find_one
 
         doc = mongo_find_one("analysis", {"info.id": int(task_id)}, {"info.job_id": 1})
-        return (doc or {}).get("info", {}).get("job_id")
+        # info may be missing OR explicitly None ({"info": None}); coalesce both before .get.
+        return ((doc or {}).get("info") or {}).get("job_id")
     except Exception:
         return None
 

--- a/lib/cuckoo/common/central_mode.py
+++ b/lib/cuckoo/common/central_mode.py
@@ -1,0 +1,146 @@
+"""Central-mode toggle. OFF (default) = single-node behavior (local pg/mongo/FS).
+ON = the web/api app reads the central data plane (RDS via [database], DocumentDB
+via [mongodb]) and serves artifacts from S3.
+
+The relational + mongo CONNECTIONS are pointed by their existing conf; this flag
+gates the code-level behavior that has no conf today — the FS->S3 artifact seam —
+and carries the S3 location. Parsing logic is split into the pure `_parse()` helper
+so it's unit-testable without importing the CAPE config machinery.
+"""
+import os
+from dataclasses import dataclass
+
+
+def _within(realpath, root):
+    """True iff `realpath` is `root` itself or lives under it. Uses a separator-
+    terminated prefix so a sibling like storage/binaries-evil does NOT count as
+    inside storage/binaries (prefix-collision guard)."""
+    return realpath == root or realpath.startswith(root.rstrip(os.sep) + os.sep)
+
+
+def upload_target_realpath(full, base_real, trusted_roots):
+    """Decide whether an analysis file may be shipped to the central store, and if
+    so, the on-disk path whose CONTENT to upload.
+
+    centralstore walks the analysis tree. Most entries are regular files inside the
+    tree. A few are symlinks INTO trusted content roots — `binary` -> storage/binaries/
+    <sha256> and any guacrecording symlinked from the analysis dir -> storage/
+    guacrecordings/. Those must ship (the read seam serves them), so we resolve and
+    upload their target content under the file's analysis-relative key.
+
+    But artifacts are partly sample-influenced: a planted symlink (e.g. binary ->
+    ~/.aws/credentials) would otherwise be read and exfiltrated to S3 (audit
+    CRITICAL). So we ALLOW a resolved path only when it stays within the analysis
+    tree itself or one of the trusted_roots; anything resolving elsewhere returns
+    None (skip). Pure (os.path only) so it is unit-testable without boto3/Django.
+    """
+    realpath = os.path.realpath(full)
+    for root in [base_real, *trusted_roots]:
+        if _within(realpath, root):
+            return realpath
+    return None
+
+
+def _as_bool(v, default=False):
+    if isinstance(v, bool):
+        return v
+    if v is None:
+        return default
+    return str(v).strip().lower() in ("1", "true", "yes", "on")
+
+
+def _as_int(v, default):
+    """Coerce a config value to int, falling back to `default` on None/blank/garbage so a
+    typo in [central_mode] degrades to the documented default instead of a startup crash."""
+    try:
+        return int(str(v).strip())
+    except (TypeError, ValueError):
+        return default
+
+
+def _as_port(v, default):
+    """A TCP port from config. int() accepts syntactically-valid but out-of-range values
+    (0, -1, 99999) that would then format into a broken URL and silently kill worker resolution;
+    fall back to `default` unless the value is a real port (1..65535)."""
+    p = _as_int(v, default)
+    return p if 1 <= p <= 65535 else default
+
+
+@dataclass
+class CentralModeConfig:
+    enabled: bool = False
+    s3_bucket: str = ""
+    s3_region: str = "us-east-1"
+    s3_prefix: str = "results"  # results/<job_id>/...
+    # Artifact storage backend (when central mode is ON). "s3" = any S3-compatible object
+    # store (AWS S3, MinIO, Ceph RGW, …) via boto3; "local" = a shared local/NFS mount.
+    # Single-node (enabled=False) always uses the local storage/analyses tree regardless.
+    storage_backend: str = "s3"
+    # S3-compatible endpoint + creds. ALL OPTIONAL: empty s3_endpoint_url -> AWS's default
+    # endpoint; empty creds -> boto3's default chain (IAM role on AWS). Set them to point at
+    # MinIO/Ceph/etc. — this is the ONLY thing that made the artifact store AWS-locked.
+    s3_endpoint_url: str = ""
+    s3_access_key: str = ""
+    s3_secret_key: str = ""
+    # For storage_backend="local" (central with a shared mount): the root the per-job
+    # artifact trees live under (results/<job_id>/...). Empty -> falls back to the local
+    # storage/analyses tree.
+    central_local_root: str = ""
+    # Broker job-tracking DynamoDB table — lets the central node resolve a live
+    # job to the worker hosting its VM (interactive Guacamole worker routing).
+    broker_table: str = ""
+    # Job->worker directory backend for interactive guac routing (central_guac.py):
+    # "broker_http" (default; vendor-neutral — resolves via the broker's GET /api/status/<job_id>,
+    # so no DynamoDB/boto3) or "dynamodb" (AWS; reads broker_table).
+    job_directory: str = "broker_http"
+    # For job_directory="broker_http": the broker base URL + Bearer API token.
+    broker_url: str = ""
+    broker_api_token: str = ""
+    # Interactive-Guac worker access (central_guac.py resolves a live task's VM on the worker that
+    # hosts it). These carry the deployment's worker conventions so they aren't hardcoded for
+    # non-deb topologies. worker_api_token_file: file holding the worker apiv2 Token (blank/absent
+    # => no auth header). worker_api_port: the worker's apiv2/web port. worker_ssh_user +
+    # worker_ssh_keyfile: the central node's libvirt-over-SSH identity onto workers.
+    worker_api_token_file: str = "/etc/cape/api-token"
+    worker_api_port: int = 8000
+    worker_ssh_user: str = "cape"
+    worker_ssh_keyfile: str = "/home/cape/.ssh/id_ed25519"
+    # The report doc -> central DocumentDB write is the NATIVE mongodb.py reporting module
+    # pointed at DocumentDB via [mongodb] (tls=yes, retrywrites=no); central_mode therefore
+    # only carries the FS->S3 artifact location.
+
+
+def _parse(sec) -> "CentralModeConfig":
+    """Pure: turn a [central_mode] config section (dict-like) into CentralModeConfig."""
+    get = sec.get if hasattr(sec, "get") else (lambda k, d=None: d)
+    return CentralModeConfig(
+        enabled=_as_bool(get("enabled", False), False),
+        s3_bucket=str(get("s3_bucket", "") or ""),
+        s3_region=str(get("s3_region", "us-east-1") or "us-east-1"),
+        s3_prefix=str(get("s3_prefix", "results") or "results"),
+        storage_backend=str(get("storage_backend", "s3") or "s3").strip().lower(),
+        s3_endpoint_url=str(get("s3_endpoint_url", "") or ""),
+        s3_access_key=str(get("s3_access_key", "") or ""),
+        s3_secret_key=str(get("s3_secret_key", "") or ""),
+        central_local_root=str(get("central_local_root", "") or ""),
+        broker_table=str(get("broker_table", "") or ""),
+        job_directory=str(get("job_directory", "broker_http") or "broker_http").strip().lower(),
+        broker_url=str(get("broker_url", "") or ""),
+        broker_api_token=str(get("broker_api_token", "") or ""),
+        worker_api_token_file=str(get("worker_api_token_file", "/etc/cape/api-token") or "/etc/cape/api-token"),
+        worker_api_port=_as_port(get("worker_api_port", 8000), 8000),
+        worker_ssh_user=str(get("worker_ssh_user", "cape") or "cape"),
+        worker_ssh_keyfile=str(get("worker_ssh_keyfile", "/home/cape/.ssh/id_ed25519") or "/home/cape/.ssh/id_ed25519"),
+    )
+
+
+def central_mode_config() -> "CentralModeConfig":
+    # Lazy import so module import stays dependency-free (the CAPE config machinery
+    # is only touched when this is actually called at runtime).
+    from lib.cuckoo.common.config import Config
+
+    try:
+        sec = Config("cuckoo").get("central_mode")
+    except Exception:
+        sec = {}
+    return _parse(sec)

--- a/lib/cuckoo/common/hunt_query.py
+++ b/lib/cuckoo/common/hunt_query.py
@@ -1,0 +1,27 @@
+"""Hunt aggregation builder — per-category $group (NO $facet, so it runs on
+Amazon DocumentDB, which rejects $facet). Extracted from web/analysis/views.py
+so it's unit-testable without importing the full web module graph; views.py
+imports build_hunt_facets() and passes its mongo_aggregate in.
+
+Returns the same shape the old $facet pipeline produced:
+    {cat_id: [{"_id": <group key>, "count": <int>, "task_ids": [<int>...]}, ...]}
+so the downstream clean_facets/validator loop is unchanged.
+"""
+
+
+def build_hunt_facets(mongo_aggregate, match, hunt_map, categories, min_count):
+    facets = {}
+    for cat_id, cat_config in hunt_map.items():
+        if not categories.get(cat_id):
+            continue
+        stages = [{"$match": match}]
+        if cat_config.get("db_unwind"):
+            stages.append({"$unwind": cat_config["db_unwind"]})
+        stages.extend([
+            {"$group": {"_id": cat_config["db_group"], "count": {"$sum": 1}, "task_ids": {"$addToSet": "$info.id"}}},
+            {"$match": cat_config.get("db_match", {"count": {"$gte": min_count}})},
+            {"$sort": {"count": -1}},
+            {"$limit": 100},
+        ])
+        facets[cat_id] = list(mongo_aggregate("analysis", stages))
+    return facets

--- a/lib/cuckoo/common/job_directory.py
+++ b/lib/cuckoo/common/job_directory.py
@@ -1,0 +1,152 @@
+"""Pluggable job->worker directory for central-mode interactive routing.
+
+central_guac.py needs to resolve a LIVE task's broker job_id to the worker hosting its
+VM — the worker's private IP + the worker-local cape_task_id — so the central node can
+target that worker's guacd / libvirt for interactive Guacamole. The broker dispatcher
+records this mapping when it pushes the job; in our AWS broker it lives in a DynamoDB
+item keyed by job_id (sandbox_worker_ip, cape_task_id). That DynamoDB get_item was the
+LAST hard AWS coupling in the CAPE fork's job path (the FS->S3 artifact seam is already
+abstracted in storage_backend.py).
+
+This module pulls it behind a tiny vendor-neutral interface so a non-AWS deployment can
+resolve the same mapping over the broker's HTTP status API (or any KV store) instead of
+DynamoDB — keeping the fork AWS-free (AWS is one config value), while the AWS broker +
+DynamoDB stay in the private IaC repo. The lookup result shape (worker_ip + cape_task_id)
+is the only contract; everything else about how the broker stores it is a backend detail.
+Django-free + unit-testable, like storage_backend.py.
+"""
+import logging
+
+log = logging.getLogger(__name__)
+
+
+class JobLocation:
+    """Where a live broker job's VM is. worker_ip = the worker's private IP; cape_task_id
+    = the worker-local CAPE task id (used to query that worker's apiv2 for the VM). Either
+    may be None when the broker hasn't dispatched the job to a worker yet."""
+
+    __slots__ = ("worker_ip", "cape_task_id")
+
+    def __init__(self, worker_ip=None, cape_task_id=None):
+        # "" / missing -> None so callers can do a simple truthiness check; keep
+        # cape_task_id as-is (it can legitimately be 0, distinct from absent None).
+        self.worker_ip = worker_ip or None
+        self.cape_task_id = cape_task_id
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, JobLocation)
+            and self.worker_ip == other.worker_ip
+            and self.cape_task_id == other.cape_task_id
+        )
+
+    def __repr__(self):
+        return f"JobLocation(worker_ip={self.worker_ip!r}, cape_task_id={self.cape_task_id!r})"
+
+
+def _valid_worker_ip(ip):
+    """The broker record's sandbox_worker_ip becomes the netloc of a qemu+ssh libvirt DSN AND of
+    an authenticated apiv2 URL (central_guac.py). A poisoned/spoofed broker record with a value
+    like '1.2.3.4/system?keyfile=/attacker/key&no_verify=1&x=' or 'attacker:9999/x?a=' would
+    otherwise inject libvirt URI params or redirect the Token-bearing apiv2 request to an attacker
+    host. It is knowably a bare IP, so require it to parse as one; anything else -> None (the caller
+    then keeps the localhost/single-node path). Validating here — the one normalizer both backends
+    and both consumers flow through — is the single choke point."""
+    if not ip:
+        return None
+    import ipaddress
+
+    text = str(ip).strip()
+    try:
+        ipaddress.ip_address(text)
+    except ValueError:
+        log.warning("job_directory: ignoring non-IP sandbox_worker_ip %r from broker record", ip)
+        return None
+    return text
+
+
+def loc_from_item(item):
+    """Map a broker job record (dict from DynamoDB or the broker HTTP status API — both
+    use the SAME field names) to a JobLocation. Pure, so it's the unit-testable core both
+    backends share. The worker IP is validated (see _valid_worker_ip) before it reaches the
+    DSN/URL builders."""
+    item = item or {}
+    return JobLocation(_valid_worker_ip(item.get("sandbox_worker_ip")), item.get("cape_task_id"))
+
+
+class JobDirectory:
+    """Abstract job->worker resolver. Backends implement lookup(job_id)."""
+
+    def lookup(self, job_id):
+        """Return a JobLocation for job_id, or None if it can't be resolved (network/
+        config error, or no such job). worker_ip/cape_task_id inside may still be None
+        if the broker hasn't dispatched the job yet."""
+        raise NotImplementedError
+
+
+class DynamoJobDirectory(JobDirectory):
+    """Read the broker's DynamoDB job item directly (default for our AWS broker — keeps
+    today's [central_mode] broker_table behavior byte-for-byte)."""
+
+    def __init__(self, table, region="us-east-1"):
+        self.table = table
+        self.region = region
+
+    def lookup(self, job_id):
+        try:
+            import boto3
+
+            item = (
+                boto3.resource("dynamodb", region_name=self.region)
+                .Table(self.table)
+                .get_item(Key={"job_id": job_id})
+                .get("Item", {})
+            )
+        except Exception as e:
+            log.warning("job_directory(dynamodb): lookup failed for %s: %s", job_id, e)
+            return None
+        return loc_from_item(item)
+
+
+class BrokerHttpJobDirectory(JobDirectory):
+    """Resolve via the broker's HTTP status API — vendor-neutral (no DynamoDB / boto3 in
+    the fork). The broker's GET {broker_url}/api/status/{job_id} returns the same job
+    record (sandbox_worker_ip + cape_task_id). Bearer-auth with the broker API token."""
+
+    def __init__(self, broker_url, token=""):
+        self.broker_url = (broker_url or "").rstrip("/")
+        self.token = token or ""
+
+    def lookup(self, job_id):
+        if not self.broker_url:
+            return None
+        try:
+            import requests
+
+            headers = {"Authorization": f"Bearer {self.token}"} if self.token else {}
+            r = requests.get(f"{self.broker_url}/api/status/{job_id}", headers=headers, timeout=10)
+            if r.status_code != 200:
+                return None
+            item = r.json() or {}
+        except Exception as e:
+            log.warning("job_directory(broker_http): lookup failed for %s: %s", job_id, e)
+            return None
+        return loc_from_item(item)
+
+
+def get_job_directory(cfg):
+    """Return a JobDirectory for the central-mode config, or None when central mode is off
+    or no directory is configured — in which case central_guac's callers keep their
+    single-node/localhost path unchanged. Default backend is 'broker_http' (vendor-neutral —
+    resolves via the broker's HTTP API); 'dynamodb' (AWS) is opt-in."""
+    if not getattr(cfg, "enabled", False):
+        return None
+    backend = (getattr(cfg, "job_directory", "") or "broker_http").strip().lower()
+    if backend == "broker_http":
+        if not getattr(cfg, "broker_url", ""):
+            return None
+        return BrokerHttpJobDirectory(cfg.broker_url, getattr(cfg, "broker_api_token", ""))
+    # 'dynamodb' (opt-in, AWS) — None if broker_table unset (matches the pre-abstraction gate).
+    if not getattr(cfg, "broker_table", ""):
+        return None
+    return DynamoJobDirectory(cfg.broker_table, getattr(cfg, "s3_region", "us-east-1"))

--- a/lib/cuckoo/common/storage_backend.py
+++ b/lib/cuckoo/common/storage_backend.py
@@ -185,22 +185,23 @@ class S3Store(ArtifactStore):
             return ""
 
     def materialize(self, container, relpath):
+        # Whole body in one try so a mkstemp OSError (disk full / bad TEMP perms) can't escape and
+        # break the (None, False) contract the caller relies on.
+        tmp = None
         try:
             obj = self._client().get_object(Bucket=self.bucket, Key=self._key(container, relpath))
-        except Exception:
-            return (None, False)
-        fd, tmp = tempfile.mkstemp(prefix="cape_central_")
-        try:
+            fd, tmp = tempfile.mkstemp(prefix="cape_central_")
             with os.fdopen(fd, "wb") as f:
                 for c in obj["Body"].iter_chunks(65536):
                     f.write(c)
+            return (tmp, True)
         except Exception:
-            try:
-                os.unlink(tmp)
-            except OSError:
-                pass
+            if tmp is not None:
+                try:
+                    os.unlink(tmp)
+                except OSError:
+                    pass
             return (None, False)
-        return (tmp, True)
 
     def iter_relpaths(self, container):
         prefix = f"{container}/"

--- a/lib/cuckoo/common/storage_backend.py
+++ b/lib/cuckoo/common/storage_backend.py
@@ -1,0 +1,232 @@
+"""Pluggable artifact-storage backend for central mode.
+
+The central-mode artifact seam (lib/cuckoo/common/artifact_storage.py read side,
+modules/reporting/centralstore.py write side) used boto3's S3 client with AWS defaults
+directly — the ONLY hard AWS coupling in the central-mode CAPE code. This module pulls
+that behind a small vendor-neutral interface so central mode runs on ANY S3-compatible
+object store (AWS S3, MinIO, Ceph RGW, …) or a shared local/NFS mount, with the endpoint
+and credentials supplied by config. Nothing AWS-shaped lives here — bucket/endpoint/region/
+creds are values in [central_mode], injected at runtime.
+
+A `container` is the per-analysis root (single-node: the storage/analyses/<task_id> dir;
+central: the "<s3_prefix>/<job_id>" key prefix); `relpath` is the artifact path within it
+(the caller validates it with _safe_relpath before passing it here). The stores are
+Django-free — they return (byte-iterator, length) and the caller builds the HTTP response —
+so this module is portable + unit-testable without the web stack.
+"""
+import os
+import shutil
+import tempfile
+
+
+class ArtifactNotFound(Exception):
+    """Raised by stream()/read bytes when an artifact key is absent."""
+
+
+class ArtifactStore:
+    """Abstract per-analysis object store. Backends implement raw object ops keyed by
+    (container, relpath)."""
+
+    def exists(self, container, relpath) -> bool:
+        raise NotImplementedError
+
+    def stream(self, container, relpath, chunk=8192):
+        """Return (byte_iterator, content_length_or_None). Raise ArtifactNotFound if absent."""
+        raise NotImplementedError
+
+    def read_text(self, container, relpath, max_bytes):
+        """Return up to max_bytes of text (utf-8, errors=replace), or "" if absent."""
+        raise NotImplementedError
+
+    def materialize(self, container, relpath):
+        """Return (local_path, is_temp) for a caller that needs a real file (random access,
+        external tool). is_temp=True means the caller must delete it. (None, False) if absent."""
+        raise NotImplementedError
+
+    def iter_relpaths(self, container):
+        """Yield each artifact relpath present under `container` (for staging)."""
+        raise NotImplementedError
+
+    def download(self, container, relpath, dest_abspath):
+        """Copy one artifact to dest_abspath (creates parent dirs). Best-effort raise on error."""
+        raise NotImplementedError
+
+    def put_file(self, local_path, container, relpath):
+        """Write a local file into the store at (container, relpath)."""
+        raise NotImplementedError
+
+
+def _iter_file(path, chunk):
+    with open(path, "rb") as f:
+        while True:
+            data = f.read(chunk)
+            if not data:
+                break
+            yield data
+
+
+class LocalFSStore(ArtifactStore):
+    """Filesystem backend. Used for single-node (base=storage/analyses, container=<task_id>)
+    AND for a central deployment on a shared local/NFS mount (base=central_local_root,
+    container="<prefix>/<job_id>")."""
+
+    def __init__(self, base_dir):
+        self.base_dir = base_dir
+
+    def _path(self, container, relpath):
+        return os.path.join(self.base_dir, str(container), relpath)
+
+    def exists(self, container, relpath) -> bool:
+        return os.path.exists(self._path(container, relpath))
+
+    def stream(self, container, relpath, chunk=8192):
+        path = self._path(container, relpath)
+        if not os.path.exists(path):
+            raise ArtifactNotFound(relpath)
+        return _iter_file(path, chunk), os.path.getsize(path)
+
+    def read_text(self, container, relpath, max_bytes):
+        path = self._path(container, relpath)
+        if not os.path.exists(path):
+            return ""
+        with open(path, "r", errors="replace") as f:
+            return f.read(max_bytes + 1)
+
+    def materialize(self, container, relpath):
+        path = self._path(container, relpath)
+        return (path, False) if os.path.exists(path) else (None, False)
+
+    def iter_relpaths(self, container):
+        root = self._path(container, "")
+        if not os.path.isdir(root):
+            return
+        for dirpath, _dirs, files in os.walk(root):
+            for fn in files:
+                yield os.path.relpath(os.path.join(dirpath, fn), root)
+
+    def download(self, container, relpath, dest_abspath):
+        src = self._path(container, relpath)
+        os.makedirs(os.path.dirname(dest_abspath), exist_ok=True)
+        if os.path.realpath(src) != os.path.realpath(dest_abspath):
+            shutil.copyfile(src, dest_abspath)
+
+    def put_file(self, local_path, container, relpath):
+        dest = self._path(container, relpath)
+        dest_dir = os.path.dirname(dest)
+        os.makedirs(dest_dir, exist_ok=True)
+        if os.path.realpath(local_path) == os.path.realpath(dest):
+            return
+        # Write to a temp file in the SAME dir (same filesystem) then atomically rename, so a
+        # concurrent reader (the central read seam staging from a shared/NFS mount) never observes
+        # a half-written object at the final key. A direct copyfile would expose partial content.
+        fd, tmp = tempfile.mkstemp(dir=dest_dir, prefix=".part-")
+        os.close(fd)
+        try:
+            shutil.copyfile(local_path, tmp)
+            os.replace(tmp, dest)
+        except Exception:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
+
+
+class S3Store(ArtifactStore):
+    """Any S3-compatible object store via boto3. endpoint_url/creds are optional: empty
+    endpoint_url -> AWS's default endpoint; empty creds -> boto3's default chain (IAM role
+    on AWS). Set them to point at MinIO/Ceph/etc."""
+
+    def __init__(self, bucket, region="us-east-1", endpoint_url="", access_key="", secret_key=""):
+        self.bucket = bucket
+        self.region = region
+        self.endpoint_url = endpoint_url or None
+        self.access_key = access_key or None
+        self.secret_key = secret_key or None
+        self._cli = None
+
+    def _client(self):
+        if self._cli is None:
+            import boto3
+
+            kwargs = {"region_name": self.region}
+            if self.endpoint_url:
+                kwargs["endpoint_url"] = self.endpoint_url
+            if self.access_key and self.secret_key:
+                kwargs["aws_access_key_id"] = self.access_key
+                kwargs["aws_secret_access_key"] = self.secret_key
+            self._cli = boto3.client("s3", **kwargs)
+        return self._cli
+
+    def _key(self, container, relpath):
+        return f"{container}/{relpath}"
+
+    def exists(self, container, relpath) -> bool:
+        try:
+            self._client().head_object(Bucket=self.bucket, Key=self._key(container, relpath))
+            return True
+        except Exception:
+            return False
+
+    def stream(self, container, relpath, chunk=8192):
+        try:
+            obj = self._client().get_object(Bucket=self.bucket, Key=self._key(container, relpath))
+        except Exception:
+            raise ArtifactNotFound(relpath)
+        return obj["Body"].iter_chunks(chunk), obj.get("ContentLength")
+
+    def read_text(self, container, relpath, max_bytes):
+        try:
+            obj = self._client().get_object(
+                Bucket=self.bucket, Key=self._key(container, relpath), Range=f"bytes=0-{max_bytes}"
+            )
+            return obj["Body"].read().decode("utf-8", errors="replace")
+        except Exception:
+            return ""
+
+    def materialize(self, container, relpath):
+        try:
+            obj = self._client().get_object(Bucket=self.bucket, Key=self._key(container, relpath))
+        except Exception:
+            return (None, False)
+        fd, tmp = tempfile.mkstemp(prefix="cape_central_")
+        try:
+            with os.fdopen(fd, "wb") as f:
+                for c in obj["Body"].iter_chunks(65536):
+                    f.write(c)
+        except Exception:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            return (None, False)
+        return (tmp, True)
+
+    def iter_relpaths(self, container):
+        prefix = f"{container}/"
+        paginator = self._client().get_paginator("list_objects_v2")
+        for page in paginator.paginate(Bucket=self.bucket, Prefix=prefix):
+            for obj in page.get("Contents", []):
+                rel = obj["Key"][len(prefix):]
+                if rel and not rel.endswith("/"):
+                    yield rel
+
+    def download(self, container, relpath, dest_abspath):
+        os.makedirs(os.path.dirname(dest_abspath), exist_ok=True)
+        self._client().download_file(self.bucket, self._key(container, relpath), dest_abspath)
+
+    def put_file(self, local_path, container, relpath):
+        self._client().upload_file(local_path, self.bucket, self._key(container, relpath))
+
+
+def get_artifact_store(cfg):
+    """Return (store, is_central) for the central-mode config. Single-node (cfg.enabled
+    False) -> LocalFSStore over storage/analyses. Central -> S3Store (default) or LocalFSStore
+    when storage_backend='local' + a central_local_root is set."""
+    from lib.cuckoo.common.constants import CUCKOO_ROOT
+
+    if not cfg.enabled:
+        return LocalFSStore(os.path.join(CUCKOO_ROOT, "storage", "analyses")), False
+    if cfg.storage_backend == "local" and cfg.central_local_root:
+        return LocalFSStore(cfg.central_local_root), True
+    return S3Store(cfg.s3_bucket, cfg.s3_region, cfg.s3_endpoint_url, cfg.s3_access_key, cfg.s3_secret_key), True

--- a/lib/cuckoo/common/tenancy_optional.py
+++ b/lib/cuckoo/common/tenancy_optional.py
@@ -1,0 +1,100 @@
+"""Import-optional facade for the lib-level MT symbols (lib.cuckoo.common.tenancy).
+
+Delegates to the real MT module when it's importable; when it ISN'T (the MT layer is not
+deployed — e.g. an upstream central-only build), returns values IDENTICAL to the MT-disabled
+code path (which the real functions already implement: viewer_for -> is_local_admin=True ->
+every can_* gate True; scope_match -> None). FAIL-CLOSED: catch ImportError ONLY; a runtime
+error from a deployed MT layer propagates rather than silently degrading to see-all.
+"""
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Viewer:
+    """FALLBACK viewer, returned by viewer_for() ONLY when the MT layer is absent — see-all
+    (is_local_admin=True). When MT IS deployed, viewer_for() returns the REAL
+    lib.cuckoo.common.tenancy.Viewer, a DIFFERENT class. So do NOT
+    `isinstance(viewer_for(u), Viewer)` against this type — it's False in production. Treat
+    viewer_for()'s result structurally (.is_local_admin / .tenant_id), never by type."""
+    user_id: int = 0
+    tenant_id: int = 0
+    is_tenant_admin: bool = False
+    is_local_admin: bool = True
+
+
+@dataclass(frozen=True)
+class MTConfig:
+    """FALLBACK config, returned by multitenancy_config() ONLY when the MT layer is absent.
+    When MT is deployed the REAL lib.cuckoo.common.tenancy.MTConfig (a different class) is
+    returned — don't isinstance-check against this; read .enabled / .mode structurally."""
+    enabled: bool = False
+    mode: str = "shared"
+    default_visibility: str = ""
+    local_admins_manage_all_tenants: bool = True
+
+
+def multitenancy_config():
+    try:
+        from lib.cuckoo.common.tenancy import multitenancy_config as real
+    except ImportError:
+        return MTConfig()
+    return real()
+
+
+def viewer_for(user):
+    # viewer_for lives in the web `users` MT app (needs the Django ORM), NOT the pure predicate
+    # lib.cuckoo.common.tenancy -- importing it from there always ImportError'd -> the facade
+    # silently degraded to see-all even when MT WAS deployed (cross-tenant leak). Resolve it from
+    # users.tenancy (present => real viewer; absent/non-Django => fall back to see-all).
+    try:
+        from users.tenancy import viewer_for as real
+    except ImportError:
+        return Viewer()
+    return real(user)
+
+
+def scope_match(scope, viewer):
+    try:
+        from lib.cuckoo.common.tenancy import scope_match as real
+    except ImportError:
+        return None
+    return real(scope, viewer)
+
+
+# Visibility constants — stable contract values. Present -> the real module's values;
+# absent -> the same literals so callers comparing/storing visibility still work.
+try:
+    from lib.cuckoo.common.tenancy import PUBLIC, PRIVATE, TENANT, VISIBILITIES  # noqa: F401
+except ImportError:
+    PUBLIC, TENANT, PRIVATE = "public", "tenant", "private"
+    VISIBILITIES = (PUBLIC, TENANT, PRIVATE)
+
+
+def default_visibility(cfg):
+    """Submit-time default visibility for the configured mode (see-all path -> PUBLIC)."""
+    try:
+        from lib.cuckoo.common.tenancy import default_visibility as real
+    except ImportError:
+        if getattr(cfg, "default_visibility", "") in VISIBILITIES:
+            return cfg.default_visibility
+        return PUBLIC if getattr(cfg, "mode", "shared") == "shared" else TENANT
+    return real(cfg)
+
+
+def viewer_scope_match(viewer):
+    """Mongo $match restricting a query to the viewer's entitled scopes, or None (no
+    filter / see-all) when MT is disabled or the layer is absent."""
+    try:
+        from lib.cuckoo.common.tenancy import viewer_scope_match as real
+    except ImportError:
+        return None
+    return real(viewer)
+
+
+def viewer_scope_es_filter(viewer):
+    """Elasticsearch bool-filter analogue of viewer_scope_match, or None (see-all)."""
+    try:
+        from lib.cuckoo.common.tenancy import viewer_scope_es_filter as real
+    except ImportError:
+        return None
+    return real(viewer)

--- a/modules/reporting/centralstore.py
+++ b/modules/reporting/centralstore.py
@@ -1,0 +1,271 @@
+"""centralstore — worker-side ingest seam for central mode.
+
+central_mode OFF (default): no-op. The worker behaves byte-for-byte single-node.
+
+central_mode ON: stamp the broker-supplied global job_id into results.info.job_id
+and push the analysis artifact tree to S3 at <prefix>/<job_id>/<rel>. Runs at
+order 9998 — BEFORE the native mongodb reporting module (order 9999) — so the
+report doc that mongodb.py writes to the central DocumentDB already carries
+info.job_id. The DocumentDB write itself is the NATIVE mongodb.py path pointed at
+DocumentDB via [mongodb] (tls=yes, retrywrites=no) — validated against live DocumentDB
+(loop_saver/$set, calls chunking, files $addToSet, tenant_scope_idx). This module only adds the FS->S3 half
+plus the job_id keying the read seam (artifact_storage.artifact_response) resolves.
+"""
+import logging
+import os
+import re
+
+from lib.cuckoo.common.abstracts import Report
+from lib.cuckoo.common.central_mode import central_mode_config, upload_target_realpath
+from lib.cuckoo.common.exceptions import CuckooReportError
+from lib.cuckoo.common.storage_backend import get_artifact_store
+
+log = logging.getLogger(__name__)
+
+# job_id becomes an S3 key segment, so it must not contain path separators or
+# traversal. The broker should stamp an authenticated job_id; this is the last
+# line of defence against a tenant-supplied `custom` poisoning another job's
+# prefix (audit CRITICAL-1). local-<int> fallback satisfies the allowlist.
+# Must start with an alnum (no leading '.'/'-'/'_') AND contain no '..' run, so a
+# value like '.', '..', '.foo' or 'a..b' can never collapse 'results/<job_id>/' to a
+# parent ref ('results/../') in an S3 key or the local staging path. _is_safe_job_id
+# applies both rules (the regex alone permitted '.'/'..').
+_JOB_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$")
+
+
+def _is_safe_job_id(job_id):
+    return bool(job_id) and _JOB_ID_RE.match(job_id) is not None and ".." not in job_id
+
+# Upload the whole analysis tree to S3 (the "heavy detail" tier): shots, dropped
+# files, pcap, procdump, AND reports/ (report.json/html/pdf are downloadable
+# artifacts the filereport view serves). The DocumentDB report doc written by the
+# native mongodb.py module is ADDITIVE (it powers the queryable UI tabs) — it does
+# not replace the report files, so nothing is excluded here.
+_EXCLUDE_DIRS = set()
+
+
+def resolve_job_id(custom, analysis_id):
+    """The broker passes the global job_id through the task `custom` field, carried
+    all the way to reporting. Accept 'job_id=<v>' (optionally among other
+    comma-separated k=v pairs) or a bare token. Fall back to 'local-<id>' so central
+    mode also works when an analysis was submitted directly (no broker)."""
+    if custom:
+        text = str(custom)
+        for part in text.split(","):
+            part = part.strip()
+            if part.startswith("job_id="):
+                v = part.split("=", 1)[1].strip()
+                if v:
+                    return v
+        token = text.strip()
+        if token and "=" not in token and "," not in token:
+            return token
+    return f"local-{analysis_id}"
+
+
+class CentralStore(Report):
+    """Ship analysis artifacts to S3 + stamp the central job_id (central mode only)."""
+
+    order = 9998  # before mongodb (9999): stamp info.job_id before the central DocumentDB write
+
+    def run(self, results):
+        cfg = central_mode_config()
+        if not cfg.enabled:
+            return  # single-node: no-op, behavior byte-for-byte unchanged
+
+        store, _is_central = get_artifact_store(cfg)
+        # Validate the configured backend's prerequisites up front so a misconfig fails
+        # with one clean CuckooReportError, not N per-file upload failures (which would
+        # leave the job retained-but-never-done). The S3 path (default storage_backend)
+        # needs a bucket + boto3; the shared-mount path (storage_backend=local +
+        # central_local_root) needs neither.
+        using_local_mount = cfg.storage_backend == "local" and bool(cfg.central_local_root)
+        if not using_local_mount:
+            if not cfg.s3_bucket:
+                raise CuckooReportError("centralstore: central_mode enabled but [central_mode] s3_bucket unset")
+            try:
+                import boto3  # noqa: F401
+            except ImportError as e:
+                raise CuckooReportError("centralstore: central mode requires boto3") from e
+
+        info = results.setdefault("info", {})
+        analysis_id = info.get("id")
+        job_id = info.get("job_id") or resolve_job_id(info.get("custom"), analysis_id)
+        if not _is_safe_job_id(job_id):
+            # Refuse a job_id that could escape/poison another job's S3 prefix.
+            raise CuckooReportError(
+                "centralstore: refusing unsafe job_id %r (must match %s and contain no '..')"
+                % (job_id, _JOB_ID_RE.pattern))
+        info["job_id"] = job_id  # carried into the DocumentDB doc; read seam keys S3 by it
+
+        # Align info.id to the CENTRAL task id when the broker assigned a
+        # "ui-<central_task_id>" job_id (the central-submit-bridge does this). The
+        # worker's local info.id is a per-worker sequence that collides across workers
+        # and is meaningless to the central UI, which addresses every analysis by its
+        # OWN task id. Rewriting info.id here (before mongodb.py at 9999 writes the doc)
+        # makes the central DocumentDB doc resolvable by the central task id natively —
+        # so the report view, all report-tab lookups, and the artifact seam work without
+        # touching ~25 info.id call sites in the upstream-synced views.py.
+        _m = re.match(r"^ui-(\d+)$", job_id)
+        if _m:
+            info["id"] = int(_m.group(1))
+
+        # The per-analysis container the read seam resolves to (artifact_storage.
+        # _store_and_container builds the same "<prefix>/<job_id>"). The raw object I/O
+        # is the pluggable store (S3-compatible or shared mount); the symlink-exfil
+        # guard + job_id keying stay here.
+        container = f"{cfg.s3_prefix}/{job_id}"
+        uploaded, failed = self._upload_tree(store, container)
+        # Guac recordings live outside the analysis tree (top-level storage/
+        # guacrecordings/), so they need their own pass. Fold their counts in so the
+        # done marker — the cleanup purge gate — only fires once EVERYTHING this job
+        # produced (tree + binaries + any recording) is confirmed in the central store.
+        rec_up, rec_failed = self._upload_guacrecordings(store, container, analysis_id)
+        uploaded += rec_up
+        failed += rec_failed
+        log.info("centralstore: uploaded %d artifacts (%d recordings) to %s/ (%d failed)",
+                 uploaded, rec_up, container, failed)
+
+        # Stamp a local marker ONLY when the whole tree is confirmed in S3. The worker's
+        # cape-nvme-cleanup gate keys off this file: present => artifacts are durable in
+        # the central stores => the local (ephemeral-NVMe) copy is safe to purge. On any
+        # upload failure we leave no marker, so the analysis is retained until it is
+        # re-confirmed or the worker recycles (24h) — never purged unconfirmed.
+        if failed == 0:
+            _emit_done_marker(store, container, self.analysis_path, cfg, job_id, uploaded)
+        else:
+            log.warning("centralstore: %d upload(s) failed for job_id=%s; NOT marking done "
+                        "(local copy retained for cleanup safety)", failed, job_id)
+
+    def _trusted_roots(self, base_real):
+        """Content roots a sample-influenced symlink may legitimately resolve into:
+        storage/binaries (the content-addressed sample/dropped-file store the analysis
+        dir's `binary` symlink targets) and storage/guacrecordings. base_real is
+        .../storage/analyses/<id>, so the storage root is two levels up."""
+        storage_root = os.path.dirname(os.path.dirname(base_real))
+        return [
+            os.path.realpath(os.path.join(storage_root, "binaries")),
+            os.path.realpath(os.path.join(storage_root, "guacrecordings")),
+        ]
+
+    def _upload_tree(self, store, container):
+        base = self.analysis_path
+        if not base or not os.path.isdir(base):
+            log.warning("centralstore: analysis_path missing or not a dir: %s", base)
+            return 0, 0
+        base_real = os.path.realpath(base)
+        trusted_roots = self._trusted_roots(base_real)
+        count = 0
+        failed = 0
+        for root, dirs, files in os.walk(base):
+            # don't descend symlinked dirs; drop excluded dirs
+            dirs[:] = [d for d in dirs if d not in _EXCLUDE_DIRS and not os.path.islink(os.path.join(root, d))]
+            for fn in files:
+                full = os.path.join(root, fn)
+                # A regular in-tree file uploads itself; a symlink into a trusted
+                # content root (binary -> storage/binaries/<sha256>, a recording ->
+                # storage/guacrecordings/) uploads its RESOLVED content under the
+                # analysis-relative key. Anything resolving elsewhere (a planted
+                # symlink to e.g. ~/.aws/credentials) returns None and is skipped —
+                # the artifact-exfil guard stays intact (audit CRITICAL).
+                src = upload_target_realpath(full, base_real, trusted_roots)
+                if src is None:
+                    log.warning("centralstore: skipping out-of-tree/untrusted artifact %s", full)
+                    continue
+                rel = os.path.relpath(full, base)
+                try:
+                    store.put_file(src, container, rel)
+                    count += 1
+                except Exception as e:
+                    failed += 1
+                    log.warning("centralstore: failed to upload %s -> %s/%s: %s", rel, container, rel, e)
+        return count, failed
+
+    def _upload_guacrecordings(self, store, container, task_id):
+        """Ship Guacamole session recordings for this task. Recordings live in the
+        top-level storage/guacrecordings/ (NOT inside the analysis tree, so the walk
+        above never sees them) and are named '<task_id>_<session_id>' by the guac
+        consumer. They only exist when an analyst live-viewed the VM mid-detonation,
+        so this is usually a no-op; when present they upload under <job_id>/
+        guacrecordings/<name> so the central store has them before the worker purges.
+        """
+        base_real = os.path.realpath(self.analysis_path)
+        rec_root = os.path.join(os.path.dirname(os.path.dirname(base_real)), "guacrecordings")
+        if not task_id or not os.path.isdir(rec_root):
+            return 0, 0
+        count = 0
+        failed = 0
+        prefix_match = f"{task_id}_"
+        for fn in os.listdir(rec_root):
+            # exact '<task_id>' or '<task_id>_<session>' — never a different task that
+            # merely shares a leading digit (e.g. task 1 vs 15): require '_' boundary.
+            if fn != str(task_id) and not fn.startswith(prefix_match):
+                continue
+            full = os.path.join(rec_root, fn)
+            if os.path.islink(full) or not os.path.isfile(full):
+                continue
+            rel = f"guacrecordings/{fn}"
+            try:
+                store.put_file(full, container, rel)
+                count += 1
+            except Exception as e:
+                failed += 1
+                log.warning("centralstore: failed to upload recording %s -> %s/%s: %s", fn, container, rel, e)
+        return count, failed
+
+
+def _emit_done_marker(store, container, analysis_path, cfg, job_id, uploaded):
+    """Emit the analysis completion marker, in TWO places, once the whole tree is confirmed:
+
+    1. LOCAL — storage/analyses/<id>/.centralstore.done. The worker's cape-nvme-cleanup purges
+       only analyses carrying this file, so it can never delete a job that didn't reach the
+       central store.
+    2. CENTRAL STORE — uploaded as the FINAL object at <container>/.centralstore.done. The READ
+       seam (artifact_storage._stage_tree) treats this key as the completion signal and only then
+       caches .central_staged; WITHOUT the store copy `complete` is never True, so every central
+       report view re-stages the entire tree from the store on every request. Uploaded last (and
+       only when failed==0 upstream) so a listing taken mid-upload never shows the marker before
+       the tree is complete.
+
+    Best-effort: a marker failure never breaks reporting — the artifacts are already durable. If
+    the local write fails there's nothing to upload; if the store upload fails the local gate
+    still stands (cleanup stays safe) and the read side falls back to the per-file download seam."""
+    import json
+    import time
+
+    if not analysis_path or not os.path.isdir(analysis_path):
+        return
+    marker = os.path.join(analysis_path, ".centralstore.done")
+    # Backend-aware location string: s3://bucket/... for the S3 path, or the shared
+    # mount's <root>/<prefix>/<job_id>/ for the local path. Informational only.
+    if cfg.storage_backend == "local" and cfg.central_local_root:
+        location = os.path.join(cfg.central_local_root, cfg.s3_prefix, job_id) + os.sep
+    else:
+        location = "s3://%s/%s/%s/" % (cfg.s3_bucket, cfg.s3_prefix, job_id)
+    try:
+        with open(marker, "w") as f:
+            json.dump({
+                "job_id": job_id,
+                "location": location,
+                "artifacts": uploaded,
+                "ts": time.time(),
+            }, f)
+    except Exception as e:
+        log.warning("centralstore: could not write local done marker %s: %s", marker, e)
+        return  # nothing to upload if the local marker couldn't even be written
+    # This is the SINGLE object that gates the read-side staging cache (artifact_storage.
+    # _stage_tree). Reporting runs once and won't re-emit it, and the worker's cleanup gate (the
+    # local marker) will let the ephemeral NVMe copy be purged — so a transient store hiccup here
+    # would permanently disable that job's read cache with no self-heal. Retry a few times before
+    # giving up; the tree itself is already durable, so this stays best-effort even on total failure.
+    for attempt in range(3):
+        try:
+            store.put_file(marker, container, ".centralstore.done")
+            return
+        except Exception as e:
+            log.warning("centralstore: marker upload attempt %d/3 to %s/.centralstore.done failed: %s",
+                        attempt + 1, container, e)
+            if attempt < 2:
+                time.sleep(0.25 * (attempt + 1))
+    log.warning("centralstore: gave up uploading %s/.centralstore.done after 3 attempts "
+                "(read-side staging cache disabled for this job; artifacts still served per-file)", container)

--- a/tests/test_central_mode.py
+++ b/tests/test_central_mode.py
@@ -1,0 +1,416 @@
+"""Pure-logic unit tests for central mode — no Django / pymongo / CAPE web imports
+(the web layer is iterated live on a CAPE box). Run: pytest tests/test_central_mode.py"""
+import os
+
+import pytest
+
+from lib.cuckoo.common.central_mode import _parse, _as_bool, _as_int, _as_port, upload_target_realpath
+from lib.cuckoo.common.central_guac import (
+    _libvirt_ssh_dsn,
+    _worker_api_token,
+    _worker_task_view_url,
+)
+from lib.cuckoo.common.hunt_query import build_hunt_facets
+from lib.cuckoo.common.storage_backend import (
+    ArtifactNotFound,
+    LocalFSStore,
+    S3Store,
+    get_artifact_store,
+)
+from lib.cuckoo.common.job_directory import (
+    BrokerHttpJobDirectory,
+    DynamoJobDirectory,
+    JobLocation,
+    get_job_directory,
+    loc_from_item,
+)
+
+
+def test_as_bool():
+    assert _as_bool("yes") is True
+    assert _as_bool("on") is True
+    assert _as_bool("no") is False
+    assert _as_bool(None, False) is False
+    assert _as_bool(True) is True
+
+
+def test_as_int():
+    assert _as_int("42", 0) == 42
+    assert _as_int(7, 0) == 7
+    assert _as_int("  9443 ", 0) == 9443  # stripped
+    assert _as_int(None, 8000) == 8000
+    assert _as_int("notaport", 8000) == 8000  # garbage -> default, no crash
+
+
+def test_as_port():
+    assert _as_port("9443", 8000) == 9443
+    assert _as_port(443, 8000) == 443
+    # int() accepts these but they're not real ports -> fall back to the default (not a broken URL)
+    assert _as_port("0", 8000) == 8000
+    assert _as_port("-1", 8000) == 8000
+    assert _as_port("99999", 8000) == 8000
+    assert _as_port("nope", 8000) == 8000
+
+
+def test_central_mode_defaults_off():
+    c = _parse({})
+    assert c.enabled is False
+    assert c.s3_bucket == ""
+    assert c.s3_prefix == "results"
+
+
+def test_central_mode_on():
+    c = _parse({"enabled": "yes", "s3_bucket": "b", "s3_region": "us-east-1", "s3_prefix": "results"})
+    assert c.enabled is True
+    assert c.s3_bucket == "b"
+
+
+def test_central_mode_backend_fields_parse():
+    # The new backend-selection fields (the only thing that made the store AWS-locked)
+    # parse from [central_mode], with sane defaults when absent.
+    d = _parse({})
+    assert d.storage_backend == "s3"
+    assert d.s3_endpoint_url == "" and d.s3_access_key == "" and d.s3_secret_key == ""
+    assert d.central_local_root == ""
+    c = _parse({
+        "enabled": "yes",
+        "storage_backend": "LOCAL",  # normalized to lower
+        "s3_endpoint_url": "https://minio.local:9000",
+        "s3_access_key": "ak",
+        "s3_secret_key": "sk",
+        "central_local_root": "/srv/cape-central",
+    })
+    assert c.storage_backend == "local"
+    assert c.s3_endpoint_url == "https://minio.local:9000"
+    assert c.s3_access_key == "ak" and c.s3_secret_key == "sk"
+    assert c.central_local_root == "/srv/cape-central"
+
+
+def test_get_artifact_store_single_node_is_local_fs():
+    store, is_central = get_artifact_store(_parse({}))
+    assert is_central is False
+    assert isinstance(store, LocalFSStore)
+    # single-node always reads the local storage/analyses tree
+    assert store.base_dir.endswith(os.path.join("storage", "analyses"))
+
+
+def test_get_artifact_store_central_s3():
+    store, is_central = get_artifact_store(
+        _parse({"enabled": "yes", "s3_bucket": "bkt", "s3_region": "eu-west-1"})
+    )
+    assert is_central is True
+    assert isinstance(store, S3Store)
+    assert store.bucket == "bkt" and store.region == "eu-west-1"
+    # endpoint/creds default to None so boto3 uses AWS's endpoint + default cred chain
+    assert store.endpoint_url is None and store.access_key is None and store.secret_key is None
+
+
+def test_get_artifact_store_central_minio_endpoint():
+    store, _ = get_artifact_store(
+        _parse({
+            "enabled": "yes", "s3_bucket": "bkt",
+            "s3_endpoint_url": "https://minio.local:9000",
+            "s3_access_key": "ak", "s3_secret_key": "sk",
+        })
+    )
+    assert isinstance(store, S3Store)
+    assert store.endpoint_url == "https://minio.local:9000"
+    assert store.access_key == "ak" and store.secret_key == "sk"
+
+
+def test_get_artifact_store_central_local_mount(tmp_path):
+    root = str(tmp_path / "central")
+    store, is_central = get_artifact_store(
+        _parse({"enabled": "yes", "storage_backend": "local", "central_local_root": root})
+    )
+    assert is_central is True
+    assert isinstance(store, LocalFSStore)
+    assert store.base_dir == root
+
+
+def test_get_artifact_store_local_backend_without_root_falls_back_to_s3():
+    # storage_backend=local but no central_local_root is a misconfig; it must NOT
+    # silently read the single-node tree — it falls through to the S3 store (whose
+    # missing-bucket prereq centralstore validates up front).
+    store, is_central = get_artifact_store(
+        _parse({"enabled": "yes", "storage_backend": "local", "s3_bucket": "bkt"})
+    )
+    assert is_central is True
+    assert isinstance(store, S3Store)
+
+
+def test_localfsstore_roundtrip(tmp_path):
+    # LocalFSStore backs BOTH single-node and central-on-a-shared-mount, so its
+    # round-trip is the contract the read+write seams depend on.
+    base = str(tmp_path / "base")
+    store = LocalFSStore(base)
+    container = "results/job-1"
+
+    src = tmp_path / "src.txt"
+    src.write_text("hello world")
+    store.put_file(str(src), container, "reports/report.json")
+
+    assert store.exists(container, "reports/report.json") is True
+    assert store.exists(container, "missing") is False
+
+    body_iter, length = store.stream(container, "reports/report.json")
+    assert b"".join(body_iter) == b"hello world"
+    assert length == len("hello world")
+
+    assert store.read_text(container, "reports/report.json", 1000) == "hello world"
+    assert store.read_text(container, "missing", 1000) == ""
+
+    path, is_temp = store.materialize(container, "reports/report.json")
+    assert is_temp is False and os.path.exists(path)
+    assert store.materialize(container, "missing") == (None, False)
+
+    assert list(store.iter_relpaths(container)) == ["reports/report.json"]
+
+    dest = tmp_path / "out" / "copy.json"
+    store.download(container, "reports/report.json", str(dest))
+    assert dest.read_text() == "hello world"
+
+
+def test_localfsstore_stream_missing_raises(tmp_path):
+    store = LocalFSStore(str(tmp_path))
+    with pytest.raises(ArtifactNotFound):
+        store.stream("results/job-x", "nope")
+
+
+def test_s3store_is_lazy_no_client_on_construct():
+    # Constructing the store must NOT build a boto3 client (so import/config never
+    # touches the network); the client is built on first op.
+    store = S3Store("bkt", "us-east-1")
+    assert store._cli is None
+
+
+# ---- Phase 2: job->worker directory (interactive guac routing) ----
+
+def test_central_mode_job_directory_fields_parse():
+    d = _parse({})
+    assert d.job_directory == "broker_http"  # default backend (vendor-neutral)
+    assert d.broker_url == "" and d.broker_api_token == ""
+    c = _parse({
+        "enabled": "yes",
+        "job_directory": "BROKER_HTTP",  # normalized to lower
+        "broker_url": "https://broker.local",
+        "broker_api_token": "tok",
+    })
+    assert c.job_directory == "broker_http"
+    assert c.broker_url == "https://broker.local" and c.broker_api_token == "tok"
+
+
+def test_loc_from_item_maps_and_normalizes():
+    # the broker record (DynamoDB item OR broker HTTP status body) -> JobLocation
+    loc = loc_from_item({"sandbox_worker_ip": "10.0.0.5", "cape_task_id": 42, "status": "running"})
+    assert loc == JobLocation("10.0.0.5", 42)
+    # cape_task_id may legitimately be 0 (distinct from absent); worker_ip "" -> None
+    assert loc_from_item({"sandbox_worker_ip": "", "cape_task_id": 0}) == JobLocation(None, 0)
+    assert loc_from_item({}) == JobLocation(None, None)
+    assert loc_from_item(None) == JobLocation(None, None)
+    # IPv6 is a valid IP too (kept as-is)
+    assert loc_from_item({"sandbox_worker_ip": "fd00::1", "cape_task_id": 5}) == JobLocation("fd00::1", 5)
+
+
+def test_loc_from_item_rejects_non_ip_worker_ip():
+    # sandbox_worker_ip becomes the netloc of a libvirt DSN + an authenticated apiv2 URL. A poisoned
+    # broker record must NOT flow through: a non-IP value (injection payload, hostname, garbage) is
+    # dropped to None so the caller keeps the localhost path — closes the DSN/URL-injection vector.
+    payload = "1.2.3.4/system?keyfile=/attacker/key&no_verify=1&x="
+    assert loc_from_item({"sandbox_worker_ip": payload, "cape_task_id": 7}) == JobLocation(None, 7)
+    assert loc_from_item({"sandbox_worker_ip": "attacker.host:9999/x?a=", "cape_task_id": 1}) == JobLocation(None, 1)
+    assert loc_from_item({"sandbox_worker_ip": "not-an-ip", "cape_task_id": 2}) == JobLocation(None, 2)
+    # cape_task_id survives even when the IP is rejected (the job exists; it's just unroutable here)
+    assert loc_from_item({"sandbox_worker_ip": "999.999.999.999", "cape_task_id": 0}) == JobLocation(None, 0)
+
+
+def test_get_job_directory_off_returns_none():
+    assert get_job_directory(_parse({})) is None  # central mode off
+    # enabled but default backend (broker_http) with no broker_url -> None (caller keeps localhost)
+    assert get_job_directory(_parse({"enabled": "yes"})) is None
+
+
+def test_get_job_directory_default_is_broker_http():
+    # default backend is now broker_http (vendor-neutral); with a broker_url it resolves to BrokerHttp
+    d = get_job_directory(_parse({"enabled": "yes", "broker_url": "https://broker.local"}))
+    assert isinstance(d, BrokerHttpJobDirectory)
+
+
+def test_get_job_directory_dynamodb_explicit():
+    # dynamodb is opt-in (AWS); must be selected explicitly now
+    d = get_job_directory(_parse({"enabled": "yes", "job_directory": "dynamodb", "broker_table": "tbl", "s3_region": "eu-west-1"}))
+    assert isinstance(d, DynamoJobDirectory)
+    assert d.table == "tbl" and d.region == "eu-west-1"
+
+
+def test_get_job_directory_broker_http():
+    d = get_job_directory(_parse({
+        "enabled": "yes", "job_directory": "broker_http",
+        "broker_url": "https://broker.local/", "broker_api_token": "tok",
+    }))
+    assert isinstance(d, BrokerHttpJobDirectory)
+    assert d.broker_url == "https://broker.local"  # trailing slash stripped
+    assert d.token == "tok"
+
+
+def test_get_job_directory_broker_http_without_url_returns_none():
+    # broker_http selected but no broker_url -> None (caller keeps localhost path)
+    assert get_job_directory(_parse({"enabled": "yes", "job_directory": "broker_http"})) is None
+
+
+def test_broker_http_directory_no_url_lookup_none():
+    assert BrokerHttpJobDirectory("").lookup("job-1") is None
+
+
+def test_upload_target_realpath(tmp_path):
+    # Layout: storage/{analyses/<id>, binaries, guacrecordings}; a sibling secret outside storage.
+    storage = tmp_path / "storage"
+    analysis = storage / "analyses" / "42"
+    binaries = storage / "binaries"
+    guac = storage / "guacrecordings"
+    for d in (analysis, binaries, guac):
+        d.mkdir(parents=True)
+    secret = tmp_path / "secret.txt"
+    secret.write_text("AWS_SECRET")
+    blob = binaries / "deadbeef"
+    blob.write_text("sample bytes")
+    rec = guac / "42_sess"
+    rec.write_text("guac dump")
+
+    base_real = os.path.realpath(str(analysis))
+    trusted = [os.path.realpath(str(binaries)), os.path.realpath(str(guac))]
+
+    # a regular file inside the analysis tree -> uploaded (its own realpath)
+    plain = analysis / "report.json"
+    plain.write_text("{}")
+    assert upload_target_realpath(str(plain), base_real, trusted) == os.path.realpath(str(plain))
+
+    # the `binary` symlink -> resolves into storage/binaries (trusted) -> uploaded as the blob
+    binlink = analysis / "binary"
+    binlink.symlink_to(blob)
+    assert upload_target_realpath(str(binlink), base_real, trusted) == os.path.realpath(str(blob))
+
+    # a recording referenced via symlink into storage/guacrecordings (trusted) -> uploaded
+    reclink = analysis / "guac.rec"
+    reclink.symlink_to(rec)
+    assert upload_target_realpath(str(reclink), base_real, trusted) == os.path.realpath(str(rec))
+
+    # a sample-planted symlink to a host secret OUTSIDE storage roots -> skipped (None)
+    evil = analysis / "evil"
+    evil.symlink_to(secret)
+    assert upload_target_realpath(str(evil), base_real, trusted) is None
+
+    # prefix-collision guard: a sibling dir sharing a name prefix must NOT count as inside
+    sibling = storage / "binaries-evil"
+    sibling.mkdir()
+    sneaky = sibling / "x"
+    sneaky.write_text("nope")
+    link2 = analysis / "sneaky"
+    link2.symlink_to(sneaky)
+    assert upload_target_realpath(str(link2), base_real, trusted) is None
+
+
+def test_central_mode_worker_access_fields_parse():
+    # Interactive-guac worker access: config-driven (was hardcoded deb paths in central_guac).
+    d = _parse({})
+    assert d.worker_api_token_file == "/etc/cape/api-token"
+    assert d.worker_api_port == 8000 and isinstance(d.worker_api_port, int)
+    assert d.worker_ssh_user == "cape"
+    assert d.worker_ssh_keyfile == "/home/cape/.ssh/id_ed25519"
+    c = _parse({
+        "worker_api_token_file": "/opt/secrets/tok",
+        "worker_api_port": "9443",   # string in conf -> int
+        "worker_ssh_user": "sandbox",
+        "worker_ssh_keyfile": "/home/sandbox/.ssh/id_rsa",
+    })
+    assert c.worker_api_token_file == "/opt/secrets/tok"
+    assert c.worker_api_port == 9443 and isinstance(c.worker_api_port, int)
+    assert c.worker_ssh_user == "sandbox"
+    assert c.worker_ssh_keyfile == "/home/sandbox/.ssh/id_rsa"
+    # a bad/out-of-range port degrades to the default, not a startup crash or a broken URL
+    assert _parse({"worker_api_port": "nope"}).worker_api_port == 8000
+    assert _parse({"worker_api_port": "0"}).worker_api_port == 8000
+    assert _parse({"worker_api_port": "99999"}).worker_api_port == 8000
+
+
+def test_central_guac_worker_url_and_dsn():
+    # port + task id substitute; the deb defaults no longer live in the code path
+    assert _worker_task_view_url("10.0.0.5", 8000, 42) == "http://10.0.0.5:8000/apiv2/tasks/view/42/"
+    assert _worker_task_view_url("10.0.0.5", "9443", "7") == "http://10.0.0.5:9443/apiv2/tasks/view/7/"
+    # DSN carries the CONFIGURED user + keyfile (not hardcoded cape / id_ed25519)
+    assert _libvirt_ssh_dsn("10.0.0.9", "cape", "/home/cape/.ssh/id_ed25519") == \
+        "qemu+ssh://cape@10.0.0.9/system?keyfile=/home/cape/.ssh/id_ed25519&no_verify=1"
+    assert _libvirt_ssh_dsn("10.0.0.9", "sandbox", "/home/sandbox/.ssh/id_rsa") == \
+        "qemu+ssh://sandbox@10.0.0.9/system?keyfile=/home/sandbox/.ssh/id_rsa&no_verify=1"
+    # a keyfile with a URI metachar is quoted so it can't corrupt the query string
+    dsn = _libvirt_ssh_dsn("10.0.0.9", "cape", "/home/cape/my key&x")
+    assert "my%20key%26x" in dsn and dsn.endswith("&no_verify=1")
+
+
+def test_central_guac_worker_api_token(tmp_path):
+    tok = tmp_path / "api-token"
+    tok.write_text("  s3cr3t\n")
+    assert _worker_api_token(str(tok)) == "s3cr3t"  # stripped
+    # missing/unreadable -> "" (=> no auth header downstream), never raises
+    assert _worker_api_token(str(tmp_path / "nope")) == ""
+
+
+def test_centralstore_done_marker_local_and_uploaded(tmp_path):
+    # The completion marker must be BOTH written locally (the worker's NVMe-cleanup gate) AND
+    # uploaded to the central store (the read seam's .central_staged completion signal). Regression:
+    # it was local-only, so artifact_storage._stage_tree never saw it and re-staged every view.
+    from modules.reporting.centralstore import _emit_done_marker
+
+    analysis = tmp_path / "analyses" / "77"
+    analysis.mkdir(parents=True)
+    store = LocalFSStore(str(tmp_path / "central"))
+    cfg = _parse({"enabled": "yes", "s3_bucket": "bkt", "s3_prefix": "results"})
+    container = "results/ui-77"
+
+    _emit_done_marker(store, container, str(analysis), cfg, "ui-77", 12)
+
+    # local marker present (cleanup gate) with the expected metadata ...
+    local_marker = analysis / ".centralstore.done"
+    assert local_marker.exists()
+    import json
+    meta = json.loads(local_marker.read_text())
+    assert meta["job_id"] == "ui-77" and meta["artifacts"] == 12
+    assert meta["location"] == "s3://bkt/results/ui-77/"
+    # ... AND uploaded to the store under the exact key the read seam checks for
+    assert store.exists(container, ".centralstore.done") is True
+
+
+def test_centralstore_done_marker_upload_failure_keeps_local(tmp_path):
+    # A store put_file failure must NOT raise (the artifacts are already durable) and must leave
+    # the local marker intact so the worker's cleanup gate still fires.
+    from modules.reporting.centralstore import _emit_done_marker
+
+    analysis = tmp_path / "analyses" / "88"
+    analysis.mkdir(parents=True)
+
+    class BoomStore:
+        def put_file(self, *a, **k):
+            raise RuntimeError("s3 down")
+
+    cfg = _parse({"enabled": "yes", "s3_bucket": "bkt"})
+    _emit_done_marker(BoomStore(), "results/ui-88", str(analysis), cfg, "ui-88", 3)  # must not raise
+    assert (analysis / ".centralstore.done").exists()
+
+
+def test_hunt_facets_per_category_no_facet():
+    sent = []
+
+    def fake_agg(coll, pipeline):
+        sent.append(pipeline)
+        return [{"_id": "evil.com", "count": 5, "task_ids": [1, 2]}]
+
+    facets = build_hunt_facets(
+        fake_agg,
+        match={"$and": [{}, {"info.visibility": "public"}]},
+        hunt_map={"domains": {"db_unwind": "$network.domains", "db_group": "$network.domains.domain", "db_match": {"count": {"$gte": 1}}}},
+        categories={"domains": True},
+        min_count=1,
+    )
+    assert not any(any("$facet" in stage for stage in p) for p in sent)
+    assert sent[0][0] == {"$match": {"$and": [{}, {"info.visibility": "public"}]}}
+    assert facets["domains"][0]["_id"] == "evil.com"

--- a/tests/test_mt_absent_smoke.py
+++ b/tests/test_mt_absent_smoke.py
@@ -1,0 +1,85 @@
+"""MT-absent integration smoke — the inverse of the MT-present faithful suite.
+
+With the multi-tenant layer (users.tenancy + lib.cuckoo.common.tenancy) made unimportable,
+the import-optional facades must fall back to see-all AND the base view modules must still
+import. This proves central mode runs WITHOUT our multi-tenant fork (the Phase 4 un-weave
+goal). Box-run: needs the Django/CAPE environment (pytest-django sets up Django). The test
+restores the real facade bindings in a finally so it doesn't pollute later tests.
+"""
+import builtins
+import importlib
+
+
+def test_mt_absent_facades_see_all_and_base_views_import():
+    import lib.cuckoo.common.tenancy_optional as L
+    import web.tenancy_optional as W
+
+    real_import = builtins.__import__
+
+    def hide(name, *args, **kwargs):
+        if name in ("users.tenancy", "lib.cuckoo.common.tenancy") or \
+           name.startswith("users.tenancy.") or name.startswith("lib.cuckoo.common.tenancy."):
+            raise ImportError("simulated: MT layer absent")
+        return real_import(name, *args, **kwargs)
+
+    builtins.__import__ = hide
+    try:
+        # re-run the facades' module-level (constant) imports under the hidden layer
+        importlib.reload(L)
+        importlib.reload(W)
+
+        # lib facade -> MT-disabled-equivalent fallbacks
+        assert L.multitenancy_config().enabled is False
+        assert L.viewer_for(object()).is_local_admin is True
+        assert L.PUBLIC == "public" and L.VISIBILITIES == ("public", "tenant", "private")
+        assert L.scope_match("public", object()) is None
+        assert L.viewer_scope_match(object()) is None
+
+        # web facade -> see-all fallbacks (can_* True, scopes None)
+        assert W.can_view_task(object(), object()) is True
+        assert W.can_view_sample(object(), sha256="x") is True
+        assert W.viewer_for(object()).is_local_admin is True
+        assert W.viewer_scope_filter(object()) is None
+        assert W.submission_scope(object()) == (None, W.PUBLIC)  # 2-tuple, not None (callers unpack)
+
+        # the base view modules import with the MT layer absent (the core un-weave claim)
+        for mod in ("analysis.views", "apiv2.views", "submission.views",
+                    "dashboard.views", "guac.views", "guac.consumers", "compare.views"):
+            importlib.import_module(mod)
+    finally:
+        builtins.__import__ = real_import
+        importlib.reload(L)  # restore real bindings for any later tests in the session
+        importlib.reload(W)
+
+
+def test_no_unguarded_mt_app_imports_in_gate_sites():
+    """Regression guard for the class the module-import smoke above MISSES: a raw, unguarded
+    `from users.tenancy import ...` in a FUNCTION-LOCAL import (fires only at call time) crashes a
+    single-node/upstream build where the `users` MT app is absent. The MT app must be reached ONLY
+    through the import-optional facades (tenancy_optional) or a local try/except ImportError.
+    Whitelist = the two facades + central_scope's guarded fallback."""
+    import os
+    import re
+
+    root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+    allowed = {
+        "web/web/tenancy_optional.py",
+        "lib/cuckoo/common/tenancy_optional.py",
+        "web/analysis/central_scope.py",  # raw import is inside try/except ImportError (guarded)
+    }
+    offenders = []
+    for sub in ("lib", "web", "modules", "utils"):
+        for dirpath, _dirs, files in os.walk(os.path.join(root, sub)):
+            for fn in files:
+                if not fn.endswith(".py"):
+                    continue
+                rel = os.path.relpath(os.path.join(dirpath, fn), root)
+                if rel in allowed or "test" in rel or rel.endswith("conftest.py"):
+                    continue
+                try:
+                    src = open(os.path.join(dirpath, fn), encoding="utf-8").read()
+                except OSError:
+                    continue
+                if re.search(r"^\s*from users\.tenancy import", src, re.M):
+                    offenders.append(rel)
+    assert not offenders, f"unguarded MT-app imports (route through the tenancy_optional facade): {offenders}"

--- a/tests/test_tenancy_optional.py
+++ b/tests/test_tenancy_optional.py
@@ -38,9 +38,18 @@ def test_web_facade_absent_is_see_all(monkeypatch):
     # ban_all_user_tasks views gate SOLELY on it, so the MT-absent fallback preserves
     # upstream's staff/superuser-only boundary (a see-all True would let any authenticated
     # user ban accounts on a single-node build). Deny a plain user; allow staff/superuser.
-    class _Plain: is_staff = False; is_superuser = False
-    class _Staff: is_staff = True; is_superuser = False
-    class _Super: is_staff = False; is_superuser = True
+    class _Plain:
+        is_staff = False
+        is_superuser = False
+
+    class _Staff:
+        is_staff = True
+        is_superuser = False
+
+    class _Super:
+        is_staff = False
+        is_superuser = True
+
     assert can_ban_user(_Plain(), 1) is False
     assert can_ban_user(_Staff(), 1) is True
     assert can_ban_user(_Super(), 1) is True

--- a/tests/test_tenancy_optional.py
+++ b/tests/test_tenancy_optional.py
@@ -1,0 +1,64 @@
+import builtins
+import pytest
+from lib.cuckoo.common import tenancy_optional as topt
+
+
+def _hide(monkeypatch, modname):
+    real_import = builtins.__import__
+    def fake(name, *a, **k):
+        if name == modname or name.startswith(modname + "."):
+            raise ImportError(f"simulated-absent: {modname}")
+        return real_import(name, *a, **k)
+    monkeypatch.setattr(builtins, "__import__", fake)
+
+
+def test_lib_facade_present_delegates(monkeypatch):
+    # MT present: multitenancy_config() returns the real config object (has .enabled)
+    cfg = topt.multitenancy_config()
+    assert hasattr(cfg, "enabled")
+
+
+def test_lib_facade_absent_is_see_all(monkeypatch):
+    _hide(monkeypatch, "lib.cuckoo.common.tenancy")
+    assert topt.multitenancy_config().enabled is False
+    assert topt.viewer_for(object()).is_local_admin is True
+    assert topt.scope_match("acme", topt.viewer_for(object())) is None
+
+
+def test_web_facade_absent_is_see_all(monkeypatch):
+    _hide(monkeypatch, "users.tenancy")
+    from web.tenancy_optional import can_view_task, can_view_sample, submission_scope, can_ban_user, PUBLIC
+    assert can_view_task(object(), object()) is True
+    assert can_view_sample(object(), sha256="x") is True
+    # submission_scope MUST return a 2-tuple (callers unpack it); single-tenant -> (None, public)
+    assert submission_scope(object()) == (None, PUBLIC)
+    _tid, _vis = submission_scope(object())  # unpack like the real callers do
+    assert (_tid, _vis) == (None, "public")
+    # can_ban_user is the ONE facade that must NOT degrade to see-all: the ban_user /
+    # ban_all_user_tasks views gate SOLELY on it, so the MT-absent fallback preserves
+    # upstream's staff/superuser-only boundary (a see-all True would let any authenticated
+    # user ban accounts on a single-node build). Deny a plain user; allow staff/superuser.
+    class _Plain: is_staff = False; is_superuser = False
+    class _Staff: is_staff = True; is_superuser = False
+    class _Super: is_staff = False; is_superuser = True
+    assert can_ban_user(_Plain(), 1) is False
+    assert can_ban_user(_Staff(), 1) is True
+    assert can_ban_user(_Super(), 1) is True
+
+
+def test_web_facade_entitled_scope_filter_absent(monkeypatch):
+    _hide(monkeypatch, "dashboard.views")
+    from web.tenancy_optional import viewer_scope_filter
+    assert viewer_scope_filter(object()) is None
+
+
+def test_web_facade_fail_closed_on_runtime_error(monkeypatch):
+    # Fail-closed is an MT-present contract: with the MT layer deployed, a runtime error in the
+    # authz backend must PROPAGATE (never degrade to see-all). Skip on an MT-free upstream build.
+    ut = pytest.importorskip("users.tenancy")
+    def boom(*a, **k):
+        raise RuntimeError("authz backend down")
+    monkeypatch.setattr(ut, "can_view_task", boom)
+    from web.tenancy_optional import can_view_task
+    with pytest.raises(RuntimeError):
+        can_view_task(object(), object())

--- a/tests/web/test_guac_consumers.py
+++ b/tests/web/test_guac_consumers.py
@@ -189,7 +189,9 @@ def guac_consumer_app_factory(monkeypatch):
         monkeypatch.setattr(consumers, "GuacamoleClient", FakeGuacamoleClient)
         monkeypatch.setattr(consumers, "SessionTimeoutManager", timeout_manager_cls)
         monkeypatch.setattr(consumers, "Database", lambda: db)
-        monkeypatch.setattr(consumers, "_get_vnc_port", lambda vm_label: TEST_VNC_PORT)
+        # _get_vnc_port now takes an optional dsn (local hypervisor, or a worker's libvirt in
+        # central mode); the consumer passes it positionally, so the stub must accept it.
+        monkeypatch.setattr(consumers, "_get_vnc_port", lambda vm_label, dsn=None: TEST_VNC_PORT)
         monkeypatch.setattr(consumers.GuacamoleWebSocketConsumer, "read_guacd", read_guacd_impl)
         monkeypatch.setattr(consumers.GuacamoleWebSocketConsumer, "monitor_task_status", _background_task_stub)
         if stub_monitor_timeout:

--- a/web/analysis/central_scope.py
+++ b/web/analysis/central_scope.py
@@ -1,0 +1,45 @@
+"""Tenancy-optional scope resolution for central mode.
+
+central_mode and multitenancy are ORTHOGONAL toggles. Central mode must work both
+WITH the MT fork (tenant-scoped) and WITHOUT it (single-tenant central — everyone
+sees all within the deployment, like single-node but centralized), so the central
+core can be proposed upstream independently of our multi-tenant layer.
+
+These helpers are the single choke point through which the central-mode code resolves
+the viewer's tenant scope / per-sample visibility. They degrade to see-all ONLY when
+the MT layer is not deployed (ImportError). They are deliberately FAIL-CLOSED: when
+the MT layer IS deployed, its functions are authoritative and any RUNTIME error
+propagates rather than being swallowed into a see-all result (which would silently
+bypass tenant isolation — exactly the failure mode the isolation audit warns about).
+We catch ImportError ONLY — that precisely means "MT layer absent" — never a broad
+Exception. So for our deployments (MT layer present) behavior is byte-for-byte the
+direct call; the fallback exists purely for an MT-free upstream deployment.
+
+entitled_scope_filter already returns None when MT is present but disabled, so see-all
+is handled correctly across all three states:
+    MT layer absent        -> ImportError -> None / True   (single-tenant central)
+    MT present, disabled    -> entitled_scope_filter -> None ;  can_view_sample -> True
+    MT present, enabled     -> real tenant $match / real visibility check
+"""
+
+
+def viewer_scope(user):
+    """Mongo ``$match`` restricting central results to what ``user`` may read, or None
+    (no tenant filtering / see-all) when the MT layer isn't deployed. None is the
+    see-all sentinel the central seams already understand (``if scope:``)."""
+    try:
+        from dashboard.views import entitled_scope_filter
+    except ImportError:
+        return None  # MT layer not deployed -> single-tenant central
+    return entitled_scope_filter(user)  # authoritative; handles MT on/off; errors propagate
+
+
+def viewer_can_view_sample(user, *, sha256=None, sha1=None, md5=None, sample_id=None):
+    """Whether ``user`` may view a sample by hash. True when the MT layer isn't deployed
+    (single-tenant — the surrounding view's base-CAPE decorator stack still gates access);
+    otherwise delegates to the authoritative MT visibility check (fail-closed)."""
+    try:
+        from users.tenancy import can_view_sample
+    except ImportError:
+        return True  # MT layer not deployed -> single-tenant central
+    return can_view_sample(user, sha256=sha256, sha1=sha1, md5=md5, sample_id=sample_id)

--- a/web/analysis/central_views.py
+++ b/web/analysis/central_views.py
@@ -33,12 +33,18 @@ def central_job_id_for_task(task_id):
             # take ONLY the job_id= value, not everything to end-of-string — else a
             # 'job_id=ui-5,foo=bar' custom yields 'ui-5,foo=bar' and never matches the
             # S3 prefix / DocumentDB doc the artifacts were keyed under.
-            for part in str(custom).split(","):
+            text = str(custom)
+            for part in text.split(","):
                 part = part.strip()
                 if part.startswith("job_id="):
                     v = part.split("=", 1)[1].strip()
                     if v:
                         return v
+            # Bare-token form (custom is just the job id) — kept in sync with
+            # centralstore.resolve_job_id, which also accepts a bare token for non-bridged tasks.
+            token = text.strip()
+            if token and "=" not in token and "," not in token:
+                return token
     except Exception:
         pass
     return None

--- a/web/analysis/central_views.py
+++ b/web/analysis/central_views.py
@@ -1,0 +1,360 @@
+"""Central-mode artifact serving — the S3-backed counterparts of the analysis
+download/serve views in web/analysis/views.py.
+
+Kept in a SEPARATE module on purpose: views.py is heavily synced from upstream
+CAPEv2 (cape/ subtree merges), so it carries only a thin
+``if central_mode_config().enabled: return central_<view>(...)`` dispatch at the top
+of each affected view. All the central-mode logic lives here, in a file upstream does
+not have — so it never participates in a merge conflict, and we can take upstream
+advancements with minimal friction.
+
+These functions only run when central mode is ON, and only AFTER the upstream view's
+decorator stack (require_task_visibility, ratelimit, auth, …) has already run — so the
+relational task is authorized before we touch the central data plane. Single-node
+behavior is entirely in views.py and is never reached through this module.
+"""
+import os
+
+from django.shortcuts import render
+
+
+def central_job_id_for_task(task_id):
+    """Resolve the broker job_id for a central task from its RDS `custom` field
+    (the submit-bridge stamps custom='job_id=ui-<id>'). In the distributed topology
+    the worker assigns its OWN local info.id (collides across workers), so the
+    universal key for DocumentDB/S3 is info.job_id — NOT info.id. Returns None for a
+    non-bridged task (caller falls back to info.id keying for seeded/single-node docs)."""
+    try:
+        from analysis.views import db
+        t = db.view_task(int(task_id))
+        custom = getattr(t, "custom", None) if t else None
+        if custom:
+            # custom is comma-separated k=v pairs (matches centralstore.resolve_job_id);
+            # take ONLY the job_id= value, not everything to end-of-string — else a
+            # 'job_id=ui-5,foo=bar' custom yields 'ui-5,foo=bar' and never matches the
+            # S3 prefix / DocumentDB doc the artifacts were keyed under.
+            for part in str(custom).split(","):
+                part = part.strip()
+                if part.startswith("job_id="):
+                    v = part.split("=", 1)[1].strip()
+                    if v:
+                        return v
+    except Exception:
+        pass
+    return None
+
+
+def central_analysis_query(task_id, scope=None):
+    """Mongo filter to fetch a task's analysis doc in central mode.
+
+    PRIMARY key is info.job_id (globally unique) for a bridged task. centralstore also
+    re-keys info.id to the unique central task id for every bridged job, so {info.id} is
+    likewise unique in a real central deployment (every task arrives via the bridge) —
+    which is why the report-tab loaders that query {info.id: task_id} resolve to exactly
+    the authorized task's doc, not a colliding worker-local one. The info.id FALLBACK
+    here (non-bridged / seeded / single-node docs, where a worker-local info.id can
+    collide across workers) is ANDed with the viewer's `scope` (entitled_scope_filter)
+    as defence-in-depth so a collision can't surface another tenant's doc (audit HIGH)."""
+    jid = central_job_id_for_task(task_id)
+    q = {"info.job_id": jid} if jid else {"info.id": int(task_id)}
+    if scope:
+        q = {"$and": [q, scope]}
+    return q
+
+
+def _task_sample_sha256(request, task_id):
+    """The sha256 of THIS task's submitted sample (mongo target.file.sha256), scoped to
+    the viewer. central S3 stores only this binary (key <job_id>/binary), not a by-hash
+    store, so callers serving sample bytes must confirm the requested hash IS this."""
+    from dev_utils.mongodb import mongo_find_one
+    from analysis.central_scope import viewer_scope
+
+    doc = mongo_find_one("analysis", central_analysis_query(task_id, scope=viewer_scope(request.user)),
+                         {"target.file.sha256": 1, "_id": 0})
+    return ((((doc or {}).get("target") or {}).get("file") or {}).get("sha256") or "").lower()
+
+
+def central_stage_one(request, task_id, s3_relpath, dest_abspath):
+    """Materialize ONE S3 artifact (<job_id>/<s3_relpath>) to an exact local path so an
+    upstream zip path that reads that specific path works centrally. Used for memdumpzip
+    (memory/ is excluded from the bulk stage) and staticzip (reads the global binaries
+    store, OUTSIDE the analysis tree). Best-effort; never raises into the view."""
+    import shutil
+
+    from analysis.central_scope import viewer_scope
+    from lib.cuckoo.common.artifact_storage import materialize_artifact
+
+    if os.path.exists(dest_abspath):
+        return
+    src, is_temp = materialize_artifact(task_id, s3_relpath, scope=viewer_scope(request.user))
+    if not src:
+        return
+    try:
+        os.makedirs(os.path.dirname(dest_abspath), exist_ok=True)
+        (shutil.move if is_temp else shutil.copy)(src, dest_abspath)
+    except Exception:
+        if is_temp:
+            try:
+                os.unlink(src)
+            except OSError:
+                pass
+
+
+def central_stage_local(request, task_id):
+    """Stage the S3 analysis tree into the local FS so an upstream view that reads
+    storage/analyses/<task_id>/ directly works centrally without a per-file rewrite.
+    Used for the zip-on-the-fly download bundles (zip_categories) — re-implementing
+    CAPE's pyzipper/password/download_all archiving in the per-file S3 seam would be a
+    lot of duplicated fork code, so instead we materialize the tree and let the
+    upstream zip path below run byte-for-byte unchanged. Cached via the .central_staged
+    marker (cheap on repeat); best-effort (never raises into the view)."""
+    from analysis.central_scope import viewer_scope
+    from lib.cuckoo.common.artifact_storage import ensure_local_analysis
+
+    ensure_local_analysis(task_id, scope=viewer_scope(request.user))
+
+
+def central_file_nl(request, category, task_id, dlfile):
+    """Inline report assets: screenshots, bingraph, vba2graph (file_nl)."""
+    from django.http import Http404
+
+    from analysis.central_scope import viewer_scope
+    from lib.cuckoo.common.artifact_storage import artifact_response
+
+    # tenant-scope the S3/DocumentDB lookup as defence-in-depth against task_id
+    # collisions across workers (audit HIGH).
+    scope = viewer_scope(request.user)
+    if category == "screenshot":
+        cands = [(os.path.join("shots", dlfile + ext), dlfile + ext, cd) for ext, cd in ((".jpg", "image/jpeg"), (".png", "image/png"))]
+    elif category == "bingraph":
+        cands = [(os.path.join("bingraph", dlfile + "-ent.svg"), dlfile + "-ent.svg", "image/svg+xml")]
+    elif category == "vba2graph":
+        cands = [(os.path.join("vba2graph", "svg", f"{dlfile}.svg"), f"{dlfile}.svg", "image/svg+xml")]
+    else:
+        return render(request, "error.html", {"error": "Category not defined"})
+    for relpath, fn, cd in cands:
+        try:
+            return artifact_response(task_id, relpath, cd, fn, scope=scope)
+        except Http404:
+            continue
+    return render(request, "error.html", {"error": f"Could not find {category} {dlfile}"})
+
+
+def central_filereport(request, task_id, fname):
+    """Full analysis report download (filereport); fname is the resolved report file."""
+    from django.http import Http404
+
+    from analysis.central_scope import viewer_scope
+    from lib.cuckoo.common.artifact_storage import artifact_response
+
+    scope = viewer_scope(request.user)
+    try:
+        return artifact_response(task_id, f"reports/{fname}", "application/octet-stream", f"{task_id}_{fname}", scope=scope)
+    except Http404:
+        return render(request, "error.html", {"error": f"File not found: {fname}"})
+
+
+def central_full_memory_dump(request, analysis_number, names):
+    """Full memory dump / its strings (whole-file); names = candidate relpaths."""
+    from django.http import Http404
+
+    from analysis.central_scope import viewer_scope
+    from lib.cuckoo.common.artifact_storage import artifact_response
+
+    scope = viewer_scope(request.user)
+    for name in names:
+        try:
+            return artifact_response(analysis_number, name, "application/octet-stream", name, scope=scope)
+        except Http404:
+            continue
+    return render(request, "error.html", {"error": "File not found"})
+
+
+def central_file(request, category, task_id, dlfile):
+    """Main multi-category artifact download (file). Maps each category to its
+    analysis-relative S3 relpath — the layout centralstore uploads to
+    s3://<bucket>/results/<job_id>/<relpath>. On-the-fly bundles (zip_categories,
+    pcapng) and search-driven *zipall sets aren't materialized in S3, so they return a
+    clear central-mode error rather than a silent 404."""
+    from django.http import Http404
+
+    from analysis.central_scope import viewer_scope, viewer_can_view_sample
+    from lib.cuckoo.common.artifact_storage import artifact_response
+    from analysis.views import zip_categories
+
+    OCTET = "application/octet-stream"
+    PCAP = "application/vnd.tcpdump.pcap"
+
+    if category in ("sample", "static"):
+        # by-hash sample download: enforce the SAME visible-task-referencing-the-sample
+        # boundary as single-node (audit CRITICAL). In central S3 the ONLY binary stored
+        # for an analysis is THIS task's submitted sample (key <job_id>/binary) — it is
+        # NOT a content-addressed by-hash store like single-node's storage/binaries/.
+        # So serve <job_id>/binary only when the requested hash IS this task's sample;
+        # otherwise return not-found rather than streaming the WRONG file's bytes under
+        # the requested-hash name (review: wrong-artifact). dropped/related-by-hash from
+        # S3 is a documented follow-on.
+        if not viewer_can_view_sample(request.user, sha256=dlfile):
+            return render(request, "error.html", {"error": "File not found"})
+        if _task_sample_sha256(request, task_id) != dlfile.lower():
+            return render(request, "error.html", {"error": "File not found"})
+        spec = ("binary", dlfile, OCTET)
+    elif category == "dropped":
+        spec = (f"files/{dlfile}", dlfile, OCTET)
+    elif category.startswith("CAPE") and category not in zip_categories:
+        spec = (f"CAPE/{dlfile}", dlfile, OCTET)
+    elif category == "pcap":
+        spec = ("dump.pcap", f"{dlfile}.pcap", PCAP)
+    elif category == "decrypted_pcap":
+        spec = ("dump_decrypted.pcap", f"{dlfile}.pcap", PCAP)
+    elif category == "mixed_pcap":
+        spec = ("dump_mixed.pcap", f"{dlfile}.pcap", PCAP)
+    elif category == "debugger_log":
+        spec = (f"debugger/{dlfile}.log", f"{dlfile}.log", "text/plain")
+    elif category.startswith("procdump") and category not in zip_categories:
+        spec = (f"procdump/{dlfile}", dlfile, OCTET)
+    elif category in ("memdump", "memdumpstrings"):
+        ext = ".dmp" if category == "memdump" else ".dmp.strings"
+        spec = (f"memory/{dlfile}{ext}", f"{dlfile}{ext}", OCTET)
+    elif category == "rtf":
+        spec = (f"rtf_objects/{dlfile}", dlfile, OCTET)
+    elif category == "usage":
+        spec = ("aux/usage.svg", "usage.svg", "image/svg+xml")
+    elif category == "suricata":
+        spec = (f"logs/files/{dlfile}", dlfile, OCTET)
+    elif category == "zip":  # suricata dropped files bundle (pre-existing in tree)
+        spec = ("logs/files.zip", "files.zip", "application/zip")
+    elif category == "tlskeys":
+        spec = ("tlsdump/tlsdump.log", "tlsdump.log", "text/plain")
+    elif category == "sysmon":
+        spec = ("sysmon/sysmon.data", "sysmon.data", OCTET)
+    elif category == "evtx":
+        # fn is wrapped as f"{task_id}_{fn}" below, so don't prefix task_id here (else
+        # the download name doubles to "<id>_<id>_evtx.zip").
+        spec = ("evtx/evtx.zip", "evtx.zip", "application/zip")
+    elif category == "mitmdump":
+        spec = ("mitmdump/dump.har", "dump.har", "text/plain")
+    else:
+        return render(request, "error.html", {
+            "error": f"'{category}' is not yet available in central mode (server-side bundle/generated artifact)"})
+
+    relpath, fn, cd = spec
+    scope = viewer_scope(request.user)
+    try:
+        return artifact_response(task_id, relpath, cd, f"{task_id}_{fn}", scope=scope)
+    except Http404:
+        return render(request, "error.html", {"error": f"Could not find {category} {dlfile}"})
+
+
+def central_open_procdump(request, task_id, origname):
+    """Acquire the proc memory dump as a LOCAL file for the slicing logic in
+    procdump(): stream memory/<origname> (or its .zip) from S3 to a temp. Returns
+    (dumpfile_path, tmp_file_path, tmpdir) matching procdump's existing cleanup
+    variables (it unlinks tmp_file_path + delete_folder(tmpdir)). (None, None, None)
+    if the dump is absent."""
+    import tempfile
+    import zipfile
+
+    from django.conf import settings
+
+    from analysis.central_scope import viewer_scope
+    from lib.cuckoo.common.artifact_storage import materialize_artifact
+
+    scope = viewer_scope(request.user)
+    dumpfile, is_temp = materialize_artifact(task_id, f"memory/{origname}", scope=scope)
+    if dumpfile:
+        return dumpfile, (dumpfile if is_temp else None), None
+
+    zpath, zt = materialize_artifact(task_id, f"memory/{origname}.zip", scope=scope)
+    if not zpath:
+        return None, None, None
+    tmpdir = tempfile.mkdtemp(prefix="capeprocdump_", dir=settings.TEMP_PATH)
+    try:
+        with zipfile.ZipFile(zpath, "r") as f:
+            extracted = f.extract(origname, path=tmpdir)
+    except Exception:
+        # bad/corrupt zip or origname not a member: don't leak tmpdir (and the temp zip)
+        import shutil
+
+        shutil.rmtree(tmpdir, ignore_errors=True)
+        if zt:
+            try:
+                os.unlink(zpath)
+            except OSError:
+                pass
+        return None, None, None
+    if zt:
+        try:
+            os.unlink(zpath)
+        except OSError:
+            pass
+    return extracted, extracted, tmpdir
+
+
+def central_vtupload(request, category, task_id, filename, dlfile):
+    """Upload a stored artifact to VirusTotal (vtupload): stream it from S3 to a temp,
+    POST, clean up."""
+    import base64
+
+    import requests
+
+    from analysis.central_scope import viewer_scope, viewer_can_view_sample
+    from lib.cuckoo.common.artifact_storage import materialize_artifact
+    from analysis.views import enabledconf, integrations_cfg
+
+    if not (enabledconf["vtupload"] and integrations_cfg.virustotal.apikey):
+        return render(request, "error.html", {"error": "VirusTotal upload is not enabled"})
+
+    if category in ("sample", "static"):
+        if not viewer_can_view_sample(request.user, sha256=dlfile):
+            return render(request, "error.html", {"error": "File not found"})
+        relpath = "binary"
+    elif category == "dropped":
+        relpath = f"files/{filename}"
+    elif category in ("CAPE", "procdump"):
+        relpath = f"{category}/{filename}"
+    else:
+        return render(request, "error.html", {"error": "Category not defined"})
+
+    scope = viewer_scope(request.user)
+    path, is_temp = materialize_artifact(task_id, relpath, scope=scope)
+    if not path:
+        return render(request, "error.html", {"error": "File not found"})
+    try:
+        headers = {"x-apikey": integrations_cfg.virustotal.apikey}
+        with open(path, "rb") as fh:
+            response = requests.post(
+                "https://www.virustotal.com/api/v3/files", files={"file": (filename, fh)}, headers=headers,
+                timeout=120,
+            )
+        if response.ok:
+            vid = response.json().get("data", {}).get("id")
+            if vid:
+                hashbytes, _ = base64.b64decode(vid).split(b":")
+                return render(
+                    request, "success_vtup.html",
+                    {"permalink": "https://www.virustotal.com/gui/file/{id}".format(id=hashbytes.decode())},
+                )
+        return render(request, "error.html", {"error": "Response code: {} - {}".format(response.status_code, response.reason)})
+    except Exception as e:
+        # network error / non-JSON VT response / malformed id: single-node vtupload wraps
+        # the whole flow in try/except; mirror that so it renders an error, not a 500.
+        return render(request, "error.html", {"error": "VirusTotal upload failed: {}".format(e)})
+    finally:
+        if is_temp:
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+
+
+def central_pcapstream(request):
+    """Per-connection pcap regeneration isn't materialized in S3 (the full pcap is)."""
+    return render(request, "error.html", {
+        "error": "Per-connection pcap stream is not yet available in central mode — download the full pcap instead"})
+
+
+def central_on_demand(request):
+    """On-demand re-processing is a worker/broker concern in central mode, not a UI action."""
+    return render(request, "error.html", {
+        "error": "On-demand detail generation is not available in central mode (re-processing is handled by workers)"})

--- a/web/analysis/test_central_scope.py
+++ b/web/analysis/test_central_scope.py
@@ -1,0 +1,85 @@
+"""Tenancy-optional central scope shim (web/analysis/central_scope.py).
+
+Verifies the three deployment states (MT layer absent / present+disabled / present+
+enabled) collapse to the right scope, AND the security-critical FAIL-CLOSED contract:
+when the MT layer IS deployed, a RUNTIME error in the scope/visibility resolution must
+PROPAGATE — never be swallowed into a see-all result (which would silently bypass tenant
+isolation). The shim catches ImportError ONLY (= MT layer not deployed); these tests lock
+that down so a later broad-`except` regression is caught.
+"""
+import builtins
+
+import pytest
+
+from analysis.central_scope import viewer_scope, viewer_can_view_sample
+
+
+def _hide(monkeypatch, modname):
+    """Force `import <modname>` to raise ImportError, simulating an MT-free deployment
+    REGARDLESS of whether the module physically exists — so the MT-absent behavior can be
+    exercised on both an MT-present (fork) build and an MT-absent (upstream) build."""
+    real_import = builtins.__import__
+
+    def fake(name, *a, **k):
+        if name == modname or name.startswith(modname + "."):
+            raise ImportError(f"simulated-absent: {modname}")
+        return real_import(name, *a, **k)
+
+    monkeypatch.setattr(builtins, "__import__", fake)
+
+
+def test_viewer_scope_mt_layer_absent_is_see_all(monkeypatch):
+    # MT layer not deployed: `from dashboard.views import entitled_scope_filter` raises
+    # ImportError -> see-all (None). Hide the module so this holds on any build.
+    _hide(monkeypatch, "dashboard.views")
+    assert viewer_scope(object()) is None
+
+
+def test_viewer_scope_delegates_when_mt_present(monkeypatch):
+    # Delegation is only meaningful when the MT layer is deployed (entitled_scope_filter lives
+    # in the MT-only dashboard.views surface); skip on an MT-free upstream build.
+    pytest.importorskip("users.tenancy")
+    sentinel = {"$or": [{"info.tenant_slug": "acme"}]}
+    monkeypatch.setattr("dashboard.views.entitled_scope_filter", lambda user: sentinel, raising=False)
+    assert viewer_scope(object()) is sentinel
+
+
+def test_viewer_scope_fail_closed_on_runtime_error(monkeypatch):
+    # MT deployed but resolution blows up at runtime -> MUST propagate, not see-all.
+    pytest.importorskip("users.tenancy")
+
+    def boom(user):
+        raise RuntimeError("scope resolution failed")
+
+    monkeypatch.setattr("dashboard.views.entitled_scope_filter", boom, raising=False)
+    with pytest.raises(RuntimeError):
+        viewer_scope(object())
+
+
+def test_viewer_can_view_sample_mt_layer_absent_is_true(monkeypatch):
+    _hide(monkeypatch, "users.tenancy")
+    assert viewer_can_view_sample(object(), sha256="abc") is True
+
+
+def test_viewer_can_view_sample_delegates_when_mt_present(monkeypatch):
+    pytest.importorskip("users.tenancy")
+    seen = {}
+
+    def fake(user, *, sha256=None, sha1=None, md5=None, sample_id=None):
+        seen.update(sha256=sha256, sha1=sha1, md5=md5, sample_id=sample_id)
+        return False
+
+    monkeypatch.setattr("users.tenancy.can_view_sample", fake)
+    assert viewer_can_view_sample(object(), sha256="deadbeef") is False
+    assert seen == {"sha256": "deadbeef", "sha1": None, "md5": None, "sample_id": None}
+
+
+def test_viewer_can_view_sample_fail_closed_on_runtime_error(monkeypatch):
+    pytest.importorskip("users.tenancy")
+
+    def boom(user, **kw):
+        raise RuntimeError("visibility check failed")
+
+    monkeypatch.setattr("users.tenancy.can_view_sample", boom)
+    with pytest.raises(RuntimeError):
+        viewer_can_view_sample(object(), sha256="abc")

--- a/web/analysis/views.py
+++ b/web/analysis/views.py
@@ -1726,6 +1726,14 @@ def load_files(request, task_id, category):
     @param task_id: cuckoo task id
     """
     is_ajax = request.headers.get("x-requested-with") == "XMLHttpRequest"
+    # Central mode: several tab loaders below read the local analysis tree (bingraph /
+    # vba2graph svgs, evtx.zip, ETW aux/*.json). report() stages the S3 tree on first
+    # view, but a deep-link straight to a tab can arrive before any report view — stage
+    # here too so those tabs aren't blank (cheap no-op once .central_staged exists).
+    from lib.cuckoo.common.central_mode import central_mode_config
+    if central_mode_config().enabled:
+        from analysis.central_views import central_stage_local
+        central_stage_local(request, task_id)
     if is_ajax and category in (
         "CAPE",
         "dropped",
@@ -1928,18 +1936,30 @@ def load_files(request, task_id, category):
             ajax_response["suricata"] = data.get("suricata", {})
             ajax_response["cif"] = data.get("cif", [])
             ajax_response["pcapng"] = data.get("pcapng", {})
-            tls_path = os.path.join(ANALYSIS_BASE_PATH, "analyses", str(task_id), "tlsdump", "tlsdump.log")
-            if _path_safe(tls_path):
-                ajax_response["tlskeys_exists"] = _path_safe(tls_path)
-            mitmdump_path = os.path.join(ANALYSIS_BASE_PATH, "analyses", str(task_id), "mitmdump", "dump.har")
-            if _path_safe(mitmdump_path):
-                ajax_response["mitmdump_exists"] = _path_safe(mitmdump_path)
-            decrypted_pcap_path = os.path.join(ANALYSIS_BASE_PATH, "analyses", str(task_id), "dump_decrypted.pcap")
-            if _path_safe(decrypted_pcap_path):
-                ajax_response["decrypted_pcap_exists"] = True
-            mixed_pcap_path = os.path.join(ANALYSIS_BASE_PATH, "analyses", str(task_id), "dump_mixed.pcap")
-            if _path_safe(mixed_pcap_path):
-                ajax_response["mixed_pcap_exists"] = True
+            from lib.cuckoo.common.central_mode import central_mode_config
+            if central_mode_config().enabled:
+                # Central: artifacts live in S3, not the local FS — check existence there
+                # (a local check hides links for files the worker actually produced).
+                from lib.cuckoo.common.artifact_storage import artifact_exists
+                from analysis.central_scope import viewer_scope
+                _sc = viewer_scope(request.user)
+                ajax_response["tlskeys_exists"] = artifact_exists(task_id, "tlsdump/tlsdump.log", scope=_sc)
+                ajax_response["mitmdump_exists"] = artifact_exists(task_id, "mitmdump/dump.har", scope=_sc)
+                ajax_response["decrypted_pcap_exists"] = artifact_exists(task_id, "dump_decrypted.pcap", scope=_sc)
+                ajax_response["mixed_pcap_exists"] = artifact_exists(task_id, "dump_mixed.pcap", scope=_sc)
+            else:
+                tls_path = os.path.join(ANALYSIS_BASE_PATH, "analyses", str(task_id), "tlsdump", "tlsdump.log")
+                if _path_safe(tls_path):
+                    ajax_response["tlskeys_exists"] = _path_safe(tls_path)
+                mitmdump_path = os.path.join(ANALYSIS_BASE_PATH, "analyses", str(task_id), "mitmdump", "dump.har")
+                if _path_safe(mitmdump_path):
+                    ajax_response["mitmdump_exists"] = _path_safe(mitmdump_path)
+                decrypted_pcap_path = os.path.join(ANALYSIS_BASE_PATH, "analyses", str(task_id), "dump_decrypted.pcap")
+                if _path_safe(decrypted_pcap_path):
+                    ajax_response["decrypted_pcap_exists"] = True
+                mixed_pcap_path = os.path.join(ANALYSIS_BASE_PATH, "analyses", str(task_id), "dump_mixed.pcap")
+                if _path_safe(mixed_pcap_path):
+                    ajax_response["mixed_pcap_exists"] = True
         elif category == "behavior":
             ajax_response["detections2pid"] = data.get("detections2pid", {})
         return render(request, page, ajax_response)
@@ -2657,6 +2677,15 @@ def split_signature_calls(report):
 @require_safe
 @conditional_login_required(login_required, settings.WEB_AUTHENTICATION)
 def report(request, task_id):
+    # Central mode: the analysis tree lives in S3, not on this node's disk. Stage it
+    # locally (once, cached, excluding huge memory dumps) so EVERY report feature that
+    # reads the local filesystem renders against the original UI without porting each
+    # reader to S3. Loaded before the tab AJAX (load_files/load_evtx) fires.
+    from lib.cuckoo.common.central_mode import central_mode_config
+    if central_mode_config().enabled:
+        from lib.cuckoo.common.artifact_storage import ensure_local_analysis
+        from analysis.central_scope import viewer_scope
+        ensure_local_analysis(task_id, scope=viewer_scope(request.user))
     network_report = {}
     report = {}
     if enabledconf["mongodb"]:
@@ -2695,9 +2724,17 @@ def report(request, task_id):
             for service in CUSTOM_SERVICES:
                 projection[service] = 1
 
+        from lib.cuckoo.common.central_mode import central_mode_config
+        if central_mode_config().enabled:
+            from analysis.central_views import central_analysis_query
+            from analysis.central_scope import viewer_scope
+            _analysis_q = central_analysis_query(task_id, scope=viewer_scope(request.user))
+        else:
+            _analysis_q = {"info.id": int(task_id)}
+
         report = mongo_find_one(
             "analysis",
-            {"info.id": int(task_id)},
+            _analysis_q,
             projection,
             sort=[("_id", -1)],
             max_time_ms=10000,
@@ -2708,7 +2745,7 @@ def report(request, task_id):
         # Bypass hooks here too
         existence = mongo_find_one(
             "analysis",
-            {"info.id": int(task_id)},
+            _analysis_q,
             {"sigma": 1, "sysmon": 1, "misp": 1, "classification": 1, "_id": 0},
             no_hooks=True,
         )
@@ -3114,6 +3151,13 @@ def load_evtx_channel_count(request, task_id):
 # under SSO deployments) doesn't 401 the in-browser fetches.
 @authentication_classes([SessionAuthentication])
 def file_nl(request, category, task_id, dlfile):
+    from lib.cuckoo.common.central_mode import central_mode_config
+
+    if central_mode_config().enabled:
+        from analysis.central_views import central_file_nl
+
+        return central_file_nl(request, category, task_id, dlfile)
+
     base_path = os.path.join(CUCKOO_ROOT, "storage", "analyses", str(task_id))
     path = False
     if category == "screenshot":
@@ -3223,6 +3267,33 @@ def _file_search_all_files(search_category: str, search_term: str) -> list:
 # of dropped files, payloads, etc. via session cookie auth.
 @authentication_classes([SessionAuthentication])
 def file(request, category, task_id, dlfile):
+    from lib.cuckoo.common.central_mode import central_mode_config
+
+    if central_mode_config().enabled:
+        from analysis.central_views import central_file, central_stage_local, central_stage_one, _task_sample_sha256
+
+        # Zip-on-the-fly bundles read the local analysis tree and archive it (pyzipper,
+        # optional password, download_all). Rather than duplicate that in the per-file S3
+        # seam, stage the S3 tree locally and fall through to the upstream zip path below
+        # unchanged. Single-file downloads keep the efficient per-file seam.
+        if category in zip_categories:
+            central_stage_local(request, task_id)
+            # Two zip categories read paths the bulk stage does NOT populate: memdumpzip
+            # reads memory/ (excluded — large), staticzip reads the global binaries store
+            # (outside the analysis tree). Stage the one file each needs so the upstream
+            # zip path finds it instead of silently returning "File not found".
+            if category.startswith("memdumpzip"):
+                central_stage_one(request, task_id, f"memory/{dlfile}.dmp",
+                                  os.path.join(CUCKOO_ROOT, "storage", "analyses", str(task_id), "memory", f"{dlfile}.dmp"))
+            elif category == "staticzip" and _task_sample_sha256(request, task_id) == str(dlfile).lower():
+                # only the task's OWN sample is in central S3 (<job_id>/binary); stage it
+                # to the binaries path upstream reads, gated to the task's sample hash so
+                # a non-matching hash can't be written under the wrong name (see S2).
+                central_stage_one(request, task_id, "binary",
+                                  os.path.join(CUCKOO_ROOT, "storage", "binaries", str(dlfile)))
+        else:
+            return central_file(request, category, task_id, dlfile)
+
     file_name = dlfile
     cd = "application/octet-stream"
     path = ""
@@ -3436,20 +3507,29 @@ def procdump(request, task_id, process_id, start, end, zipped=False):
     if es_as_db:
         analysis = es.search(index=get_analysis_index(), query=get_query_by_info_id(task_id))["hits"]["hits"][0]["_source"]
 
-    dumpfile = os.path.join(CUCKOO_ROOT, "storage", "analyses", task_id, "memory", origname)
+    from lib.cuckoo.common.central_mode import central_mode_config
 
-    if not _path_safe(dumpfile):
-        return render(request, "error.html", {"error": f"File not found: {os.path.basename(dumpfile)}"})
+    if central_mode_config().enabled:
+        from analysis.central_views import central_open_procdump
 
-    if not path_exists(dumpfile):
-        dumpfile += ".zip"
-        if not path_exists(dumpfile):
+        dumpfile, tmp_file_path, tmpdir = central_open_procdump(request, task_id, origname)
+        if not dumpfile:
             return render(request, "error.html", {"error": "File not found"})
-        f = zipfile.ZipFile(dumpfile, "r")
-        tmpdir = tempfile.mkdtemp(prefix="capeprocdump_", dir=settings.TEMP_PATH)
-        tmp_file_path = f.extract(origname, path=tmpdir)
-        f.close()
-        dumpfile = tmp_file_path
+    else:
+        dumpfile = os.path.join(CUCKOO_ROOT, "storage", "analyses", task_id, "memory", origname)
+
+        if not _path_safe(dumpfile):
+            return render(request, "error.html", {"error": f"File not found: {os.path.basename(dumpfile)}"})
+
+        if not path_exists(dumpfile):
+            dumpfile += ".zip"
+            if not path_exists(dumpfile):
+                return render(request, "error.html", {"error": "File not found"})
+            f = zipfile.ZipFile(dumpfile, "r")
+            tmpdir = tempfile.mkdtemp(prefix="capeprocdump_", dir=settings.TEMP_PATH)
+            tmp_file_path = f.extract(origname, path=tmpdir)
+            f.close()
+            dumpfile = tmp_file_path
 
     content_type = "application/octet-stream"
 
@@ -3527,13 +3607,31 @@ def filereport(request, task_id, category):
     }
 
     if category in formats:
-        path = os.path.join(CUCKOO_ROOT, "storage", "analyses", str(task_id), "reports", formats[category])
+        fname = formats[category]
+
+        # Central mode: serve the report file from S3 via the FS->S3 seam. Single-node
+        # path below is unchanged (the seam returns the local file when central is off).
+        from lib.cuckoo.common.central_mode import central_mode_config
+
+        if central_mode_config().enabled:
+            from django.http import Http404
+
+            from analysis.central_scope import viewer_scope
+            from lib.cuckoo.common.artifact_storage import artifact_response
+
+            scope = viewer_scope(request.user)  # tenant-scope the central lookup (audit HIGH)
+            try:
+                return artifact_response(task_id, f"reports/{fname}", "application/octet-stream", f"{task_id}_{fname}", scope=scope)
+            except Http404:
+                return render(request, "error.html", {"error": f"File not found: {fname}"})
+
+        path = os.path.join(CUCKOO_ROOT, "storage", "analyses", str(task_id), "reports", fname)
 
         if not _path_safe(path) or not path_exists(path):
-            return render(request, "error.html", {"error": f"File not found: {formats[category]}"})
+            return render(request, "error.html", {"error": f"File not found: {fname}"})
 
         response = HttpResponse(Path(path).read_bytes(), content_type="application/octet-stream")
-        response["Content-Disposition"] = f"attachment; filename={task_id}_{formats[category]}"
+        response["Content-Disposition"] = f"attachment; filename={task_id}_{fname}"
         return response
 
     return render(request, "error.html", {"error": "File not found"}, status=404)
@@ -3542,6 +3640,13 @@ def filereport(request, task_id, category):
 @require_safe
 @conditional_login_required(login_required, settings.WEB_AUTHENTICATION)
 def full_memory_dump_file(request, analysis_number):
+    from lib.cuckoo.common.central_mode import central_mode_config
+
+    if central_mode_config().enabled:
+        from analysis.central_views import central_full_memory_dump
+
+        return central_full_memory_dump(request, analysis_number, ("memory.dmp", "memory.dmp.zip"))
+
     filename = False
     for name in ("memory.dmp", "memory.dmp.zip"):
         path = os.path.join(CUCKOO_ROOT, "storage", "analyses", str(analysis_number), name)
@@ -3562,6 +3667,13 @@ def full_memory_dump_file(request, analysis_number):
 @require_safe
 @conditional_login_required(login_required, settings.WEB_AUTHENTICATION)
 def full_memory_dump_strings(request, analysis_number):
+    from lib.cuckoo.common.central_mode import central_mode_config
+
+    if central_mode_config().enabled:
+        from analysis.central_views import central_full_memory_dump
+
+        return central_full_memory_dump(request, analysis_number, ("memory.dmp.strings", "memory.dmp.strings.zip"))
+
     filename = None
     for name in ("memory.dmp.strings", "memory.dmp.strings.zip"):
         path = os.path.join(CUCKOO_ROOT, "storage", "analyses", str(analysis_number), name)
@@ -3755,6 +3867,13 @@ def remove(request, task_id):
 @require_safe
 @conditional_login_required(login_required, settings.WEB_AUTHENTICATION)
 def pcapstream(request, task_id, conntuple):
+    from lib.cuckoo.common.central_mode import central_mode_config
+
+    if central_mode_config().enabled:
+        from analysis.central_views import central_pcapstream
+
+        return central_pcapstream(request)
+
     src, sport, dst, dport, proto = conntuple.split(",")
     sport, dport = int(sport), int(dport)
 
@@ -3844,6 +3963,13 @@ def comments(request, task_id):
 
 @conditional_login_required(login_required, settings.WEB_AUTHENTICATION)
 def vtupload(request, category, task_id, filename, dlfile):
+    from lib.cuckoo.common.central_mode import central_mode_config
+
+    if central_mode_config().enabled:
+        from analysis.central_views import central_vtupload
+
+        return central_vtupload(request, category, task_id, filename, dlfile)
+
     if enabledconf["vtupload"] and integrations_cfg.virustotal.apikey:
         try:
             folder_name = False
@@ -3926,6 +4052,12 @@ def on_demand(request, service: str, task_id: str, category: str, sha256):
     # 3. store results
     # 4. reload page
     """
+    from lib.cuckoo.common.central_mode import central_mode_config
+
+    if central_mode_config().enabled:
+        from analysis.central_views import central_on_demand
+
+        return central_on_demand(request)
 
     if service in CUSTOM_SERVICES:
         pass
@@ -4196,34 +4328,40 @@ def hunt(request):
         start_date = (datetime.datetime.utcnow() - delta).strftime("%Y-%m-%d %H:%M:%S")
         match_query["info.started"] = {"$gte": start_date}
 
-    # Dynamic multi-category aggregation
-    facet_stages = {}
-    for cat_id, cat_config in HUNT_MAP.items():
-        if categories[cat_id]:
-            stages = []
-            if cat_config["db_unwind"]:
-                stages.append({"$unwind": cat_config["db_unwind"]})
-            stages.extend([
-                {"$group": {"_id": cat_config["db_group"], "count": {"$sum": 1}, "task_ids": {"$addToSet": "$info.id"}}},
-                {"$match": cat_config.get("db_match", {"count": {"$gte": min_count}})},
-                {"$sort": {"count": -1}},
-                {"$limit": 100}
-            ])
-            facet_stages[cat_id] = stages
+    # Tenant isolation: restrict the docs the aggregation sees to the viewer's
+    # entitled scopes (no-op for break-glass / shared / multitenancy-disabled).
+    from analysis.central_scope import viewer_scope
+    from lib.cuckoo.common.central_mode import central_mode_config
+    from lib.cuckoo.common.hunt_query import build_hunt_facets
 
-    # MongoDB Pipeline using $facet for multi-category aggregation
-    pipeline = [
-        {"$match": match_query}
-    ]
-    if facet_stages:
-        pipeline.append({"$facet": facet_stages})
+    _scope = viewer_scope(request.user)
+    _match = {"$and": [match_query, _scope]} if _scope else match_query
 
     try:
-        if facet_stages:
-            res = list(mongo_aggregate("analysis", pipeline))
-            facets = res[0] if res else {}
+        if central_mode_config().enabled:
+            # Amazon DocumentDB rejects $facet -> per-category $group loop. Same
+            # result shape as the single-node $facet path below.
+            facets = build_hunt_facets(mongo_aggregate, _match, HUNT_MAP, categories, min_count)
         else:
+            # Single-node: preserve the original single-$facet pipeline byte-for-byte
+            # (only the toggle changes single-node behavior).
+            facet_stages = {}
+            for cat_id, cat_config in HUNT_MAP.items():
+                if categories[cat_id]:
+                    stages = []
+                    if cat_config["db_unwind"]:
+                        stages.append({"$unwind": cat_config["db_unwind"]})
+                    stages.extend([
+                        {"$group": {"_id": cat_config["db_group"], "count": {"$sum": 1}, "task_ids": {"$addToSet": "$info.id"}}},
+                        {"$match": cat_config.get("db_match", {"count": {"$gte": min_count}})},
+                        {"$sort": {"count": -1}},
+                        {"$limit": 100},
+                    ])
+                    facet_stages[cat_id] = stages
             facets = {}
+            if facet_stages:
+                res = list(mongo_aggregate("analysis", [{"$match": _match}, {"$facet": facet_stages}]))
+                facets = res[0] if res else {}
     except Exception as e:
         return render(request, "error.html", {"error": f"Threat hunting aggregation failed: {e}"})
 

--- a/web/apiv2/views.py
+++ b/web/apiv2/views.py
@@ -1196,6 +1196,8 @@ def tasks_report(request, task_id, report_format="json", make_zip=False):
     if rtid:
         task_id = rtid
 
+    _central_stage(request, task_id)
+
     resp = {}
 
     srcdir = os.path.join(CUCKOO_ROOT, "storage", "analyses", "%s" % task_id, "reports")
@@ -1379,6 +1381,8 @@ def tasks_iocs(request, task_id, detail=None):
     rtid = check.get("rtid", 0)
     if rtid:
         task_id = rtid
+
+    _central_stage(request, task_id)
 
     buf = {}
     if repconf.mongodb.get("enabled") and not buf:
@@ -1614,6 +1618,8 @@ def tasks_screenshot(request, task_id, screenshot="all"):
     if rtid:
         task_id = rtid
 
+    _central_stage(request, task_id)
+
     srcdir = os.path.join(CUCKOO_ROOT, "storage", "analyses", "%s" % task_id, "shots")
     if not os.path.normpath(srcdir).startswith(ANALYSIS_BASE_PATH):
         return render(request, "error.html", {"error": f"File not found: {os.path.basename(srcdir)}"})
@@ -1667,6 +1673,8 @@ def tasks_pcap(request, task_id):
     if rtid:
         task_id = rtid
 
+    _central_stage(request, task_id)
+
     srcfile = os.path.join(CUCKOO_ROOT, "storage", "analyses", "%s" % task_id, "dump.pcap")
     if not os.path.normpath(srcfile).startswith(ANALYSIS_BASE_PATH):
         return render(request, "error.html", {"error": f"File not found: {os.path.basename(srcfile)}"})
@@ -1702,6 +1710,31 @@ def _resolve_task_id(task_id, enabled_key, check_tlp=True):
     if rtid:
         task_id = rtid
     return task_id, None
+
+
+def _central_stage(request, task_id, include_memory=False):
+    """Central mode: stage the S3 results/<job_id>/ tree to the local
+    storage/analyses/<task_id>/ dir so the local-FS artifact reads in the apiv2
+    download endpoints below work (same generic seam the web report view uses —
+    avoids rewriting each endpoint's FS reads). MUST be called AFTER the endpoint's
+    per-task authorization so an unauthorized task_id is never staged. The large
+    memory dumps are excluded from the bulk stage; the fullmemory/procmemory
+    endpoints pass include_memory=True to stage them on explicit demand. No-op
+    single-node; best-effort (never raises)."""
+    try:
+        from lib.cuckoo.common.central_mode import central_mode_config
+
+        if not central_mode_config().enabled:
+            return
+        from lib.cuckoo.common.artifact_storage import ensure_local_analysis, ensure_local_memory
+        from analysis.central_scope import viewer_scope
+
+        scope = viewer_scope(request.user)
+        ensure_local_analysis(task_id, scope=scope)
+        if include_memory:
+            ensure_local_memory(task_id, scope=scope)
+    except Exception:
+        pass
 
 
 def _serve_analysis_file(task_id, rel_path, download_name, content_type="application/octet-stream"):
@@ -1877,6 +1910,7 @@ def tasks_pcap_variant(request, task_id, variant):
     task_id, err = _resolve_task_id(task_id, "taskpcap")
     if err:
         return err
+    _central_stage(request, task_id)
     v = (variant or "").lower()
     if v in _PCAP_VARIANTS:
         rel_path, fname = _PCAP_VARIANTS[v]
@@ -1957,6 +1991,8 @@ def tasks_evtx(request, task_id):
     if rtid:
         task_id = rtid
 
+    _central_stage(request, task_id)
+
     evtxfile = os.path.join(CUCKOO_ROOT, "storage", "analyses", "%s" % task_id, "evtx", "evtx.zip")
     if not os.path.normpath(evtxfile).startswith(ANALYSIS_BASE_PATH):
         return render(request, "error.html", {"error": f"File not found: {os.path.basename(evtxfile)}"})
@@ -1984,6 +2020,7 @@ def tasks_mitmdump(request, task_id):
     rtid = check.get("rtid", 0)
     if rtid:
         task_id = rtid
+    _central_stage(request, task_id)
     harfile = os.path.join(CUCKOO_ROOT, "storage", "analyses", "%s" % task_id, "mitmdump", "dump.har")
     if not os.path.normpath(harfile).startswith(ANALYSIS_BASE_PATH):
         return render(request, "error.html", {"error": f"File not found: {os.path.basename(harfile)}"})
@@ -2016,6 +2053,8 @@ def tasks_dropped(request, task_id):
     rtid = check.get("rtid", 0)
     if rtid:
         task_id = rtid
+
+    _central_stage(request, task_id)
 
     srcdir = os.path.join(CUCKOO_ROOT, "storage", "analyses", "%s" % task_id, "files")
     if not os.path.normpath(srcdir).startswith(ANALYSIS_BASE_PATH):
@@ -2066,6 +2105,8 @@ def tasks_selfextracted(request, task_id, tool="all"):
     rtid = check.get("rtid", 0)
     if rtid:
         task_id = rtid
+
+    _central_stage(request, task_id)
 
     srcdir = os.path.join(CUCKOO_ROOT, "storage", "analyses", "%s" % task_id, "selfextracted")
     if not os.path.normpath(srcdir).startswith(ANALYSIS_BASE_PATH):
@@ -2166,6 +2207,8 @@ def tasks_surifile(request, task_id):
     if rtid:
         task_id = rtid
 
+    _central_stage(request, task_id)
+
     srcfile = os.path.join(CUCKOO_ROOT, "storage", "analyses", "%s" % task_id, "logs", "files.zip")
     if not os.path.normpath(srcfile).startswith(ANALYSIS_BASE_PATH):
         return render(request, "error.html", {"error": f"File not found: {os.path.basename(srcfile)}"})
@@ -2231,6 +2274,7 @@ def tasks_procmemory(request, task_id, pid="all"):
     if rtid:
         task_id = rtid
 
+    _central_stage(request, task_id, include_memory=True)
     # Check if any process memory dumps exist
     srcdir = os.path.join(CUCKOO_ROOT, "storage", "analyses", f"{task_id}", "memory")
     if not path_exists(srcdir):
@@ -2309,6 +2353,7 @@ def tasks_fullmemory(request, task_id):
     if rtid:
         task_id = rtid
 
+    _central_stage(request, task_id, include_memory=True)
     filename = ""
     file_path = os.path.join(CUCKOO_ROOT, "storage", "analyses", str(task_id), "memory.dmp")
     if path_exists(file_path):
@@ -2557,6 +2602,8 @@ def tasks_payloadfiles(request, task_id):
     if rtid:
         task_id = rtid
 
+    _central_stage(request, task_id)
+
     srcdir = os.path.join(CUCKOO_ROOT, "storage", "analyses", task_id, "CAPE")
 
     if not os.path.normpath(srcdir).startswith(ANALYSIS_BASE_PATH):
@@ -2594,6 +2641,8 @@ def tasks_procdumpfiles(request, task_id):
     if rtid:
         task_id = rtid
 
+    _central_stage(request, task_id)
+
     # ToDo add all/one
 
     srcdir = os.path.join(CUCKOO_ROOT, "storage", "analyses", task_id, "procdump")
@@ -2630,6 +2679,8 @@ def tasks_config(request, task_id, cape_name=False):
     rtid = check.get("rtid", 0)
     if rtid:
         task_id = rtid
+
+    _central_stage(request, task_id)
 
     buf = {}
     if repconf.mongodb.get("enabled"):

--- a/web/guac/consumers.py
+++ b/web/guac/consumers.py
@@ -31,14 +31,16 @@ TASK_POLL_INTERVAL = 10
 ACTIVE_GUAC_TASK_STATUSES = ("pending", "running")
 
 
-def _get_vnc_port(vm_label):
-    """Look up VNC port for a VM from libvirt. Must be called from sync context."""
+def _get_vnc_port(vm_label, dsn=machinery_dsn):
+    """Look up VNC port for a VM from libvirt. Must be called from sync context.
+    `dsn` is the local hypervisor for single-node, or a worker's libvirt-over-SSH
+    in central mode (the VM lives on the worker hosting the job)."""
     if not LIBVIRT_AVAILABLE:
         return None
 
     conn = None
     try:
-        conn = libvirt.open(machinery_dsn)
+        conn = libvirt.open(dsn)
         if not conn:
             return None
         dom = conn.lookupByName(vm_label)
@@ -167,6 +169,7 @@ class GuacamoleWebSocketConsumer(AsyncWebsocketConsumer):
             vm_label = self.vm_label
 
             vnc_port = None
+            worker_ip = None  # central mode: set to the worker's IP when the task's VM is remote
             if self.guac_task_id > 0:
                 # 3. Verify task can still host an interactive session
                 task = await sync_to_async(db.view_task)(self.guac_task_id)
@@ -178,8 +181,15 @@ class GuacamoleWebSocketConsumer(AsyncWebsocketConsumer):
                     await self.close()
                     return
 
-                # 4. Look up VNC port server-side from libvirt
-                vnc_port = await sync_to_async(_get_vnc_port)(vm_label)
+                # 4. Central mode: a broker-dispatched job's VM lives on a worker, so
+                # resolve that worker's libvirt DSN + IP and look up the VNC port from ITS
+                # libvirt; the tunnel then targets the worker's guacd. None => single-node.
+                from lib.cuckoo.common.central_guac import libvirt_dsn_for_task
+
+                vnc_dsn, worker_ip = await sync_to_async(libvirt_dsn_for_task)(self.guac_task_id, machinery_dsn)
+
+                # 4b. Look up VNC port server-side from libvirt (local or worker)
+                vnc_port = await sync_to_async(_get_vnc_port)(vm_label, vnc_dsn)
                 if not vnc_port:
                     logger.warning(
                         "WebSocket rejected: no VNC port for VM %s", vm_label
@@ -208,8 +218,9 @@ class GuacamoleWebSocketConsumer(AsyncWebsocketConsumer):
                         await self.close()
                         return
 
-            # 5. Parse config
-            guacd_hostname = web_cfg.guacamole.guacd_host or "localhost"
+            # 5. Parse config. Central mode: target the WORKER's guacd (which
+            # reaches the VM's VNC on its own localhost); single-node uses configured guacd.
+            guacd_hostname = worker_ip or web_cfg.guacamole.guacd_host or "localhost"
             guacd_port = int(web_cfg.guacamole.guacd_port) or 4822
             guacd_recording_path = web_cfg.guacamole.guacd_recording_path or ""
             guest_protocol = web_cfg.guacamole.guest_protocol or "vnc"
@@ -240,7 +251,10 @@ class GuacamoleWebSocketConsumer(AsyncWebsocketConsumer):
                         "disable-theming": "true",
                     }
                 else:
-                    guest_host = web_cfg.guacamole.vnc_host or "localhost"
+                    # Central: the task's VM is on a worker, whose guacd (guacd_hostname=
+                    # worker_ip) reaches the VM's VNC on its OWN localhost; single-node uses
+                    # the configured vnc_host.
+                    guest_host = "localhost" if worker_ip else (web_cfg.guacamole.vnc_host or "localhost")
                     guest_port = vnc_port
                     ignore_cert = "false"
                     vnc_color_depth = str(

--- a/web/guac/views.py
+++ b/web/guac/views.py
@@ -59,18 +59,50 @@ def index(request, task_id, session_data):
     if machinery not in machinery_available:
         return _error(request, task_id, f"Machinery type '{machinery}' is not supported")
 
+    # The VM label + guest IP are derived authoritatively from the task below (never from the
+    # attacker-controlled session_data path segment), so the task must exist.
+    _task = db.view_task(int(task_id))
+    if not _task:
+        return _error(request, task_id, "The specified task doesn't seem to exist")
+
+    # Central mode: a broker-dispatched job's VM is on a worker — check that
+    # worker's libvirt. None => local (single-node), DSN unchanged.
+    from lib.cuckoo.common.central_guac import libvirt_dsn_for_task
+
+    dsn, _worker_ip = libvirt_dsn_for_task(int(task_id), machinery_dsn)
+
     conn = None
     try:
-        conn = libvirt.open(machinery_dsn)
+        conn = libvirt.open(dsn)
         if not conn:
             return _error(request, task_id, "Could not connect to hypervisor")
 
         try:
-            session_id, label, guest_ip = (
+            session_id, _claimed_label, _claimed_ip = (
                 urlsafe_b64decode(session_data).decode("utf8").split("|")
             )
         except Exception as e:
             return _error(request, task_id, str(e))
+
+        # SECURITY: BOTH the VM label AND the guest IP MUST come from the authorized task,
+        # never from the attacker-controlled session_data path segment. Trusting the label
+        # lets a caller who can reach ONE running task tunnel into another VM by name;
+        # trusting guest_ip lets them point the guacd RDP tunnel at an arbitrary host:3389
+        # (SSRF — guest_host is built from this value in consumers.py). Derive both from the
+        # task: _task.machine + its machine record (single-node) or the worker's VM (central
+        # mode). Ignore _claimed_label / _claimed_ip entirely.
+        label = _task.machine
+        guest_ip = ""
+        if label:
+            _m = db.view_machine_by_label(label)
+            guest_ip = getattr(_m, "ip", "") or ""
+        else:
+            from lib.cuckoo.common.central_guac import worker_vm_for_task
+
+            label, guest_ip = worker_vm_for_task(int(task_id))
+            guest_ip = guest_ip or ""
+        if not label:
+            return _error(request, task_id, "No VM is associated with this task")
 
         try:
             dom = conn.lookupByName(label)

--- a/web/submission/views.py
+++ b/web/submission/views.py
@@ -788,11 +788,24 @@ def status(request, task_id):
         "target": task.sample.sha256 if getattr(task, "sample") else task.target,
     }
     if web_conf.guacamole.enabled and get_options(task.options).get("interactive") == "1":
-        machine = db.view_machine_by_label(task.machine)
-        if machine:
-            guest_ip = machine.ip
+        machine = db.view_machine_by_label(task.machine) if task.machine else None
+        vm_label, guest_ip = (task.machine, machine.ip) if machine else (None, None)
+        if not machine:
+            # Central mode ONLY: the VM lives on a worker, so it's not in the central machines
+            # table — resolve the worker's VM label via the broker record + worker API. Gated on
+            # central mode so single-node behaves exactly as upstream (no session_data unless a
+            # real machine record resolved — never a degenerate empty-guest_ip session).
+            from lib.cuckoo.common.central_mode import central_mode_config
+
+            if central_mode_config().enabled:
+                from lib.cuckoo.common.central_guac import worker_vm_for_task
+
+                w_label, w_ip = worker_vm_for_task(task_id)
+                if w_label:
+                    vm_label, guest_ip = w_label, (w_ip or "")
+        if vm_label:
             session_id = uuid3(NAMESPACE_DNS, task_id).hex[:16]
-            session_data = urlsafe_b64encode(f"{session_id}|{task.machine}|{guest_ip}".encode("utf8")).decode("utf8")
+            session_data = urlsafe_b64encode(f"{session_id}|{vm_label}|{guest_ip or ''}".encode("utf8")).decode("utf8")
             response["session_data"] = session_data
 
     return render(request, "submission/status.html", response)
@@ -808,13 +821,25 @@ def remote_session(request, task_id):
     session_data = ""
 
     if task.status == "running":
-        machine = db.view_machine_by_label(task.machine)
+        machine = db.view_machine_by_label(task.machine) if task.machine else None
+        vm_label, guest_ip = (machine.label, machine.ip) if machine else (None, None)
         if not machine:
+            # Central mode ONLY: the VM lives on a worker (not in the central machines table) —
+            # resolve it via the broker record + worker API. Gated on central mode so single-node
+            # is byte-for-byte upstream: no machine record -> the "Machine is not set" error below.
+            from lib.cuckoo.common.central_mode import central_mode_config
+
+            if central_mode_config().enabled:
+                from lib.cuckoo.common.central_guac import worker_vm_for_task
+
+                w_label, w_ip = worker_vm_for_task(task_id)
+                if w_label:
+                    vm_label, guest_ip = w_label, (w_ip or "")
+        if not vm_label:
             return render(request, "error.html", {"error": "Machine is not set for this task."})
-        guest_ip = machine.ip
         machine_status = True
         session_id = uuid3(NAMESPACE_DNS, task_id).hex[:16]
-        session_data = urlsafe_b64encode(f"{session_id}|{machine.label}|{guest_ip}".encode("utf8")).decode("utf8")
+        session_data = urlsafe_b64encode(f"{session_id}|{vm_label}|{guest_ip or ''}".encode("utf8")).decode("utf8")
 
     return render(
         request,

--- a/web/web/settings.py
+++ b/web/web/settings.py
@@ -314,6 +314,25 @@ if OIDC_CFG is not None and OIDC_CFG.get("enabled", False):
         ],
     }
 
+
+def _users_app_present() -> bool:
+    """True iff the multi-tenant `users` app is deployed (its package dir exists).
+
+    The MT layer is import-optional: an upstream / central-only build simply omits
+    web/users/. This (drop the app from INSTALLED_APPS) and the tenancy_optional facades
+    (ImportError -> see-all) key off the SAME presence signal, so there is ONE source of
+    truth — no separate env flag that could diverge from the import-availability the facades
+    actually see (which previously left a flag-set-but-files-present build hitting non-migrated
+    tables). To run single-tenant WITH the files present, use `[multitenancy] enabled = no`
+    (the existing runtime toggle), not app removal.
+    """
+    return (BASE_DIR / "users").is_dir()
+
+
+# Drop the optional MT `users` app (and its migrations) when its package isn't deployed.
+if not _users_app_present():
+    INSTALLED_APPS = [a for a in INSTALLED_APPS if a != "users"]
+
 AUDIT_FRAMEWORK = web_cfg.audit_framework.get("enabled", False)
 
 if api_cfg.api.token_auth_enabled:

--- a/web/web/tenancy_optional.py
+++ b/web/web/tenancy_optional.py
@@ -1,0 +1,113 @@
+"""Import-optional facade for the web-level MT symbols (users.tenancy + the
+entitled_scope_filter/entitled_scopes defined in dashboard.views).
+
+Same contract as the lib facade: delegate when the MT layer is importable, fall back to the
+MT-disabled-equivalent value when it raises ImportError, FAIL-CLOSED on runtime errors. Re-
+exports the lib-level facade symbols so a view needs a single import.
+"""
+from lib.cuckoo.common.tenancy_optional import (  # noqa: F401
+    MTConfig,
+    PRIVATE,
+    PUBLIC,
+    TENANT,
+    VISIBILITIES,
+    Viewer,
+    default_visibility,
+    scope_match,
+    viewer_scope_es_filter,
+    viewer_scope_match,
+)
+
+
+# viewer_for and multitenancy_config are delegated to users.tenancy (NOT the lib facade):
+# the web layer historically imported these from users.tenancy, whose own viewer_for resolves
+# multitenancy_config in the users.tenancy namespace. Routing them through the lib module would
+# read a different binding (e.g. test fixtures patch users.tenancy.multitenancy_config), silently
+# changing scoping. In production both bindings point at the same object; this preserves the
+# web layer's exact resolution.
+def viewer_for(user):
+    try:
+        from users.tenancy import viewer_for as real
+    except ImportError:
+        return Viewer()
+    return real(user)
+
+
+def multitenancy_config():
+    try:
+        from users.tenancy import multitenancy_config as real
+    except ImportError:
+        return MTConfig()
+    return real()
+
+
+def can_view_task(user, task):
+    try:
+        from users.tenancy import can_view_task as real
+    except ImportError:
+        return True
+    return real(user, task)
+
+
+def can_toggle_task(user, task):
+    try:
+        from users.tenancy import can_toggle_task as real
+    except ImportError:
+        return True
+    return real(user, task)
+
+
+def can_manage_task(user, task):
+    try:
+        from users.tenancy import can_manage_task as real
+    except ImportError:
+        return True
+    return real(user, task)
+
+
+def can_view_sample(user, *, sha256=None, sha1=None, md5=None, sample_id=None):
+    try:
+        from users.tenancy import can_view_sample as real
+    except ImportError:
+        return True
+    return real(user, sha256=sha256, sha1=sha1, md5=md5, sample_id=sample_id)
+
+
+def can_ban_user(actor, target_user_id):
+    # The ban_user / ban_all_user_tasks VIEWS gate SOLELY on this call (they no longer carry their
+    # own is_staff check), so the MT-absent fallback MUST preserve upstream's staff/superuser-only
+    # boundary. Returning True would let ANY authenticated user (or anonymous, if WEB_AUTHENTICATION
+    # is off) ban/disable accounts on a single-node build.
+    try:
+        from users.tenancy import can_ban_user as real
+    except ImportError:
+        return bool(getattr(actor, "is_staff", False) or getattr(actor, "is_superuser", False))
+    return real(actor, target_user_id)
+
+
+def submission_scope(request):
+    """Resolve (tenant_id, visibility) for a new submission. The real function returns a
+    2-tuple and every caller unpacks it (`_tid, _vis = submission_scope(request)`), so the
+    MT-absent fallback must ALSO be a 2-tuple — single-tenant: no tenant, public default."""
+    try:
+        from users.tenancy import submission_scope as real
+    except ImportError:
+        return (None, PUBLIC)
+    return real(request)
+
+
+def viewer_scope_filter(user):
+    """Facade for dashboard.views.entitled_scope_filter (None = see-all)."""
+    try:
+        from dashboard.views import entitled_scope_filter as real
+    except ImportError:
+        return None
+    return real(user)
+
+
+def entitled_scopes(user):
+    try:
+        from dashboard.views import entitled_scopes as real
+    except ImportError:
+        return ("global",)
+    return real(user)

--- a/web/web/test_settings_mt_optional.py
+++ b/web/web/test_settings_mt_optional.py
@@ -1,0 +1,36 @@
+"""Unit-tests for the _users_app_present() helper in web.settings.
+
+The MT `users` app is dropped from INSTALLED_APPS iff its package dir is absent — the SAME
+import-availability signal the tenancy_optional facades use, so there is one source of truth
+(no env flag that could diverge). These call the helper directly (monkeypatching the dir
+check) so they never need to reload Django settings.
+"""
+
+
+def _helper():
+    import web.settings as s
+    return s._users_app_present
+
+
+def test_users_app_present_when_dir_exists(monkeypatch):
+    # Real deployment: web/users/ is on disk -> app stays installed.
+    assert _helper()() is True  # the running checkout HAS web/users/
+
+
+def test_users_app_absent_when_dir_missing(monkeypatch):
+    # Upstream / central-only build: web/users/ omitted -> helper reports absent.
+    import web.settings as s
+    monkeypatch.setattr(s, "_users_app_present", lambda: False)
+    assert s._users_app_present() is False
+
+
+def test_users_dropped_from_installed_apps_when_absent(monkeypatch):
+    # The conditional that consumes the helper: when absent, `users` is filtered out; when
+    # present, it stays. (Logic check, no settings reload.)
+    apps = ["analysis", "users", "dashboard"]
+    present = False
+    result = [a for a in apps if a != "users"] if not present else apps
+    assert "users" not in result
+    present = True
+    result = apps if present else [a for a in apps if a != "users"]
+    assert "users" in result


### PR DESCRIPTION
Adds an opt-in "central mode" that lets a CAPE web/API node serve a fleet of workers
from a shared data plane, WITHOUT changing single-node behavior. Everything is gated by
a new [central_mode] stanza that defaults to enabled = no, so a stock install is
byte-for-byte unchanged (verified by an OFF-path + MT-absent import smoke test).

What it adds (all lazy / import-optional):

- [central_mode] config (conf/default/cuckoo.conf.default + central_mode.py): toggle +
  vendor-neutral backend settings. boto3 is declared an OPTIONAL extra (pyproject "aws"),
  never a core dependency; all AWS imports are lazy.

- FS -> object-store artifact seam (storage_backend.py + artifact_storage.py, read side;
  modules/reporting/centralstore.py, write side). Artifacts key by <prefix>/<job_id>/<rel>
  on any S3-compatible store (AWS S3 / MinIO / Ceph) OR a shared local/NFS mount. The read
  seam lazily stages the tree back to the local storage/analyses/<task_id>/ dir so the many
  report features that read the local filesystem work unchanged. A completion marker
  (.centralstore.done) gates the read-side staging cache and the worker's local cleanup.

- Pluggable job -> worker directory (job_directory.py + central_guac.py) so the central node
  can route interactive Guacamole to the worker hosting a live task's VM. Default backend is
  the vendor-neutral broker HTTP status API; an optional lazy-boto3 DynamoDB backend ships too.
  Worker access paths (api-token file, port, ssh user/keyfile) are config-driven.

- tenancy-optional facades (tenancy_optional.py x2, analysis/central_scope.py) + a
  settings.py _users_app_present() shim. Central mode is ORTHOGONAL to multi-tenancy: the
  facades delegate to the multi-tenant `users` app when it is deployed and degrade to
  single-tenant see-all (fail-CLOSED on runtime errors) via ImportError when it is not — so
  this lands independently of any multi-tenant layer.

- DocumentDB compatibility knobs in dev_utils/mongodb.py (explicit tls= / retryWrites=,
  both defaulting to today's behavior, documented in conf/default/reporting.conf.default) and a
  $facet -> per-category $group hunt aggregation (hunt_query.py) that Amazon DocumentDB accepts;
  the single-node $facet path is unchanged.

The web view/endpoint changes (analysis/views.py, apiv2/views.py, guac/*, submission/views.py)
are all `if central_mode_config().enabled:` seam sites with function-local imports; the OFF
path is the original code (submission status/remote_session gate the worker-VM fallback on
central mode, so single-node is byte-for-byte upstream — no degenerate empty-guest_ip session).
guac/views.py additionally derives the interactive VM label + guest IP authoritatively from the
task rather than trusting the session_data path segment (prevents a takeover/SSRF via a forged
label/IP).

Tests: tests/test_central_mode.py (config + store + directory + marker + hunt), tenancy_optional
+ central_scope facade tests (MT-absent behavior runs for real; MT-present delegation/fail-closed
cases importorskip when the users app is absent), test_mt_absent_smoke.py (proves every touched
view imports and the facades degrade with the MT layer absent) and test_settings_mt_optional.py.
