### PR TITLE
Detect API spamming in behavior analysis and prompt user to resubmit with exclude-apis

### DIFF
--- a/conf/default/processing.conf.default
+++ b/conf/default/processing.conf.default
@@ -33,6 +33,11 @@ enabled = no
 enabled = no
 
 [behavior]
+# Detect API spamming and suggest exclude-apis in the web interface
+detect_apispam = yes
+# Limit at which to consider an API as spammed (default limit in capemon is 256 / 0x100)
+apispam_limit = 256
+
 enabled = yes
 # Toggle specific modules within the BehaviorAnalysis class
 anomaly = yes

--- a/modules/processing/behavior.py
+++ b/modules/processing/behavior.py
@@ -44,6 +44,7 @@ from lib.cuckoo.common.utils import (
     bytes2str,
     convert_to_printable,
     default_converter,
+    get_options,
     logtime,
     pretty_print_arg,
     pretty_print_retval,
@@ -526,7 +527,7 @@ class Summary:
 
     key = "summary"
 
-    def __init__(self, options):
+    def __init__(self, options, task=None):
         self.keys = []
         self.read_keys = []
         self.write_keys = []
@@ -540,7 +541,9 @@ class Summary:
         self.created_services = []
         self.executed_commands = []
         self.resolved_apis = []
+        self.api_counts = defaultdict(int)
         self.options = options
+        self.task = task
 
         self.dispatch = {
             "NtCreateKey": self._handle_NtCreateKey,
@@ -740,6 +743,7 @@ class Summary:
         @return: None.
         """
         api = call["api"]
+        self.api_counts[api] += 1
         handler = self.dispatch.get(api)
         if handler:
             handler(call, process)
@@ -813,6 +817,27 @@ class Summary:
         """Get registry keys, mutexes and files.
         @return: Summary of keys, read keys, written keys, mutexes and files.
         """
+        detect_apispam = getattr(self.options, "detect_apispam", True)
+        apispam_limit = int(getattr(self.options, "apispam_limit", 256))
+
+        apispam = []
+        apispam_exclude_apis = ""
+
+        if detect_apispam:
+            apispam = [api for api, count in self.api_counts.items() if count >= apispam_limit]
+
+            if apispam and self.task:
+                task_options = self.task.get("options", "")
+                if isinstance(task_options, str):
+                    parsed_options = get_options(task_options)
+                else:
+                    parsed_options = task_options or {}
+                
+                existing_exclude = parsed_options.get("exclude-apis", "")
+                existing = existing_exclude.split(":") if existing_exclude else []
+                merged = sorted(list(set(existing + apispam)))
+                apispam_exclude_apis = ":".join(merged)
+
         return {
             "files": self.files,
             "read_files": self.read_files,
@@ -827,6 +852,8 @@ class Summary:
             "mutexes": self.mutexes,
             "created_services": self.created_services,
             "started_services": self.started_services,
+            "apispam": apispam,
+            "apispam_exclude_apis": apispam_exclude_apis,
         }
 
 
@@ -1511,7 +1538,7 @@ class BehaviorAnalysis(Processing):
             instances = [
                 Anomaly(),
                 ProcessTree(),
-                Summary(self.options),
+                Summary(self.options, task=self.task),
                 Enhanced(),
                 EncryptedBuffers(),
                 NetworkMap(),

--- a/web/templates/analysis/overview/_info.html
+++ b/web/templates/analysis/overview/_info.html
@@ -1,5 +1,19 @@
 <section id="information" class="mb-4">
 
+    <!-- API Spam Warning -->
+    {% if analysis.behavior.summary.apispam %}
+        <div class="alert alert-warning text-center" role="alert">
+            <h5 class="alert-heading font-weight-bold"><i class="fas fa-exclamation-triangle"></i> API Spam Detected</h5>
+            <p class="mb-2">This analysis generated an excessive number of identical API calls for the following APIs: 
+                <strong>{{ analysis.behavior.summary.apispam|join:", " }}</strong>.
+            </p>
+            <p class="mb-0">
+                To improve analysis performance and avoid log truncation, consider resubmitting the file with the following exclusion options:<br>
+                <code class="d-inline-block p-2 mt-2 bg-dark text-white rounded user-select-all">exclude-apis={{ analysis.behavior.summary.apispam_exclude_apis }}</code>
+            </p>
+        </div>
+    {% endif %}
+
     <!-- Detections Badge Container -->
     {% if analysis.detections %}
         <div class="text-center mb-3">


### PR DESCRIPTION
This PR adds logic to detect API spamming (default threshold 256 / 0x100) and displays a warning to the user on the summary overview, allowing them to easily copy a tailored exclude-apis option for their resubmission.