### PR TITLE
fix(api): allow explicit reserved machine selection

### DIFF
--- a/tests/web/test_apiv2.py
+++ b/tests/web/test_apiv2.py
@@ -1,8 +1,10 @@
 import pathlib
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
 from django.test import SimpleTestCase
+from django.core.files.uploadedfile import SimpleUploadedFile
 
 from lib.cuckoo.common.config import ConfigMeta
 from lib.cuckoo.core.data.task import (
@@ -20,11 +22,24 @@ from lib.cuckoo.core.data.task import (
     Task,
 )
 
-
 @pytest.fixture
 def taskreprocess_enabled(custom_conf_path: pathlib.Path):
     with open(custom_conf_path / "api.conf", "wt") as fil:
         print("[taskreprocess]\nenabled = yes", file=fil)
+    ConfigMeta.refresh()
+    yield
+
+
+@pytest.fixture
+def dlnexeccreate_enabled(custom_conf_path: pathlib.Path):
+    with open(custom_conf_path / "api.conf", "wt") as fil:
+        print(
+            "[dlnexeccreate]\n"
+            "enabled = yes\n"
+            "allmachines = no\n"
+            "status = yes",
+            file=fil,
+        )
     ConfigMeta.refresh()
     yield
 
@@ -88,3 +103,125 @@ class ReprocessTask(SimpleTestCase):
                     assert response.status_code == 200
                     assert response.headers["content-type"] == "application/json"
                     assert response.json() == expected_response
+
+
+@pytest.mark.usefixtures("db", "tmp_cuckoo_root")
+class TestReservedMachineSubmission(SimpleTestCase):
+    def test_url_submission_accepts_explicit_reserved_machine(self):
+        normal_machine = SimpleNamespace(label="normal-machine")
+        reserved_machine = SimpleNamespace(label="reserved-machine")
+
+        def list_machines(*args, **kwargs):
+            if kwargs.get("include_reserved"):
+                return [normal_machine, reserved_machine]
+            return [normal_machine]
+
+        with (
+            patch(
+                "apiv2.views.db.list_machines",
+                side_effect=list_machines,
+            ),
+            patch(
+                "apiv2.views.db.add_url",
+                return_value=123,
+            ) as add_url,
+        ):
+            response = self.client.post(
+                "/apiv2/tasks/create/url/",
+                {
+                    "url": "https://example.com/",
+                    "machine": "reserved-machine",
+                },
+            )
+
+        assert response.status_code == 200
+        assert response.json()["data"]["task_ids"] == [123]
+        add_url.assert_called_once()
+        assert add_url.call_args.kwargs["machine"] == "reserved-machine"
+
+    def test_file_submission_accepts_explicit_reserved_machine(self):
+        normal_machine = SimpleNamespace(label="normal-machine")
+        reserved_machine = SimpleNamespace(label="reserved-machine")
+
+        def list_machines(*args, **kwargs):
+            if kwargs.get("include_reserved"):
+                return [normal_machine, reserved_machine]
+            return [normal_machine]
+
+        uploaded_file = SimpleUploadedFile(
+            "sample.exe",
+            b"MZ-test-content",
+            content_type="application/octet-stream",
+        )
+
+        processed_details = {
+            "errors": [],
+            "task_ids": [123],
+        }
+
+        with (
+            patch(
+                "apiv2.views.db.list_machines",
+                side_effect=list_machines,
+            ),
+            patch(
+                "apiv2.views.process_new_task_files",
+                return_value=(
+                    [(b"MZ-test-content", b"/tmp/sample.exe", "test-sha256")],
+                    processed_details,
+                ),
+            ),
+            patch(
+                "apiv2.views.download_file",
+                return_value=("ok", {"task_ids": [123], "errors": []}),
+            ),
+        ):
+            response = self.client.post(
+                "/apiv2/tasks/create/file/",
+                {
+                    "file": uploaded_file,
+                    "machine": "reserved-machine",
+                },
+            )
+
+        assert response.status_code == 200
+        assert response.json()["data"]["task_ids"] == [123]
+
+    @pytest.mark.usefixtures("dlnexeccreate_enabled")
+    def test_dlnexec_submission_accepts_explicit_reserved_machine(self):
+        normal_machine = SimpleNamespace(label="normal-machine")
+        reserved_machine = SimpleNamespace(label="reserved-machine")
+
+        def list_machines(*args, **kwargs):
+            if kwargs.get("include_reserved"):
+                return [normal_machine, reserved_machine]
+            return [normal_machine]
+
+        with (
+            patch(
+                "apiv2.views.db.list_machines",
+                side_effect=list_machines,
+            ),
+            patch(
+                "apiv2.views.process_new_dlnexec_task",
+                return_value=(
+                    b"/tmp/downloaded.exe",
+                    b"MZ-test-content",
+                    "",
+                ),
+            ),
+            patch(
+                "apiv2.views.download_file",
+                return_value=("ok", {"task_ids": [123], "errors": []}),
+            ),
+        ):
+            response = self.client.post(
+                "/apiv2/tasks/create/dlnexec/",
+                {
+                    "dlnexec": "https://example.com/sample.exe",
+                    "machine": "reserved-machine",
+                },
+            )
+
+        assert response.status_code == 200
+        assert response.json()["data"]["task_ids"] == [123]

--- a/web/apiv2/views.py
+++ b/web/apiv2/views.py
@@ -336,6 +336,9 @@ def tasks_create_file(request):
 
         task_machines = []
         vm_list = [vm.label for vm in db.list_machines()]
+        explicit_vm_list = [
+            vm.label for vm in db.list_machines(include_reserved=True)
+        ]
 
         if machine.lower() == "all":
             if not apiconf.filecreate.get("allmachines"):
@@ -345,12 +348,12 @@ def tasks_create_file(request):
                 task_machines.append(entry)
         else:
             # Check if VM is in our machines table
-            if machine == "" or machine in vm_list:
+            if machine == "" or machine in explicit_vm_list:
                 task_machines.append(machine)
             else:
                 resp = {
                     "error": True,
-                    "error_value": f"Machine '{machine}' does not exist. Available: {', '.join(vm_list)}",
+                    "error_value": f"Machine '{machine}' does not exist. Available: {', '.join(explicit_vm_list)}",
                 }
                 return Response(resp)
 
@@ -460,6 +463,9 @@ def tasks_create_url(request):
         task_ids = []
         task_machines = []
         vm_list = [vm.label for vm in db.list_machines()]
+        explicit_vm_list = [
+            vm.label for vm in db.list_machines(include_reserved=True)
+        ]
 
         if not url:
             resp = {"error": True, "error_value": "URL value is empty"}
@@ -473,13 +479,16 @@ def tasks_create_url(request):
                 task_machines.append(entry)
         else:
             # Check if VM is in our machines table
-            if machine == "" or machine in vm_list:
+            if machine == "" or machine in explicit_vm_list:
                 task_machines.append(machine)
             # Error if its not
             else:
                 resp = {
                     "error": True,
-                    "error_value": "Machine '{0}' does not exist. Available: {1}".format(machine, ", ".join(vm_list)),
+                    "error_value": "Machine '{0}' does not exist. Available: {1}".format(
+                        machine,
+                        ", ".join(explicit_vm_list),
+                    ),
                 }
                 return Response(resp)
 
@@ -564,6 +573,9 @@ def tasks_create_dlnexec(request):
         details = {}
         task_machines = []
         vm_list = [vm.label for vm in db.list_machines()]
+        explicit_vm_list = [
+            vm.label for vm in db.list_machines(include_reserved=True)
+        ]
 
         if machine.lower() == "all":
             if not apiconf.dlnexeccreate.get("allmachines"):
@@ -573,13 +585,13 @@ def tasks_create_dlnexec(request):
                 task_machines.append(entry)
         else:
             # Check if VM is in our machines table
-            if machine == "" or machine in vm_list:
+            if machine == "" or machine in explicit_vm_list:
                 task_machines.append(machine)
             # Error if its not
             else:
                 resp = {
                     "error": True,
-                    "error_value": "Machine '{0}' does not exist. Available: {1}".format(machine, ", ".join(vm_list)),
+                    "error_value": "Machine '{0}' does not exist. Available: {1}".format(machine, ", ".join(explicit_vm_list)),
                 }
                 return Response(resp)
 


### PR DESCRIPTION
## Problem

CAPE’s API task-creation endpoints validate requested machines against the default machine list.

Reserved machines are excluded from that default list, so an explicitly named reserved machine is rejected as unavailable even though the caller deliberately selected it.

This affects file, URL, and download-and-execute submissions.

## Changes

- Validate explicitly named machines against `db.list_machines(include_reserved=True)`.
- Keep existing `machine="all"` behavior based on the normal non-reserved machine list.
- Return the expanded explicit-machine list in validation errors.
- Add regression coverage for file, URL, and download-and-execute submissions using an explicitly selected reserved machine.

## Behavior

Explicitly naming a reserved machine is now accepted by the API and passed through to task creation.

Reserved machines are not added to `machine="all"` expansion. That path continues to use the default machine list and therefore preserves the existing reserved-machine exclusion policy.

Invalid explicit machine names continue to return an error, but the reported available-machine list now includes reserved machines that can be selected directly.

## Validation

- Python compilation
- `git diff --check`
- `pytest -q tests/web/test_apiv2.py` — 7 passed