### PR TITLE
Fix netlog argument conversion

### DIFF
--- a/lib/cuckoo/common/netlog.py
+++ b/lib/cuckoo/common/netlog.py
@@ -276,7 +276,7 @@ class BsonParser:
                     log.warning("Inconsistent arg count (compared to arg names) on %s: %s names %s", dec, argnames, apiname)
                     continue
 
-                argdict = {argnames[i]: converters[i](arg) for i, arg in enumerate(args)}
+                argdict = {name: conv(arg) for name, conv, arg in zip(argnames, converters, args)}
 
                 if apiname == "__process__":
                     # Special new process message from cuckoomon.
@@ -408,8 +408,7 @@ class ProtobufParser:
 
             arguments = []
             if len(call.arguments) == len(argnames):
-                 for i, val in enumerate(call.arguments):
-                     arguments.append((argnames[i], converters[i](val)))
+                arguments = [(name, conv(val)) for name, conv, val in zip(argnames, converters, call.arguments)]
 
             self.fd.log_call(context, apiname, category, arguments)
 

--- a/lib/cuckoo/common/utils.py
+++ b/lib/cuckoo/common/utils.py
@@ -818,10 +818,9 @@ def sanitize_filename(x: str):
 
 
 def default_converter(v):
-    # Fix signed ints (bson is kind of limited there).
-    # Need to account for subclasses since pymongo's bson module
-    # uses 'bson.int64.Int64' clwhat ass for 64-bit values.
-    if isinstance(v, int) or issubclass(type(v), int):
+    # Fix signed ints (bson is limited there).
+    # Since pymongo's Int64 inherits from int, isinstance(v, int) is fully sufficient.
+    if isinstance(v, int):
         return v & 0xFFFFFFFFFFFFFFFF if v & 0xFFFFFFFF00000000 else v & 0xFFFFFFFF
     return v
 


### PR DESCRIPTION
Align BSON and Protobuf argument parsing with the matching argument names, converters, and values instead of relying on positional indexing. This prevents mismatches when argument lists are not perfectly aligned and ensures parsed call arguments remain consistent. The integer converter was also simplified to use isinstance(int), while still preserving the expected 64-bit signed-int handling.