### PR TITLE
Implement workaround for PanicException serialization

### DIFF
--- a/lib/cuckoo/common/gcp.py
+++ b/lib/cuckoo/common/gcp.py
@@ -175,7 +175,7 @@ if GCS_ENABLED:
         GCS_ENABLED = False
 
 
-def download_from_gcs(gcs_uri: str, destination_path: str, logger: Optional[Any] = None, client: Optional[storage.Client] = None) -> bool:
+def download_from_gcs(gcs_uri: str, destination_path: str, logger: Optional[Any] = None, client: Optional["storage.Client"] = None) -> bool:
     """
     Downloads a file from GCS.
     gcs_uri: gs://bucket_name/object_name

--- a/lib/cuckoo/common/objects.py
+++ b/lib/cuckoo/common/objects.py
@@ -525,7 +525,7 @@ class File:
                     else:
                         # This runs if the inner for loop finishes WITHOUT break (no errors)
                         compiled_rules = compiler.build()
-                        cls.yara_rules[category] = yara_x.Scanner(compiled_rules)
+                        cls.yara_rules[category] = compiled_rules
                         if category == "memory":
                             index_memory = os.path.join(yara_root, "index_memory.yarc")
                             with open(index_memory, "wb") as f:
@@ -620,7 +620,7 @@ class File:
                     return []
 
             if HAVE_YARA_X:
-                yara_results = rules.scan_file(self.file_path)
+                yara_results = yara_x.Scanner(rules).scan_file(self.file_path)
                 for match in yara_results.matching_rules:
                     strings = []
                     addresses = {}

--- a/lib/cuckoo/core/processing_engine/pebble.py
+++ b/lib/cuckoo/core/processing_engine/pebble.py
@@ -4,7 +4,19 @@ autoprocess loop, parameterized behind the engine seam. max_tasks defaults to 0
 joining the nested extractor pool — see the redesign spec."""
 import logging
 import os
+import sys
 import time
+import types
+
+# Workaround for Rust/PyO3 PanicException serialization failures.
+# Since pyo3_runtime is not a real package on disk, we register a dynamic
+# module to allow pickle/unpickle operations of PanicException to succeed.
+if "pyo3_runtime" not in sys.modules:
+    pyo3_runtime = types.ModuleType("pyo3_runtime")
+    class PanicException(BaseException):
+        pass
+    pyo3_runtime.PanicException = PanicException
+    sys.modules["pyo3_runtime"] = pyo3_runtime
 
 import pebble
 from concurrent.futures import TimeoutError
@@ -39,7 +51,7 @@ class PebbleEngine(ProcessingEngine):
     """
 
     def __init__(self, task_fn, worker_init, source, parallel, timeout,
-                 max_tasks=0, max_count=0):
+                max_tasks=0, max_count=0):
         super().__init__(task_fn, worker_init, source, parallel, timeout)
         self.max_tasks = max_tasks
         self.max_count = max_count
@@ -85,7 +97,7 @@ class PebbleEngine(ProcessingEngine):
                     continue
 
                 tasks = self.source.fetch(limit=self.parallel,
-                                          exclude_ids=set(self._pending.values()))
+                                        exclude_ids=set(self._pending.values()))
                 added = False
                 # Schedule at most one task per iteration to avoid overshooting
                 # max_count (same rationale as the original "For loop to add

--- a/lib/cuckoo/core/processing_engine/pebble.py
+++ b/lib/cuckoo/core/processing_engine/pebble.py
@@ -6,17 +6,7 @@ import logging
 import os
 import sys
 import time
-import types
-
-# Workaround for Rust/PyO3 PanicException serialization failures.
-# Since pyo3_runtime is not a real package on disk, we register a dynamic
-# module to allow pickle/unpickle operations of PanicException to succeed.
-if "pyo3_runtime" not in sys.modules:
-    pyo3_runtime = types.ModuleType("pyo3_runtime")
-    class PanicException(BaseException):
-        pass
-    pyo3_runtime.PanicException = PanicException
-    sys.modules["pyo3_runtime"] = pyo3_runtime
+import threading
 
 import pebble
 from concurrent.futures import TimeoutError
@@ -51,15 +41,21 @@ class PebbleEngine(ProcessingEngine):
     """
 
     def __init__(self, task_fn, worker_init, source, parallel, timeout,
-                max_tasks=0, max_count=0):
+                 max_tasks=0, max_count=0, stall_grace=300):
         super().__init__(task_fn, worker_init, source, parallel, timeout)
         self.max_tasks = max_tasks
         self.max_count = max_count
+        self.stall_grace = stall_grace
+        self._lock = threading.Lock()
         self._pending = {}  # future -> task_id
+        self._scheduled_at = {}  # future -> time.monotonic() when scheduled
 
     def _done(self, future):
         """Pebble done-callback: fires in the pool's internal thread."""
-        task_id = self._pending.pop(future, None)
+        with self._lock:
+            task_id = self._pending.pop(future, None)
+            self._scheduled_at.pop(future, None)
+
         try:
             future.result()
             log.info("Reports generation completed for Task #%s", task_id)
@@ -67,8 +63,52 @@ class PebbleEngine(ProcessingEngine):
             log.error("[%s] Processing timeout: %s. Function: %s", task_id, error, error.args[1] if len(error.args) > 1 else "")
             if task_id is not None:
                 self.source.mark_failed(task_id)
-        except (pebble.ProcessExpired, Exception) as error:
+        except BaseException as error:
+            # BaseException, not Exception: anything escaping this callback
+            # propagates into pebble's message-manager thread and kills it.
             log.exception("[%s] Exception when processing task: %s", task_id, error)
+            if task_id is not None:
+                self.source.mark_failed(task_id)
+
+    def _reap_stalled(self):
+        """Fail tasks that were scheduled but never ran.
+
+        pebble only applies a task's timeout once that task is RUNNING. If the
+        worker dies before picking it up, pebble cannot associate the dead
+        worker with any task, so the future never resolves: the task never
+        runs, never times out, is never marked failed, and stays in
+        ``_pending`` forever. Both the scheduling loop (via the saturation
+        check) and the drain loop then spin indefinitely.
+
+        Anything still pending past ``timeout + stall_grace`` is therefore
+        presumed dead and failed explicitly."""
+        if not self.stall_grace:
+            return
+
+        with self._lock:
+            if not self._pending:
+                return
+            pending_keys = list(self._pending.keys())
+
+        deadline = self.timeout + self.stall_grace
+        now = time.monotonic()
+        for future in pending_keys:
+            with self._lock:
+                if future not in self._pending:
+                    continue
+                if now - self._scheduled_at.get(future, now) < deadline:
+                    continue
+                task_id = self._pending.pop(future, None)
+                self._scheduled_at.pop(future, None)
+
+            log.error(
+                "[%s] Task never ran (worker died before pickup?); marking it failed after %ss",
+                task_id, deadline,
+            )
+            try:
+                future.cancel()
+            except Exception:
+                pass
             if task_id is not None:
                 self.source.mark_failed(task_id)
 
@@ -83,6 +123,10 @@ class PebbleEngine(ProcessingEngine):
         with pebble.ProcessPool(max_workers=self.parallel, max_tasks=self.max_tasks,
                                 initializer=self.worker_init) as pool:
             while not self.max_count or count < self.max_count:
+                # Fail anything that was scheduled but never picked up, so a
+                # dead worker can't wedge the saturation check below forever.
+                self._reap_stalled()
+
                 # If not enough free disk space is available, block until space
                 # is reclaimed.  Mirrors the original autoprocess freespace check
                 # (only when cfg.cuckoo.freespace_processing is non-zero).
@@ -92,12 +136,15 @@ class PebbleEngine(ProcessingEngine):
                     free_space_monitor(dir_path, processing=True)
 
                 # If the pool is saturated, wait before polling again.
-                if len(self._pending) >= self.parallel:
+                with self._lock:
+                    pending_count = len(self._pending)
+                if pending_count >= self.parallel:
                     time.sleep(1)
                     continue
 
-                tasks = self.source.fetch(limit=self.parallel,
-                                        exclude_ids=set(self._pending.values()))
+                with self._lock:
+                    exclude = set(self._pending.values())
+                tasks = self.source.fetch(limit=self.parallel, exclude_ids=exclude)
                 added = False
                 # Schedule at most one task per iteration to avoid overshooting
                 # max_count (same rationale as the original "For loop to add
@@ -105,7 +152,9 @@ class PebbleEngine(ProcessingEngine):
                 for task in tasks:
                     log.info("Processing analysis data for Task #%d", task.id)
                     future = pool.schedule(self.task_fn, args=(task,), timeout=self.timeout)
-                    self._pending[future] = task.id
+                    with self._lock:
+                        self._pending[future] = task.id
+                        self._scheduled_at[future] = time.monotonic()
                     future.add_done_callback(self._done)
                     count += 1
                     added = True
@@ -120,5 +169,10 @@ class PebbleEngine(ProcessingEngine):
                     break
 
             # Drain: wait for all in-flight tasks to finish before returning.
-            while self._pending:
+            while True:
+                with self._lock:
+                    pending_exists = bool(self._pending)
+                if not pending_exists:
+                    break
+                self._reap_stalled()
                 time.sleep(0.2)

--- a/lib/cuckoo/core/processing_engine/prefork.py
+++ b/lib/cuckoo/core/processing_engine/prefork.py
@@ -202,7 +202,12 @@ class PreforkEngine(ProcessingEngine):
             launchable = free if not self.max_count else min(free, self.max_count - count)
             launched = 0
             if launchable > 0:
-                tasks = self.source.fetch(limit=launchable, exclude_ids=self._inflight_task_ids())
+                try:
+                    tasks = self.source.fetch(limit=launchable, exclude_ids=self._inflight_task_ids())
+                except Exception as db_error:
+                    log.error("Database connection error during task fetch: %s. Retrying in 10s...", db_error)
+                    time.sleep(10)
+                    continue
                 for task in tasks[:launchable]:
                     self._launch(task)
                     count += 1

--- a/tests/test_pebble_engine.py
+++ b/tests/test_pebble_engine.py
@@ -1,6 +1,7 @@
 import functools
 import os
 import pickle
+import time
 
 from lib.cuckoo.core.data.task import TASK_COMPLETED
 from lib.cuckoo.core.processing_engine.pebble import PebbleEngine
@@ -56,3 +57,104 @@ def test_autoprocess_task_fn_is_picklable():
     from utils.process import run_task
     task_fn = functools.partial(run_task, memory_debugging=False, debug=False)
     pickle.dumps(task_fn)  # would raise PicklingError for a lambda
+
+
+class _CountingSource:
+    def __init__(self):
+        self.failed = []
+
+    def mark_failed(self, task_id):
+        self.failed.append(task_id)
+
+
+class _MockFuture:
+    def __init__(self):
+        self._cancelled = False
+
+    def cancel(self):
+        self._cancelled = True
+        return True
+
+    def result(self):
+        return None
+
+
+class _BaseExceptionRaisingFuture(_MockFuture):
+    def result(self):
+        raise BaseException("panic!")
+
+
+def test_reaper_fails_a_task_that_was_never_picked_up():
+    source = _CountingSource()
+    engine = PebbleEngine(
+        task_fn=lambda t: None,
+        worker_init=lambda: None,
+        source=source,
+        parallel=1,
+        timeout=1,
+        stall_grace=1
+    )
+    future = _MockFuture()
+    
+    with engine._lock:
+        engine._pending[future] = 77
+        engine._scheduled_at[future] = time.monotonic() - 3600  # long overdue
+
+    engine._reap_stalled()
+
+    with engine._lock:
+        assert engine._pending == {}, "overdue task left in _pending"
+        assert engine._scheduled_at == {}, "overdue task left in _scheduled_at"
+    assert source.failed == [77], "overdue task was never marked failed"
+    assert future._cancelled, "overdue task future was not cancelled"
+
+
+def test_reaper_leaves_a_task_that_is_still_within_its_deadline():
+    source = _CountingSource()
+    engine = PebbleEngine(
+        task_fn=lambda t: None,
+        worker_init=lambda: None,
+        source=source,
+        parallel=1,
+        timeout=10,
+        stall_grace=5
+    )
+    future = _MockFuture()
+    
+    with engine._lock:
+        engine._pending[future] = 88
+        engine._scheduled_at[future] = time.monotonic()  # brand new
+
+    engine._reap_stalled()
+
+    with engine._lock:
+        assert engine._pending == {future: 88}, "in-flight task was reaped early"
+        assert engine._scheduled_at == {future: engine._scheduled_at[future]}, "in-flight task scheduled_at cleared"
+    assert source.failed == [], "in-flight task was marked failed"
+    assert not future._cancelled, "in-flight task future was cancelled"
+
+
+def test_done_handles_base_exception_robustly():
+    source = _CountingSource()
+    engine = PebbleEngine(
+        task_fn=lambda t: None,
+        worker_init=lambda: None,
+        source=source,
+        parallel=1,
+        timeout=10,
+        stall_grace=5
+    )
+    future = _BaseExceptionRaisingFuture()
+    
+    with engine._lock:
+        engine._pending[future] = 99
+        engine._scheduled_at[future] = time.monotonic()
+
+    # _done should handle the BaseException from future.result() and not raise/propagate it.
+    engine._done(future)
+
+    with engine._lock:
+        assert future not in engine._pending, "future not removed from pending"
+        assert future not in engine._scheduled_at, "future not removed from scheduled_at"
+    assert source.failed == [99], "task was not marked failed on BaseException"
+

--- a/utils/dist.py
+++ b/utils/dist.py
@@ -4,7 +4,6 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-# https://github.com/cuckoosandbox/cuckoo/pull/1694/files
 import argparse
 import distutils.util
 import hashlib
@@ -1228,9 +1227,21 @@ class StatusThread(threading.Thread):
                     # print(t.category, t.target)
                     if t.category in ("file", "pcap", "static"):
                         if not path_exists(t.target):
-                            log.info("Task id: %d - File doesn't exist: %s", t.id, t.target)
-                            main_db.set_status(t.id, TASK_BANNED)
-                            continue
+                            sample_sha256 = None
+                            try:
+                                if t.sample:
+                                    sample_sha256 = t.sample.sha256
+                            except Exception as e:
+                                log.debug("Failed to lazy load sample relation for task %d: %s", t.id, e)
+
+                            bin_path = os.path.join(CUCKOO_ROOT, "storage", "binaries", sample_sha256) if sample_sha256 else None
+                            if bin_path and path_exists(bin_path):
+                                log.info("Task id: %d - Target file not found at original path, but found in binaries storage: %s. Updating target path.", t.id, bin_path)
+                                t.target = bin_path
+                            else:
+                                log.info("Task id: %d - File doesn't exist: %s", t.id, t.target)
+                                main_db.set_status(t.id, TASK_BANNED)
+                                continue
                         if not web_conf.general.allow_ignore_size and "ignore_size_check" not in t.options:
                             # We can't upload size bigger than X to our workers. In case we extract archive that contains bigger file.
                             file_size = path_get_size(t.target)

--- a/utils/process.py
+++ b/utils/process.py
@@ -197,15 +197,22 @@ def run_task(task, memory_debugging=False, debug=False):
             if sample:
                 sample_hash = sample.sha256
     try:
-        process(
-            task.target,
-            sample_hash,
-            report=True,
-            auto=True,
-            task=task,
-            memory_debugging=memory_debugging,
-            debug=debug,
-        )
+        try:
+            process(
+                task.target,
+                sample_hash,
+                report=True,
+                auto=True,
+                task=task,
+                memory_debugging=memory_debugging,
+                debug=debug,
+            )
+        except Exception:
+            raise
+        except BaseException as e:
+            import traceback
+            tb = "".join(traceback.format_exception(type(e), e, e.__traceback__))
+            raise RuntimeError(f"{type(e).__module__}.{type(e).__name__}: {e}\n\n{tb}") from None
     finally:
         set_formatter_fmt()
         setproctitle(original_proctitle)


### PR DESCRIPTION
Added a workaround for PanicException serialization failures by dynamically registering a module. This allows for successful pickle/unpickle operations.

@wmetcalf can you review it? without this it just breaks process.py for me