### PR TITLE
fix(proxmox): retry failed read operations

### DIFF
--- a/modules/machinery/proxmox.py
+++ b/modules/machinery/proxmox.py
@@ -240,10 +240,12 @@ class Proxmox(Machinery):
         vm, node = self.find_vm(label)
         self.rollback(label, vm, node)
 
-        try:
-            status = vm.status.current.get()
-        except ResourceException as e:
-            raise CuckooMachineError(f"Couldn't get status: {e}")
+        deadline = time.monotonic() + self.timeout
+        status = self._get_with_retry(
+            vm.status.current,
+            deadline=deadline,
+            description=f"{label}: Couldn't get VM status",
+        )
 
         if status["status"] == "running":
             log.debug("%s: Already running after rollback, no need to start it", label)

--- a/modules/machinery/proxmox.py
+++ b/modules/machinery/proxmox.py
@@ -6,6 +6,8 @@ import logging
 import sys
 import time
 
+from requests.exceptions import RequestException
+
 from lib.cuckoo.common.abstracts import Machinery
 from lib.cuckoo.common.config import Config
 from lib.cuckoo.common.exceptions import CuckooCriticalError, CuckooMachineError
@@ -14,6 +16,8 @@ try:
     from proxmoxer import ProxmoxAPI, ResourceException
 except ImportError:
     sys.exit("Install by yourself. Missed dependency: pip3 install proxmoxer -U")
+
+READ_RETRY_EXCEPTIONS = (ResourceException, RequestException)
 
 # silence overly verbose INFO level logging default of proxmoxer module
 logging.getLogger("proxmoxer").setLevel(logging.WARNING)
@@ -44,6 +48,23 @@ class Proxmox(Machinery):
 
         super(Proxmox, self)._initialize_check()
 
+    def _get_with_retry(self, resource, *, deadline, description, **kwargs):
+        """Retry a Proxmox GET operation until the supplied deadline."""
+        while True:
+            try:
+                return resource.get(**kwargs)
+            except READ_RETRY_EXCEPTIONS as e:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise CuckooMachineError(f"{description}: {e}") from e
+
+                delay = min(1, remaining)
+                log.warning("%s: %s; retrying in %.1f seconds", description, e, delay)
+                time.sleep(delay)
+
+                if time.monotonic() >= deadline:
+                    raise CuckooMachineError(f"{description}: {e}") from e
+
     def find_vm(self, label):
         """Find a VM in the Proxmox cluster and return its node and vm proxy
         objects for extraction of additional data by other methods.
@@ -59,10 +80,13 @@ class Proxmox(Machinery):
         )
 
         # /cluster/resources[type=vm] will give us all VMs no matter which node they reside on
-        try:
-            vms = proxmox.cluster.resources.get(type="vm")
-        except ResourceException as e:
-            raise CuckooMachineError(f"Error enumerating VMs: {e}")
+        deadline = time.monotonic() + self.timeout
+        vms = self._get_with_retry(
+            proxmox.cluster.resources,
+            deadline=deadline,
+            description=f"{label}: Error enumerating VMs",
+            type="vm",
+        )
 
         for vm in vms:
             if vm["name"] == label:
@@ -80,13 +104,18 @@ class Proxmox(Machinery):
         """Wait for long-running Proxmox task to finish.
 
         @param taskid: id of Proxmox task to wait for
-        @raise CuckooMachineError: if task status cannot be determined."""
-        elapsed = 0
-        while elapsed < self.timeout:
+        @return: task status, or None if the timeout expires."""
+        deadline = time.monotonic() + self.timeout
+
+        while time.monotonic() < deadline:
             try:
-                task = node.tasks(taskid).status.get()
-            except ResourceException as e:
-                raise CuckooMachineError(f"Error getting status of task {taskid}: {e}")
+                task = self._get_with_retry(
+                    node.tasks(taskid).status,
+                    deadline=deadline,
+                    description=f"{label}: Error getting status of task {taskid}",
+                )
+            except CuckooMachineError:
+                return None
 
             # extract operation name from task status for display
             operation = task["type"]
@@ -95,8 +124,10 @@ class Proxmox(Machinery):
 
             if task["status"] != "stopped":
                 log.debug("%s: Waiting for operation %s (%s) to finish", label, operation, taskid)
-                time.sleep(1)
-                elapsed += 1
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    return None
+                time.sleep(min(1, remaining))
                 continue
 
             # VMs sometimes remain locked for some seconds after a task
@@ -104,16 +135,22 @@ class Proxmox(Machinery):
             # is attempted. So query the current VM status to extract the lock
             # status.
             try:
-                status = vm.status.current.get()
-            except ResourceException as e:
-                raise CuckooMachineError(f"Couldn't get status: {e}")
+                status = self._get_with_retry(
+                    vm.status.current,
+                    deadline=deadline,
+                    description=f"{label}: Couldn't get VM status after task {taskid}",
+                )
+            except CuckooMachineError:
+                return None
 
             if "lock" in status:
                 log.debug("%s: Task finished but VM still locked", label)
                 if status["lock"] != operation:
                     log.warning("%s: Task finished but VM locked by different operation: %s", label, operation)
-                time.sleep(1)
-                elapsed += 1
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    return None
+                time.sleep(min(1, remaining))
                 continue
 
             # task is really, really done
@@ -136,10 +173,12 @@ class Proxmox(Machinery):
         # heuristically determine the most recent snapshot if no snapshot name
         # is explicitly configured.
         log.debug("%s: No snapshot configured, determining most recent one", label)
-        try:
-            snapshots = vm.snapshot.get()
-        except ResourceException as e:
-            raise CuckooMachineError(f"Error enumerating snapshots: {e}")
+        deadline = time.monotonic() + self.timeout
+        snapshots = self._get_with_retry(
+            vm.snapshot,
+            deadline=deadline,
+            description=f"{label}: Error enumerating snapshots",
+        )
 
         snaptime = 0
         snapshot = None

--- a/tests/test_proxmox.py
+++ b/tests/test_proxmox.py
@@ -1,0 +1,294 @@
+import importlib
+import sys
+from types import ModuleType, SimpleNamespace
+from typing import Generator
+
+import pytest
+from pytest_mock import MockerFixture
+from requests.exceptions import RequestException
+
+
+class FakeClock:
+    """Deterministic clock for timeout-based retry tests."""
+
+    def __init__(self):
+        self.now = 0
+
+    def monotonic(self):
+        return self.now
+
+    def sleep(self, seconds):
+        self.now += seconds
+
+
+@pytest.fixture
+def proxmox_module(
+    monkeypatch: pytest.MonkeyPatch,
+    mocker: MockerFixture,
+) -> Generator:
+    """Import Proxmox machinery without requiring proxmoxer."""
+
+    proxmoxer = ModuleType("proxmoxer")
+
+    class ResourceException(Exception):
+        """Minimal representation of proxmoxer's ResourceException."""
+
+        def __init__(
+            self,
+            status_code,
+            status_message,
+            content,
+            errors=None,
+            exit_code=None,
+        ):
+            self.status_code = status_code
+            self.status_message = status_message
+            self.content = content
+            self.errors = errors
+            self.exit_code = exit_code
+            super().__init__(f"{status_code} {status_message}: {content}")
+
+    proxmoxer.ProxmoxAPI = mocker.Mock()
+    proxmoxer.ResourceException = ResourceException
+
+    monkeypatch.setitem(sys.modules, "proxmoxer", proxmoxer)
+    sys.modules.pop("modules.machinery.proxmox", None)
+
+    module = importlib.import_module("modules.machinery.proxmox")
+
+    yield module
+
+    sys.modules.pop("modules.machinery.proxmox", None)
+
+
+def make_machinery(proxmox_module, timeout):
+    machinery = proxmox_module.Proxmox.__new__(
+        proxmox_module.Proxmox
+    )
+    machinery.timeout = timeout
+    return machinery
+
+
+def install_fake_clock(
+    proxmox_module,
+    mocker: MockerFixture,
+):
+    clock = FakeClock()
+
+    mocker.patch.object(
+        proxmox_module.time,
+        "monotonic",
+        clock.monotonic,
+    )
+    mocker.patch.object(
+        proxmox_module.time,
+        "sleep",
+        clock.sleep,
+    )
+
+    return clock
+
+
+def resource_error(
+    proxmox_module,
+    status_code,
+    status_message,
+    content,
+):
+    return proxmox_module.ResourceException(
+        status_code,
+        status_message,
+        content,
+    )
+
+
+def test_find_vm_retries_resource_get_until_success(
+    proxmox_module,
+    mocker: MockerFixture,
+):
+    machinery = make_machinery(proxmox_module, timeout=10)
+    clock = install_fake_clock(proxmox_module, mocker)
+
+    machinery.options = SimpleNamespace(
+        proxmox=SimpleNamespace(
+            hostname="proxmox.example",
+            username="test-user",
+            password="test-password",
+        )
+    )
+
+    proxmox = proxmox_module.ProxmoxAPI.return_value
+    vm_proxy = mocker.Mock()
+
+    class HypervisorProxy:
+        def __getattr__(self, vmid):
+            assert vmid == "101"
+            return vm_proxy
+
+    class NodeProxy:
+        def __getattr__(self, vm_type):
+            assert vm_type == "qemu"
+            return HypervisorProxy()
+
+    node_proxy = NodeProxy()
+    proxmox.nodes.return_value = node_proxy
+
+    proxmox.cluster.resources.get.side_effect = [
+        resource_error(
+            proxmox_module,
+            400,
+            "Bad Request",
+            "request could not be processed",
+        ),
+        [
+            {
+                "name": "analysis-vm",
+                "node": "node-a",
+                "type": "qemu",
+                "vmid": 101,
+            }
+        ],
+    ]
+
+    found_vm, found_node = machinery.find_vm("analysis-vm")
+
+    assert found_vm is vm_proxy
+    assert found_node is node_proxy
+    assert proxmox.cluster.resources.get.call_count == 2
+    assert clock.now < machinery.timeout
+
+
+def test_find_snapshot_retries_request_get_until_success(
+    proxmox_module,
+    mocker: MockerFixture,
+):
+    machinery = make_machinery(proxmox_module, timeout=10)
+    clock = install_fake_clock(proxmox_module, mocker)
+
+    machinery.db = mocker.Mock()
+    machinery.db.view_machine_by_label.return_value.snapshot = None
+
+    vm = mocker.Mock()
+    vm.snapshot.get.side_effect = [
+        RequestException("temporary transport failure"),
+        [
+            {"name": "current"},
+            {"name": "older", "snaptime": 100},
+            {"name": "newer", "snaptime": 200},
+        ],
+    ]
+
+    snapshot = machinery.find_snapshot("analysis-vm", vm)
+
+    assert snapshot == "newer"
+    assert vm.snapshot.get.call_count == 2
+    assert clock.now < machinery.timeout
+
+
+def test_wait_for_task_retries_resource_get_until_success(
+    proxmox_module,
+    mocker: MockerFixture,
+):
+    machinery = make_machinery(proxmox_module, timeout=10)
+    clock = install_fake_clock(proxmox_module, mocker)
+
+    node = mocker.Mock()
+    vm = mocker.Mock()
+
+    completed_task = {
+        "type": "qmrollback",
+        "status": "stopped",
+        "exitstatus": "OK",
+    }
+
+    node.tasks.return_value.status.get.side_effect = [
+        resource_error(
+            proxmox_module,
+            400,
+            "Bad Request",
+            "request could not be processed",
+        ),
+        resource_error(
+            proxmox_module,
+            503,
+            "Service Unavailable",
+            "temporary API failure",
+        ),
+        completed_task,
+    ]
+    vm.status.current.get.return_value = {"status": "stopped"}
+
+    task = machinery.wait_for_task(
+        "UPID:test",
+        "analysis-vm",
+        vm,
+        node,
+    )
+
+    assert task == completed_task
+    assert node.tasks.return_value.status.get.call_count == 3
+    assert clock.now < machinery.timeout
+
+
+def test_wait_for_task_stops_retrying_get_at_timeout(
+    proxmox_module,
+    mocker: MockerFixture,
+):
+    machinery = make_machinery(proxmox_module, timeout=5)
+    clock = install_fake_clock(proxmox_module, mocker)
+
+    node = mocker.Mock()
+    vm = mocker.Mock()
+
+    node.tasks.return_value.status.get.side_effect = resource_error(
+        proxmox_module,
+        400,
+        "Bad Request",
+        "request could not be processed",
+    )
+
+    task = machinery.wait_for_task(
+        "UPID:test",
+        "analysis-vm",
+        vm,
+        node,
+    )
+
+    assert task is None
+    assert clock.now >= machinery.timeout
+    assert node.tasks.return_value.status.get.call_count > 1
+    vm.status.current.get.assert_not_called()
+
+
+def test_wait_for_task_retries_vm_status_get_until_success(
+    proxmox_module,
+    mocker: MockerFixture,
+):
+    machinery = make_machinery(proxmox_module, timeout=10)
+    clock = install_fake_clock(proxmox_module, mocker)
+
+    node = mocker.Mock()
+    vm = mocker.Mock()
+
+    completed_task = {
+        "type": "qmrollback",
+        "status": "stopped",
+        "exitstatus": "OK",
+    }
+
+    node.tasks.return_value.status.get.return_value = completed_task
+    vm.status.current.get.side_effect = [
+        RequestException("temporary transport failure"),
+        {"status": "stopped"},
+    ]
+
+    task = machinery.wait_for_task(
+        "UPID:test",
+        "analysis-vm",
+        vm,
+        node,
+    )
+
+    assert task == completed_task
+    assert vm.status.current.get.call_count == 2
+    assert clock.now < machinery.timeout

--- a/tests/test_proxmox.py
+++ b/tests/test_proxmox.py
@@ -292,3 +292,27 @@ def test_wait_for_task_retries_vm_status_get_until_success(
     assert task == completed_task
     assert vm.status.current.get.call_count == 2
     assert clock.now < machinery.timeout
+
+
+def test_start_retries_vm_status_get_until_success(
+    proxmox_module,
+    mocker: MockerFixture,
+):
+    machinery = make_machinery(proxmox_module, timeout=10)
+    clock = install_fake_clock(proxmox_module, mocker)
+
+    vm = mocker.Mock()
+    node = mocker.Mock()
+
+    mocker.patch.object(machinery, "find_vm", return_value=(vm, node))
+    mocker.patch.object(machinery, "rollback")
+
+    vm.status.current.get.side_effect = [
+        RequestException("temporary transport failure"),
+        {"status": "running"},
+    ]
+
+    machinery.start("analysis-vm")
+
+    assert vm.status.current.get.call_count == 2
+    machinery.rollback.assert_called_once_with("analysis-vm", vm, node)

--- a/tests/test_proxmox.py
+++ b/tests/test_proxmox.py
@@ -299,7 +299,7 @@ def test_start_retries_vm_status_get_until_success(
     mocker: MockerFixture,
 ):
     machinery = make_machinery(proxmox_module, timeout=10)
-    clock = install_fake_clock(proxmox_module, mocker)
+    install_fake_clock(proxmox_module, mocker)
 
     vm = mocker.Mock()
     node = mocker.Mock()


### PR DESCRIPTION
## Problem

CAPE’s Proxmox machinery currently treats transient failures from read-only Proxmox API operations as immediate machinery errors.

Temporary `proxmoxer` resource errors or HTTP transport failures can occur while enumerating VMs, listing snapshots, polling task status, or checking the VM lock state. Failing on the first read error can interrupt otherwise recoverable operations.

## Changes

- Add a shared retry helper for Proxmox `GET` operations.
- Retry both `proxmoxer.ResourceException` and `requests.RequestException`.
- Apply bounded retry behavior to:
  - VM enumeration
  - Snapshot enumeration
  - Task-status polling
  - VM-status reads after task completion
- Use the existing machinery timeout as the retry deadline.
- Return `None` from task polling when the deadline expires, preserving the caller’s timeout handling.
- Add focused tests with a deterministic clock for successful retries and timeout behavior.

## Behavior

Transient Proxmox read failures are retried in one-second intervals, up to the remaining machinery timeout.

VM and snapshot discovery still raise `CuckooMachineError` if the read cannot succeed before the deadline.

Task polling returns `None` if task status or post-task VM status cannot be read before the timeout, matching the method’s timeout result.

Successful reads continue through the existing machinery flow without changing write operations or task semantics.

## Validation

- Python compilation
- `git diff --check`
- `pytest -q tests/test_proxmox.py tests/test_abstracts.py` — 15 passed