### PR TITLE
Ability to disable ratelimit when token authentication is enabled

### DIFF
--- a/web/web/settings.py
+++ b/web/web/settings.py
@@ -356,12 +356,16 @@ if api_cfg.api.token_auth_enabled:
     REST_FRAMEWORK = {
         "DEFAULT_AUTHENTICATION_CLASSES": _api_auth_classes,
         "DEFAULT_PERMISSION_CLASSES": ("rest_framework.permissions.IsAuthenticated",),
-        "DEFAULT_THROTTLE_CLASSES": ["apiv2.throttling.SubscriptionRateThrottle"],
-        "DEFAULT_THROTTLE_RATES": {
-            "user": api_cfg.api.default_user_ratelimit,
-            "subscription": api_cfg.api.default_subscription_ratelimit,
-        },
     }
+
+    if api_cfg.api.ratelimit:
+        REST_FRAMEWORK.update({
+            "DEFAULT_THROTTLE_CLASSES": ["apiv2.throttling.SubscriptionRateThrottle"],
+            "DEFAULT_THROTTLE_RATES": {
+                "user": api_cfg.api.default_user_ratelimit,
+                "subscription": api_cfg.api.default_subscription_ratelimit,
+            },
+        })
 
 else:
     REST_FRAMEWORK = {


### PR DESCRIPTION
By default it's still turned on, this PR adds ability to turn it of in the custom config via already defined `ratelimit` config entry (that I didn't see used right now and I believe it's intention was to provide this functionality).