### PR TITLE
Fix broken HTML report/reimplement call table

### DIFF
--- a/data/html/css/style.css
+++ b/data/html/css/style.css
@@ -43,7 +43,40 @@ body {
 }
 
 .page-link {
-    background-color: #444
+    background-color: #444;
+}
+
+.page-link:hover {
+    background-color: #EE1B2F;
+}
+
+.page-link-active {
+    background-color: #EE1B2F;
+}
+
+.text-success {
+    color: #62c462 !important;
+}
+
+.text-success:hover {
+    color: #62c462 !important;
+}
+
+#top_pagination {
+    scroll-margin-top: 75px;
+}
+
+.pagination {
+    --bs-pagination-disabled-bg: #2c3034;        /* Dark pale grey background */
+    --bs-pagination-disabled-color: #6c757d;     /* Muted grey text */
+    --bs-pagination-disabled-border-color: #373b3e; /* Matching subtle border */
+}
+
+.page-item.active .page-link {
+    z-index: 3;
+    color: #fff;
+    background-color: #ee1b2f !important;
+    border-color: transparent;
 }
 
 .page-item.active .page-link {
@@ -183,6 +216,168 @@ h4, .h4 {
 	width : 40%;
 }
 
+
+/* Category buttons (base colors) */
+.btn-cat-default {
+    background-color: #696969;
+    color: #000;
+    border-color: #696969;
+}
+
+.btn-cat-filesystem {
+    background-color: #ffe3c5;
+    color: #000;
+    border-color: #ffe3c5;
+}
+
+.btn-cat-registry {
+    background-color: #ffc5c5;
+    color: #000;
+    border-color: #ffc5c5;
+}
+
+.btn-cat-process {
+    background-color: #c5e0ff;
+    color: #000;
+    border-color: #c5e0ff;
+}
+
+.btn-cat-threading {
+    background-color: #d3e0ff;
+    color: #000;
+    border-color: #d3e0ff;
+}
+
+.btn-cat-services {
+    background-color: #ccc5ff;
+    color: #000;
+    border-color: #ccc5ff;
+}
+
+.btn-cat-device {
+    background-color: #d3c5cc;
+    color: #000;
+    border-color: #d3c5cc;
+}
+
+.btn-cat-network {
+    background-color: #d3ffc5;
+    color: #000;
+    border-color: #d3ffc5;
+}
+
+.btn-cat-socket {
+    background-color: #d3ffc5;
+    color: #000;
+    border-color: #d3ffc5;
+}
+
+.btn-cat-synchronization {
+    background-color: #f9c5ff;
+    color: #000;
+    border-color: #f9c5ff;
+}
+
+.btn-cat-browser {
+    background-color: #dfffdf;
+    color: #000;
+    border-color: #dfffdf;
+}
+
+.btn-cat-crypto {
+    background-color: #f0f2c5;
+    color: #000;
+    border-color: #f0f2c5;
+}
+
+.btn-cat-all {
+    background-color: #198754;
+    color: #000;
+    border-color: #198754;
+}
+
+/* Active state border colors (your current behavior) */
+.btn-cat-default.active,
+.btn-cat-default:active,
+.show > .btn-cat-default.dropdown-toggle {
+    border-color: #696969;
+}
+
+.btn-cat-filesystem.active,
+.btn-cat-filesystem:active,
+.show > .btn-cat-filesystem.dropdown-toggle {
+    border-color: #ffe3c5;
+}
+
+.btn-cat-registry.active,
+.btn-cat-registry:active,
+.show > .btn-cat-registry.dropdown-toggle {
+    border-color: #ffc5c5;
+}
+
+.btn-cat-process.active,
+.btn-cat-process:active,
+.show > .btn-cat-process.dropdown-toggle {
+    border-color: #c5e0ff;
+}
+
+.btn-cat-threading.active,
+.btn-cat-threading:active,
+.show > .btn-cat-threading.dropdown-toggle {
+    border-color: #d3e0ff;
+}
+
+.btn-cat-services.active,
+.btn-cat-services:active,
+.show > .btn-cat-services.dropdown-toggle {
+    border-color: #ccc5ff;
+}
+
+.btn-cat-device.active,
+.btn-cat-device:active,
+.show > .btn-cat-device.dropdown-toggle {
+    border-color: #dcd1d6;
+}
+
+.btn-cat-network.active,
+.btn-cat-network:active,
+.show > .btn-cat-network.dropdown-toggle {
+    border-color: #dcffd1;
+}
+
+.btn-cat-socket.active,
+.btn-cat-socket:active,
+.show > .btn-cat-socket.dropdown-toggle {
+    border-color: #dcffd1;
+}
+
+.btn-cat-synchronization.active,
+.btn-cat-synchronization:active,
+.show > .btn-cat-synchronization.dropdown-toggle {
+    border-color: #fad1ff;
+}
+
+.btn-cat-browser.active,
+.btn-cat-browser:active,
+.show > .btn-cat-browser.dropdown-toggle {
+    border-color: #e5ffe5;
+}
+
+.btn-cat-crypto.active,
+.btn-cat-crypto:active,
+.show > .btn-cat-crypto.dropdown-toggle {
+    border-color: #f3f5d1;
+}
+
+.btn-cat-all.active,
+.btn-cat-all:active,
+.show > .btn-cat-all.dropdown-toggle {
+    border-color: #479f76;
+}
+
+
+
+
 td {
     word-wrap: break-word;
 }
@@ -227,4 +422,39 @@ pre {
 #filter-toggle {
     display: inline-block;
     cursor: pointer;
+}
+
+.alert-primary, .alert-info {
+    background-color: #1c1c1c;
+}
+
+/* Hover/focus states */
+.form-control[type="file"]::file-selector-button:hover {
+    background-color: #3f474e;
+}
+
+/* Mid-gray form controls */
+:root {
+    --form-bg: #5c5c5c;
+    --form-border: #666;
+    --form-text: #fff;
+    --form-placeholder: rgba(255, 255, 255, .55);
+}
+
+.form-control,
+.form-select {
+    background-color: var(--form-bg) !important;
+    color: var(--form-text) !important;
+    border-color: var(--form-border) !important;
+}
+
+.form-control::placeholder {
+    color: var(--form-placeholder) !important;
+}
+
+.form-control:focus,
+.form-select:focus {
+    background-color: var(--form-bg) !important;
+    border-color: #007ABCFF !important;
+    box-shadow: 0 0 0 .25rem rgba(0, 38, 60, 0.25);
 }

--- a/data/html/generic/_network_http.html
+++ b/data/html/generic/_network_http.html
@@ -12,7 +12,7 @@
             <table class="table table-striped table-bordered">
             {% if http.request %}
                 <tr><td>
-                    {% if http.req.sha256 %}
+                    {% if http.request.sha256 %}
                         <button type="button" class="btn btn-secondary btn-sm" disabled><span class="fas fa-download"></span> Request content</button>
                     {% else %}
                         Request:
@@ -24,7 +24,7 @@
             {% endif %}
             <tr><td>
             {% if http.response %}
-                {% if http.resp.sha256 %}
+                {% if http.response.sha256 %}
                     <button type="button" class="btn btn-secondary btn-sm" disabled><span class="fas fa-download"></span> Response content</button>
                 {% else %}
                     Response:
@@ -33,8 +33,8 @@
                     <li>{{value}}</li>
                 {% endfor %}
                 </br>Response preview:
-                {% if http.resp.preview %}
-                    {% for line in http.resp.preview %}
+                {% if http.response.preview %}
+                    {% for line in http.response.preview %}
                         <li>{{line}}</li>
                     {% endfor %}
                 {% endif %}

--- a/data/html/sections/behavior.html
+++ b/data/html/sections/behavior.html
@@ -1,9 +1,46 @@
 {% set proctree_details = True %}
 {% include "sections/proctree.html" %}
+
+
+
 <div class="mt-4">
     <div class="section-title">
         <h4>Behavioral Analysis</h4>
     </div>
+
+    {% if summary_report %}
+        {% if results.behavior and results.behavior.processes %}
+            {% for process in results.behavior.processes %}
+                <div>
+                    <h4>{{process.process_name}} <small>PID: {{process.process_id}}, Parent PID: {{process.parent_id}}</small></h4>
+                </div>
+            {% endfor %}
+        {% else %}
+            Nothing to display.
+        {% endif %}
+    {% else %}
+        <div class="card bg-dark border-secondary">
+            <div class="card-header border-secondary">
+                <ul class="nav nav-pills card-header-pills" id="processTabs" role="tablist">
+                    {% for process in results.behavior.processes %}
+                    <li class="nav-item">
+                    <a class="nav-link {% if loop.first %}active{% endif %}" 
+                        id="process-{{ process.process_id }}-tab" 
+                        data-bs-toggle="pill" 
+                        href="#process_{{ process.process_id }}" 
+                        role="tab" 
+                        aria-controls="process_{{ process.process_id }}" 
+                        aria-selected="{% if loop.first %}true{% else %}false{% endif %}">
+                            <i class="fas fa-microchip me-1"></i> {{ process.process_name }} <small>({{ process.process_id }})</small>
+                        </a>
+                    </li>
+                    {% endfor %}
+                </ul>
+            </div>
+            {% include "sections/calltables.html" %}
+        </div>
+    {% endif %}
+
 
     {% if results.behavior and results.behavior.anomaly %}
     <div class="card mt-3">

--- a/data/html/sections/calltables.html
+++ b/data/html/sections/calltables.html
@@ -1,0 +1,351 @@
+
+<script type="text/javascript">
+class ProcessTablePaginator {
+    constructor(pid, pageSize = 100) {
+        this.pid = pid;
+        this.defaultPageSize = pageSize;
+        this.pageSize = pageSize;
+        this.currentPage = 1;
+
+        // api type filters
+        this.activeCategory = 'default';
+        this.searchTerm = '';
+        
+        // advanced filters
+        this.callerTerm = '';
+        this.tidTerm = '';
+
+        this.pane = document.getElementById(`process_${pid}`);
+        if (!this.pane) return;
+
+        this.table = this.pane.querySelector('table');
+        this.allRows = Array.from(this.table.querySelectorAll('tr')).slice(1);
+        this.filteredRows = [...this.allRows];
+
+        this.topPagEl = this.pane.querySelector(`.pagination_top_${pid}`);
+        this.bottomPagEl = this.pane.querySelector(`.pagination_bottom_${pid}`);
+
+        this.initEvents();
+        this.applyFilters();
+    }
+
+    initEvents() {
+        // handle api type filter clicks
+        this.pane.querySelectorAll('.badge-filter').forEach(btn => {
+            btn.addEventListener('click', () => {
+                const parts = btn.id.split('_');
+                let cat = parts[1];
+                if (cat === 'sync') cat = 'synchronization';
+
+                this.activeCategory = cat;
+                this.currentPage = 1;
+
+                this.pane.querySelectorAll('.badge-filter').forEach(b => b.classList.remove('active', 'btn-light'));
+                btn.classList.add('active', 'btn-light');
+
+                this.applyFilters();
+            });
+        });
+
+        // API type text search
+        const filterInput = document.getElementById(`apifilter_${this.pid}`);
+        const filterBtn = document.getElementById(`search_button_${this.pid}`);
+
+        const runTextSearch = () => {
+            this.searchTerm = filterInput.value.trim().toLowerCase();
+            this.currentPage = 1;
+            this.applyFilters();
+        };
+
+        if (filterBtn) filterBtn.addEventListener('click', runTextSearch);
+        if (filterInput) {
+            filterInput.addEventListener('keyup', (e) => {
+                if (e.key === 'Enter') runTextSearch();
+            });
+        }
+
+        // advanced filters (Caller & Thread ID)
+        const callerInput = document.getElementById(`callerfilter_${this.pid}`);
+        const tidInput = document.getElementById(`tidfilter_${this.pid}`);
+        const submitAdvBtn = document.getElementById(`submit_filter_${this.pid}`);
+
+        const runAdvSearch = () => {
+            this.callerTerm = callerInput ? callerInput.value.trim().toLowerCase() : '';
+            this.tidTerm = tidInput ? tidInput.value.trim().toLowerCase() : '';
+            this.currentPage = 1;
+            this.applyFilters();
+        };
+
+        if (submitAdvBtn) submitAdvBtn.addEventListener('click', runAdvSearch);
+        
+        [callerInput, tidInput].forEach(input => {
+            if (input) {
+                input.addEventListener('keyup', (e) => {
+                    if (e.key === 'Enter') runAdvSearch();
+                });
+            }
+        });
+    }
+
+    applyFilters() {
+        this.filteredRows = this.allRows.filter(row => {
+            const cells = row.querySelectorAll('td');
+            if (cells.length < 3) return false;
+
+            // Extract table cell data (0: Timestamp, 1: Thread ID, 2: Function, 3: Arguments...)
+            const tidText = cells[1].textContent.trim().toLowerCase();
+            const rowText = row.textContent.toLowerCase();
+
+            // Category Filter Check
+            let matchesCategory = true;
+            if (this.activeCategory !== 'all' && this.activeCategory !== 'default') {
+                matchesCategory = row.classList.contains(this.activeCategory) || 
+                                  row.classList.contains(`cat-${this.activeCategory}`) ||
+                                  row.className.includes(this.activeCategory);
+            }
+
+            // Main API Search Check
+            let matchesSearch = true;
+            if (this.searchTerm) {
+                if (this.searchTerm.startsWith('!')) {
+                    const negTerm = this.searchTerm.substring(1);
+                    matchesSearch = negTerm ? !rowText.includes(negTerm) : true;
+                } else {
+                    matchesSearch = rowText.includes(this.searchTerm);
+                }
+            }
+
+            // Advanced Thread ID Filter Check (Cell 1)
+            let matchesTID = true;
+            if (this.tidTerm) {
+                matchesTID = tidText.includes(this.tidTerm);
+            }
+
+            // Advanced Caller Filter Check
+            // Matches against entire row (or specifically against arguments / attributes if present in row data)
+            let matchesCaller = true;
+            if (this.callerTerm) {
+                matchesCaller = rowText.includes(this.callerTerm);
+            }
+
+            return matchesCategory && matchesSearch && matchesTID && matchesCaller;
+        });
+
+        // Toggle pagination sizing
+        this.pageSize = (this.activeCategory === 'all') ? Infinity : this.defaultPageSize;
+
+        this.renderPage();
+        this.renderPaginationUI();
+    }
+
+    renderPage() {
+        if (this.pageSize === Infinity) {
+            this.allRows.forEach(row => row.style.display = 'none');
+            this.filteredRows.forEach(row => row.style.display = '');
+            return;
+        }
+
+        const totalPages = Math.ceil(this.filteredRows.length / this.pageSize) || 1;
+        if (this.currentPage > totalPages) this.currentPage = totalPages;
+
+        const startIndex = (this.currentPage - 1) * this.pageSize;
+        const endIndex = startIndex + this.pageSize;
+
+        this.allRows.forEach(row => row.style.display = 'none');
+
+        const visibleSlice = this.filteredRows.slice(startIndex, endIndex);
+        visibleSlice.forEach(row => row.style.display = '');
+    }
+
+    renderPaginationUI() {
+        if (this.pageSize === Infinity) {
+            if (this.topPagEl) this.topPagEl.innerHTML = '';
+            if (this.bottomPagEl) this.bottomPagEl.innerHTML = '';
+            return;
+        }
+
+        const totalPages = Math.ceil(this.filteredRows.length / this.pageSize) || 1;
+        const html = this.buildPaginationHTML(totalPages);
+
+        if (this.topPagEl) this.topPagEl.innerHTML = html;
+        if (this.bottomPagEl) this.bottomPagEl.innerHTML = html;
+
+        [this.topPagEl, this.bottomPagEl].forEach(container => {
+            if (!container) return;
+            container.querySelectorAll('.page-link').forEach(link => {
+                link.addEventListener('click', (e) => {
+                    e.preventDefault();
+                    const targetPage = parseInt(link.dataset.page, 10);
+                    if (targetPage && targetPage !== this.currentPage && targetPage >= 1 && targetPage <= totalPages) {
+                        this.currentPage = targetPage;
+                        this.renderPage();
+                        this.renderPaginationUI();
+                    }
+                });
+            });
+        });
+    }
+
+    buildPaginationHTML(totalPages) {
+        if (totalPages <= 1) return '';
+
+        let html = '';
+        const prevDisabled = this.currentPage === 1 ? 'disabled' : '';
+        html += `<li class="page-item ${prevDisabled}"><a class="page-link" href="#" data-page="${this.currentPage - 1}">Previous</a></li>`;
+
+        let startPage = Math.max(1, this.currentPage - 2);
+        let endPage = Math.min(totalPages, startPage + 4);
+        if (endPage - startPage < 4) {
+            startPage = Math.max(1, endPage - 4);
+        }
+
+        if (startPage > 1) {
+            html += `<li class="page-item"><a class="page-link" href="#" data-page="1">1</a></li>`;
+            if (startPage > 2) html += `<li class="page-item disabled"><span class="page-link">...</span></li>`;
+        }
+
+        for (let i = startPage; i <= endPage; i++) {
+            const active = i === this.currentPage ? 'active' : '';
+            html += `<li class="page-item ${active}"><a class="page-link" href="#" data-page="${i}">${i}</a></li>`;
+        }
+
+        if (endPage < totalPages) {
+            if (endPage < totalPages - 1) html += `<li class="page-item disabled"><span class="page-link">...</span></li>`;
+            html += `<li class="page-item"><a class="page-link" href="#" data-page="${totalPages}">${totalPages}</a></li>`;
+        }
+
+        const nextDisabled = this.currentPage === totalPages ? 'disabled' : '';
+        html += `<li class="page-item ${nextDisabled}"><a class="page-link" href="#" data-page="${this.currentPage + 1}">Next</a></li>`;
+
+        return html;
+    }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    window.processPaginators = {};
+    document.querySelectorAll('.tab-pane[data-pid]').forEach(pane => {
+        const pid = pane.getAttribute('data-pid');
+        window.processPaginators[pid] = new ProcessTablePaginator(pid, 100);
+    });
+});
+</script>
+
+<div class="card-body">
+    <div class="tab-content" id="processTabsContent">
+        {% if results.behavior and results.behavior.processes %}
+            {% for process in results.behavior.processes %}
+                <div class="tab-pane fade {% if loop.index == 1 %}show active{% endif %}" id="process_{{ process.process_id }}" role="tabpanel" aria-labelledby="process-{{ process.process_id }}-tab" data-pid="{{ process.process_id }}" data-length="{{ process.calls|length }}">
+                    <div class="alert alert-primary text-info border-primary text-center shadow-sm mb-4">
+                        <h5 class="alert-heading fw-bold">{{process.process_name}}</h5>
+                        <p class="mb-0">
+                            PID: <strong>{{process.process_id}}</strong> | Parent PID: <strong>{{process.parent_id}}</strong>
+                            <br>Path: <code class="text-white">{{process.module_path}}</code>
+                            {% if process.environ.CommandLine %}<br>Cmd: <code class="text-white">{{ process.environ.CommandLine }}</code>{% endif %}
+                            <br>Image Base: <strong>{% if process.environ.MainExeBase %}{{ process.environ.MainExeBase }}{% else %}{{process.image_base}}{% endif %}</strong> |
+                            Size: <strong>{% if process.environ.MainExeSize %}{{ process.environ.MainExeSize }}{% else %}{{process.size}}{% endif %}</strong> |
+                            Bitness: <strong>{% if process.environ.Bitness %}{{ process.environ.Bitness }}{% else %}{{process.bitness}}{% endif %}</strong>
+                            {% if process.environ.DllBase %}<br />Dll Image Base: <b>{{ process.environ.DllBase }}</b>{% endif %}
+                        </p>
+                    </div>
+                    <div class="row mb-4 align-items-center justify-content-center">
+                        <div class="col-12 text-center">
+                            <div class="btn-group flex-wrap mb-3" role="group">
+                                <button id="badge_default_{{process.process_id}}" type="button" class="btn btn-cat-default badge-filter">Default</button>
+                                <button id="badge_registry_{{process.process_id}}" type="button" class="btn btn-cat-registry badge-filter">Registry</button>
+                                <button id="badge_filesystem_{{process.process_id}}" type="button" class="btn btn-cat-filesystem badge-filter">Filesystem</button>
+                                <button id="badge_network_{{process.process_id}}" type="button" class="btn btn-cat-network badge-filter">Network</button>
+                                <button id="badge_process_{{process.process_id}}" type="button" class="btn btn-cat-process badge-filter">Process</button>
+                                <button id="badge_threading_{{process.process_id}}" type="button" class="btn btn-cat-threading badge-filter">Threading</button>
+                                <button id="badge_services_{{process.process_id}}" type="button" class="btn btn-cat-services badge-filter">Services</button>
+                                <button id="badge_sync_{{process.process_id}}" type="button" class="btn btn-cat-synchronization badge-filter">Sync</button>
+                                <button id="badge_crypto_{{process.process_id}}" type="button" class="btn btn-cat-crypto badge-filter">Crypto</button>
+                                <button id="badge_browser_{{process.process_id}}" type="button" class="btn btn-cat-browser badge-filter">Browser</button>
+                                <button id="badge_device_{{process.process_id}}" type="button" class="btn btn-cat-device badge-filter">Device</button>
+                                <button id="badge_all_{{process.process_id}}" type="button" class="btn btn-cat-all badge-filter">All</button>
+                            </div>
+
+                            <div class="input-group mb-3 w-50 mx-auto">
+                                <input type="text" class="form-control bg-dark text-white border-secondary" id="apifilter_{{process.process_id}}" placeholder="Filter API calls (e.g. 'CreateFile, !CloseHandle')">
+                                <button class="btn btn-outline-info" type="button" id="search_button_{{process.process_id}}"><i class="fas fa-filter"></i> Apply</button>
+                            </div>
+
+                            <button class="btn btn-sm btn-link text-white-50" type="button" data-bs-toggle="collapse" data-bs-target="#advFilter_{{process.process_id}}">
+                                Advanced Filters <i class="fas fa-chevron-down float-end text-white-50 ms-1"></i>
+                            </button>
+
+                            <div class="collapse mt-2" id="advFilter_{{process.process_id}}">
+                                <div class="card card-body bg-dark">
+                                    <div class="row g-3">
+                                        <div class="col">
+                                            <input type="text" class="form-control text-white bg-dark border-1" id="callerfilter_{{process.process_id}}" placeholder="Caller">
+                                        </div>
+                                        <div class="col">
+                                            <input type="text" class="form-control text-white bg-dark border-1" id="tidfilter_{{process.process_id}}" placeholder="Thread ID">
+                                        </div>
+                                        <div class="col-auto">
+                                            <button class="btn btn-outline-info" id="submit_filter_{{process.process_id}}">
+                                                <i class="fas fa-filter"></i>Filter</button>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <nav aria-label="Page navigation" class="mb-3">
+                        <ul class="pagination justify-content-center pagination_top_{{process.process_id}}" data-bs-theme="dark"></ul>
+                    </nav>
+
+                    <table class="table-bordered table-condensed" style="width: 100%; word-wrap:break-word;table-layout: fixed;">
+                        <tr>
+                            <th width="10%">Time</th>
+                            <th width="3%">TID</th>
+                            <th width="8%">Caller</th>
+                            <th width="15%">API</th>
+                            <th width="42%">Arguments</th>
+                            <th width="5%">Status</th>
+                            <th width="11%">Return</th>
+                            <th width="6%">Repeated</th>
+                        </tr>
+                        {% for call in process.calls %}
+                            <tr class="{{call.category}}">
+                                <td>{{call.timestamp[11:]}}</td>
+                                <td>{{call.thread_id}}</td>
+                                <td>{{call.caller}}<br />{{call.parentcaller}}</td>
+                                <td><span class="mono">{{call.api}}</span></td>
+                                <td style="word-wrap: break-word;">
+                                {% for argument in call.arguments %}
+                                    {% if argument.pretty_value %}
+                                        {{argument.name}} => <span class="mono" title="{{argument.value}}">{{argument.pretty_value}}</span><br />
+                                    {% else %}
+                                        {{argument.name}} => <span class="mono">{{argument.value}}</span><br />
+                                    {% endif %}
+                                {% endfor %}
+                                </td>
+                                <td>{% if call.status %}SUCCESS{% else %}FAILURE{% endif %}</td>
+                                {% if call.pretty_return %}
+                                    <td style="word-wrap: break-word;"><span class="mono" title="{{call.return}}">{{call.pretty_return}}</span></td>
+                                {% else %}
+                                    <td><span class="mono">{{call.return}}</span></td>
+                                {% endif %}
+                                <td>
+                                {% if call.repeated and call.repeated > 0 %}
+                                    {{call.repeated}}
+                                    {% if call.repeated == 1 %}
+                                    time
+                                    {% elif call.repeated > 1 %}
+                                    times
+                                    {% endif %}
+                                {% endif %}
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </table>
+                    <nav aria-label="Page navigation" class="mt-3">
+                        <ul class="pagination justify-content-center pagination_bottom_{{process.process_id}}" data-bs-theme="dark"></ul>
+                    </nav>
+                </div>
+            {% endfor %}
+        {% endif %}
+    </div>
+</div>

--- a/modules/reporting/reporthtml.py
+++ b/modules/reporting/reporthtml.py
@@ -27,6 +27,11 @@ except ImportError:
 
 log = logging.getLogger(__name__)
 
+def network_rn_func(value):
+    """get basename from path"""
+    if isinstance(value, bytes):
+        value = value.decode()
+    return list(filter(None, value.split("\r\n")))
 
 class ReportHTML(Report):
     """Stores report in HTML format."""
@@ -114,6 +119,7 @@ class ReportHTML(Report):
                     "flare_capa_attck": flare_capa_attck,
                     "flare_capa_mbc": flare_capa_mbc,
                     "datefmt": datefmt,
+                    "network_rn": network_rn_func
                 }
             )
             env.loader = FileSystemLoader(os.path.join(CUCKOO_ROOT, "data", "html"))


### PR DESCRIPTION
### Problem
-----
This PR addresses #3088 where there was errors in HTML report generation and the behaviour section was empty. 
Credit to @zOLakh for reporting it and @ppil for diagnosing it

### Changes
-----
- Fixed the bad req references 
- Added the missing jinja filter
- Added API call table listing to roughly mirror the web version in behaviour and appearence 
    - Includes api category filtering, TID/caller filtering and pagination
    - Does not include the 'search' function because in my testing the web one didn't work either

The HTML reports do get quite big for large traces because unlike the web version we don't have the luxury of calling the chunk API and everything has to be embedded.

### Output
-----

* No more report generation errors 

* Restored the process tree (this isn't actually the same as the more minimal web version)

<img width="1145" height="832" alt="image" src="https://github.com/user-attachments/assets/1bf768f0-e178-4b85-a77e-be575cdca8f6" />

* The call table 
<img width="2538" height="1428" alt="image" src="https://github.com/user-attachments/assets/760a024f-9fd6-4ddd-9e16-70fc3741035a" />
