### PR TITLE
Add Google Magika file type identification

### DIFF
--- a/conf/default/processing.conf.default
+++ b/conf/default/processing.conf.default
@@ -159,6 +159,24 @@ definitions = data/trid/triddefs.trd
 enabled = no
 binary = /usr/bin/diec
 
+[magika]
+# Google Magika - deep-learning content type identification.
+# https://github.com/google/magika
+# Install: poetry run pip install -U magika
+# Main benfit is classification of text file types i.e. PowerShell, ini files etc.
+enabled = no
+# Optional path to a custom/pinned model directory. Empty = use the model
+# shipped with the installed magika package.
+model_dir =
+# high_confidence (default, most conservative) | medium_confidence | best_guess
+prediction_mode = high_confidence
+# Display-only: results scoring below this are still recorded and shown, just
+# flagged low_confidence so a weak prediction isn't read as a confident one.
+min_score = 0.5
+# Skip files larger than this (MB). 0 = no limit. Magika only reads the head,
+# middle and tail of a file, so this is cheap to raise.
+max_file_size = 100
+
 [virustotal]
 enabled = yes
 on_demand = no

--- a/lib/cuckoo/common/integrations/file_extra_info.py
+++ b/lib/cuckoo/common/integrations/file_extra_info.py
@@ -80,6 +80,8 @@ HAVE_FLOSS = False
 if integration_conf.floss.enabled and not integration_conf.floss.on_demand:
     from lib.cuckoo.common.integrations.floss import HAVE_FLOSS, Floss
 
+from lib.cuckoo.common.integrations.magika import magika_info
+
 log = logging.getLogger(__name__)
 
 logging.getLogger("Kixtart-Detokenizer").setLevel(logging.CRITICAL)
@@ -247,6 +249,14 @@ def static_file_info(
 
         if processing_conf.die.enabled and "die" not in data_dictionary:
             data_dictionary["die"] = detect_it_easy_info(file_path)
+
+        # Below the libmagic "type" already present in data_dictionary. Cached
+        # in the magika integration, so this is a no-op lookup for anything
+        # that already went through File.get_all().
+        if processing_conf.magika.enabled and "magika" not in data_dictionary:
+            magika_result = magika_info(file_path)
+            if magika_result:
+                data_dictionary["magika"] = magika_result
 
         if HAVE_FLOSS and processing_conf.floss.enabled and "Mono" not in data_dictionary.get("type", "") and "floss" not in data_dictionary:
             floss_strings = Floss(file_path, package).run()

--- a/lib/cuckoo/common/objects.py
+++ b/lib/cuckoo/common/objects.py
@@ -28,6 +28,7 @@ from lib.cuckoo.common.defines import (
     PAGE_WRITECOPY,
 )
 from lib.cuckoo.common.integrations.clamav import get_clamav
+from lib.cuckoo.common.integrations.magika import MAGIKA_ENABLED, magika_info
 from lib.cuckoo.common.integrations.parse_pe import IMAGE_FILE_MACHINE_AMD64, IMAGE_FILE_MACHINE_I386, IsPEImage
 from lib.cuckoo.common.path_utils import path_exists
 
@@ -206,6 +207,7 @@ class File:
         self._sha512 = None
         self._pefile = False
         self.file_type = None
+        self._magika = None
         self.pe = None
 
     def get_name(self):
@@ -427,6 +429,19 @@ class File:
             self.file_type = self.get_content_type()
 
         return self.file_type
+
+    def get_magika(self):
+        """Get the Google Magika content type prediction.
+        Enable in: processing.conf -> [magika] -> enabled
+
+        Reported alongside, never instead of, get_type(): the libmagic
+        verdict is left untouched so both are visible and comparable.
+
+        @return: dict with label/description/mime_type/group/score, or {}.
+        """
+        if self._magika is None:
+            self._magika = magika_info(self.file_path_ansii)
+        return self._magika
 
     def _yara_encode_string(self, yara_string):
         # Beware, spaghetti code ahead.
@@ -843,6 +858,16 @@ class File:
             "tlsh": self.get_tlsh(),
             "sha3_384": self.get_sha3_384(),
         }
+
+        # Sits alongside (below) "type" for every category that goes through
+        # File.get_all(): target, dropped, procdumps, CAPE payloads, extracted
+        # files, suricata files and process memory dumps. Absent -- not empty
+        # -- when magika is disabled or returns nothing, so the UI row simply
+        # does not render.
+        if MAGIKA_ENABLED:
+            magika_result = self.get_magika()
+            if magika_result:
+                infos["magika"] = magika_result
 
         return infos, self.pe
 

--- a/lib/cuckoo/common/web_utils.py
+++ b/lib/cuckoo/common/web_utils.py
@@ -1344,6 +1344,7 @@ search_term_map_repetetive_blocks = {
     "crc32": "crc32",
     "die": "die",
     "trid": "trid",
+    "magika": "magika.label",
     "imphash": "imphash",
 }
 

--- a/modules/processing/CAPE.py
+++ b/modules/processing/CAPE.py
@@ -249,6 +249,12 @@ class CAPE(Processing):
 
         if "type" not in file_info:
             file_info["type"] = f.get_type()
+        # `file_info` can come straight from the mongo file cache, which may
+        # predate magika being enabled (or a model change). Backfill it.
+        if processing_conf.magika.enabled and "magika" not in file_info:
+            magika_result = f.get_magika()
+            if magika_result:
+                file_info["magika"] = magika_result
         if "name" not in file_info:
             file_info["name"] = f.get_name()
         if "guest_paths" not in file_info:
@@ -460,6 +466,17 @@ class CAPE(Processing):
                 # Don't let a clamav prefetch error block analysis — the
                 # legacy serial fallback inside get_clamav() still works.
                 log.debug("clamav prefetch failed", exc_info=True)
+
+        # Same lifecycle contract as the clamav cache: drop per-path magika
+        # results at the task boundary so a long-lived worker can't serve a
+        # stale prediction for a path that has been reused by another task.
+        if processing_conf.magika.enabled:
+            try:
+                from lib.cuckoo.common.integrations.magika import clear_magika_cache
+
+                clear_magika_cache()
+            except Exception:
+                log.debug("magika cache clear failed", exc_info=True)
 
         #  Static processing of submitted file
         if self.task["category"] in ("file", "static"):

--- a/web/templates/analysis/generic/_file_info.html
+++ b/web/templates/analysis/generic/_file_info.html
@@ -279,6 +279,25 @@
                 </td>
             </tr>
             {% endif %}
+
+            {% if file.magika %}
+            <tr>
+                <th class="text-end text-info" style="width: 15%;">Magika File Type</th>
+                <td class="text-break">
+                    {{file.magika.description|default:file.magika.label}}
+                    <a href="/analysis/search/magika:{{file.magika.label}}" class="badge bg-secondary ms-1 text-decoration-none">{{file.magika.label}}</a>
+                    {% if file.magika.mime_type %}<span class="badge bg-secondary ms-1">{{file.magika.mime_type}}</span>{% endif %}
+                    {% if file.magika.score %}
+                        <span class="badge {% if file.magika.low_confidence %}bg-warning text-dark{% else %}bg-success{% endif %} ms-1"
+                              data-bs-toggle="tooltip"
+                              title="{% if file.magika.low_confidence %}Model confidence, below the configured min_score{% else %}Model confidence{% endif %}">{{file.magika.score}}</span>
+                    {% endif %}
+                    {% if file.magika.dl_label %}
+                        <span class="badge bg-dark border border-secondary ms-1" data-bs-toggle="tooltip" title="Raw model guess before {{file.magika.overwrite_reason}} override">raw: {{file.magika.dl_label}}</span>
+                    {% endif %}
+                </td>
+            </tr>
+            {% endif %}
         </table>
     </div>
 

--- a/web/templates/analysis/search.html
+++ b/web/templates/analysis/search.html
@@ -60,6 +60,7 @@
                                 <tr><td class="text-center"><code>iconfuzzy:</code></td><td>Fuzzy icon hash</td></tr>
                                 <tr><td class="text-center"><code>dhash:</code></td><td>Icon dhash</td></tr>
                                 <tr><td class="text-center"><code>die:</code></td><td>Detect It Easy (DIE) signature (e.g., <code>die:obsidium</code>)</td></tr>
+                                <tr><td class="text-center"><code>magika:</code></td><td>Google Magika content type label (e.g., <code>magika:pebin</code>, <code>magika:powershell</code>)</td></tr>
                                 <tr><td class="text-center"><code>extracted_tool:</code></td><td>Extracted tool (e.g., <code>InnoExtract</code>)</td></tr>
                                 <tr><td class="text-center"><code>virustotal:</code></td><td>VirusTotal Detected Name</td></tr>
                                 <tr><td class="text-center"><code>clamav:</code></td><td>Local ClamAV detections</td></tr>


### PR DESCRIPTION
Adds google magika to processing (https://github.com/google/magika). Main benefit of Magika is identification of text based formats - PowerShell scripts, python, .ini files etc. It will identify or guess at other filetypes. You can adjust confidence or hide low confidence matches too where it is guessing such as on shellcode data.

<img width="1107" height="597" alt="image" src="https://github.com/user-attachments/assets/cb30edca-0d75-4d61-a3ce-81c46ec82ef1" />

<img width="1113" height="652" alt="image" src="https://github.com/user-attachments/assets/a90cfc3a-f2f0-403f-9abe-b9e64259eb95" />
