### PR TITLE
fix: 'force_int' - remove return in finally (PEP 765) and dedupe definition

### DIFF
--- a/lib/cuckoo/common/web_utils.py
+++ b/lib/cuckoo/common/web_utils.py
@@ -1663,11 +1663,9 @@ def perform_search(
 
 def force_int(value):
     try:
-        value = int(value)
+        return int(value)
     except Exception:
-        value = 0
-    finally:
-        return value
+        return 0
 
 
 def force_bool(value):

--- a/web/submission/views.py
+++ b/web/submission/views.py
@@ -31,7 +31,6 @@ from lib.cuckoo.common.web_utils import (
     download_file,
     download_from_3rdparty,
     downloader_services,
-    force_int,
     get_file_content,
     load_vms_exits,
     load_vms_tags,

--- a/web/submission/views.py
+++ b/web/submission/views.py
@@ -31,6 +31,7 @@ from lib.cuckoo.common.web_utils import (
     download_file,
     download_from_3rdparty,
     downloader_services,
+    force_int,
     get_file_content,
     load_vms_exits,
     load_vms_tags,
@@ -284,15 +285,6 @@ class conditional_login_required:
         if not self.condition:
             return func
         return self.decorator(func)
-
-
-def force_int(value):
-    try:
-        value = int(value)
-    except Exception:
-        value = 0
-    finally:
-        return value
 
 
 @conditional_login_required(login_required, settings.WEB_AUTHENTICATION)


### PR DESCRIPTION
1. Rewrote `force_int` so it returns directly from try/except instead of return inside a finally (PEP 765, `SyntaxWarning` in Python 3.14)
2. Remove duplicated implementation in `web/submission/views.py` (dead code)
