### PR TITLE
build: require SFlock2 0.3.84

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -5757,14 +5757,14 @@ type = ["importlib_metadata (>=7.0.2) ; python_version < \"3.10\"", "jaraco.deve
 
 [[package]]
 name = "sflock2"
-version = "0.3.76"
+version = "0.3.87"
 description = "Sample staging and detonation utility"
 optional = false
 python-versions = "<4.0,>=3.10"
 groups = ["main"]
 files = [
-    {file = "sflock2-0.3.76-py3-none-any.whl", hash = "sha256:3d989d142fc49ebd049f75eb8d402451fcd20148cf27aaa20c540ac95a9c81ff"},
-    {file = "sflock2-0.3.76.tar.gz", hash = "sha256:eed75b32adf3c82a60d9339fda63a151355f9be7639d7d583de8f43ea6604e4c"},
+    {file = "sflock2-0.3.87-py3-none-any.whl", hash = "sha256:1007ebdfa0d4505f6afc3cb24e362f70efc8bf79def8a67524281aff1e5fe344"},
+    {file = "sflock2-0.3.87.tar.gz", hash = "sha256:ac05f55f13525ebf318ef1b27ec2737def608c1b701f31afb4ba9c33c9d9a6d5"},
 ]
 
 [package.dependencies]
@@ -5772,6 +5772,7 @@ click = "*"
 cryptography = ">=44.0.0"
 olefile = ">=0.43"
 pefile = "*"
+python-dateutil = "*"
 python-magic = {version = ">=0.4.13", optional = true, markers = "sys_platform == \"linux\" and extra == \"linux\""}
 unicorn = {version = ">=2.0.0", optional = true, markers = "extra == \"shellcode\""}
 yara-python = {version = ">=4.1.0", optional = true, markers = "extra == \"shellcode\""}
@@ -7083,4 +7084,4 @@ yara = ["plyara"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10, <4.0"
-content-hash = "6498cff0467e22c4423f6669349822b1218db41223ee142ead281ec3b7d0a325"
+content-hash = "f697094f5bba08bc55f1b59d1336611e976aca37039c610efc5df05431b9793e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "orjson>=3.9.15",
     # "maec==4.1.0.17",
     # "regex==2021.7.6",
-    "SFlock2[linux,shellcode]>=0.3.76",
+    "SFlock2[linux,shellcode]>=0.3.84",
     # "volatility3==2.11.0",
     # "XLMMacroDeobfuscator==0.2.7",
     "pyzipper==0.3.6",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2477,9 +2477,9 @@ setproctitle==1.3.2 ; python_version >= "3.10" and python_version < "4.0" \
 setuptools==78.1.1 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:c3a9c4211ff4c309edb8b8c4f1cbfa7ae324c4ba9f91ff254e3d305b9fd54561 \
     --hash=sha256:fcc17fd9cd898242f6b4adfaca46137a9edef687f43e6f78469692a5e70d851d
-sflock2==0.3.76 ; python_version >= "3.10" and python_version < "4.0" \
-    --hash=sha256:3d989d142fc49ebd049f75eb8d402451fcd20148cf27aaa20c540ac95a9c81ff \
-    --hash=sha256:eed75b32adf3c82a60d9339fda63a151355f9be7639d7d583de8f43ea6604e4c
+sflock2==0.3.87 ; python_version >= "3.10" and python_version < "4.0" \
+    --hash=sha256:1007ebdfa0d4505f6afc3cb24e362f70efc8bf79def8a67524281aff1e5fe344 \
+    --hash=sha256:ac05f55f13525ebf318ef1b27ec2737def608c1b701f31afb4ba9c33c9d9a6d5
 six==1.17.0 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274 \
     --hash=sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81

--- a/uv.lock
+++ b/uv.lock
@@ -556,7 +556,7 @@ requires-dist = [
     { name = "ruff", specifier = ">=0.7.2" },
     { name = "setproctitle", specifier = "==1.3.2" },
     { name = "setuptools", specifier = "==78.1.1" },
-    { name = "sflock2", extras = ["linux", "shellcode"], specifier = ">=0.3.76" },
+    { name = "sflock2", extras = ["linux", "shellcode"], specifier = ">=0.3.84" },
     { name = "sqlalchemy", specifier = "==2.0.41" },
     { name = "sqlalchemy-utils", specifier = "==0.41.1" },
     { name = "tldextract", specifier = ">=5.1.2" },


### PR DESCRIPTION
## Problem

CAPE declares SFlock2 `0.3.76` as its minimum supported version.

That minimum is too old for the required SFlock2 behavior. Environments resolving dependencies from the project metadata can therefore install an unsupported release even when newer lock files happen to select a later version.

## Changes

- Raise the declared SFlock2 minimum from `0.3.76` to `0.3.84`.
- Update the Poetry lock file to a compatible resolved release.
- Update `requirements.txt` with the corresponding resolved version and hashes.
- Update `uv.lock` so its declared dependency constraint matches the new minimum.

## Behavior

Fresh dependency resolution will no longer permit SFlock2 versions older than `0.3.84`.

The generated lock files may resolve a later compatible release. In this patch, Poetry and `requirements.txt` resolve SFlock2 `0.3.87`, while the `uv.lock` package entry remains on a compatible version satisfying the new `>=0.3.84` constraint.

## Validation

- `git diff --check`
- `poetry check`
- Verified consistent SFlock2 constraints across `pyproject.toml`, `poetry.lock`, `requirements.txt`, and `uv.lock`