### PR TITLE
Fix optional tenancy access checks

### DIFF
--- a/docs/book/src/usage/index.rst
+++ b/docs/book/src/usage/index.rst
@@ -11,6 +11,7 @@ This chapter explains how to use CAPE.
     internals
     submit
     web
+    multitenancy
     api
     audit
     dist

--- a/docs/book/src/usage/multitenancy.rst
+++ b/docs/book/src/usage/multitenancy.rst
@@ -1,0 +1,167 @@
+Multitenancy — Supported Configurations & Boundaries
+====================================================
+
+Multitenancy (the ````[multitenancy]```` section of ````cuckoo.conf````) scopes every read
+surface so a user of one tenant cannot see or act on another tenant's tasks,
+samples, reports, artifacts, statistics, search results, or live-VM (Guacamole)
+sessions. This document states exactly which deployment modes that guarantee
+covers today, and what is intentionally **fail-closed** (safe but limited) until
+support is added.
+
+Enabling on an existing (populated) install — run the backfill
+--------------------------------------------------------------
+
+Turning ````enabled = yes```` stamps tenant/visibility onto **new** analyses only. Reports
+already in MongoDB have no ````info.tenant_id```` / ````info.user_id```` / ````info.visibility````
+stamp, so the scoped search / statistics / compare surfaces treat them as
+**fail-closed / invisible** to every tenant (no leak, but the history disappears
+from those views) until they are stamped. Run the one-shot backfill once, after
+flipping the flag:
+
+.. code-block:: none
+
+    python utils/db_migration/mongo_backfill_tenant.py
+
+It reads each selected ````analysis```` doc's Postgres task and writes
+````info.tenant_id```` / ````info.user_id```` / ````info.visibility```` (orphans whose task was pruned
+fail closed to ````private````), and creates the ````tenant_scope_idx```` index. It touches only
+(a) un-stamped docs (missing ````info.visibility````, first-enable) and (b) crash-orphans in
+the exact reporter fail-closed shape (````visibility=private```` + null ````tenant_id```` AND
+````user_id````) — never a stamped permissive doc — so it stays idempotent and safe to re-run.
+In a **central** deployment run it on the CENTRAL node **while quiesced**: it only
+restamps docs whose id space matches the node (broker ````ui-*```` ids ⇔ central RDS;
+worker-local ids ⇔ single-node), and it is not lock-serialized against a live toggle.
+The Alembic migration backfills the **SQL** columns only — the mongo stamp is this
+separate step. A fresh install needs no backfill (every report is stamped at
+creation).
+
+Supported (isolation enforced end-to-end)
+-----------------------------------------
+
+* **Report store: MongoDB.** MT scoping of the aggregate/search/statistics/
+  compare surfaces reads the tenant stamp (````info.tenant_id```` / ````info.user_id```` /
+  ````info.visibility````) written into the mongo analysis document. **MongoDB is
+  required for multitenancy.**
+* **Single-node CAPE** (one host running web + processing + analysis).
+* **Central control plane + broker workers** (the "central mode" path): the
+  central UI serves artifacts staged from workers, keyed by the broker ````job_id````.
+  Tenant stamping works across this path **only when workers can resolve the
+  submitter's tenancy from the central control-plane DB**: a worker's own
+  ````[database]```` is its LOCAL per-worker task DB (a different id space), and
+  ````centralstore```` rewrites ````info.id```` to the CENTRAL task id, so the worker resolves
+  and stamps tenancy against the central RDS via ````[central_mode] central_database_url````.
+  If that URL is unset, central-mode analyses stamp **fail-closed** (private / unowned
+  — invisible to everyone but break-glass), never leaked. Point ````central_database_url````
+  at the **writer/primary** endpoint (the same Postgres the central node uses as its
+  ````[database]````), NOT a read replica: the worker's post-write reconcile takes its
+  per-task advisory lock there to serialize with the central node's visibility toggle
+  (advisory locks are cluster-wide, so same-key locks on the same primary mutually
+  exclude). If it points at a standby, ````pg_advisory_lock```` wouldn't exclude the primary
+  and the re-read would be replication-lag stale — the worker detects
+  ````pg_is_in_recovery()````, warns, and runs unserialized-but-fail-closed, leaving a narrow
+  reprocess-during-toggle re-widen window (still no persistent leak: the fail-closed
+  insert + backfill keep it safe).
+* **Guacamole interactive sessions** for task-backed analyses: minting a live-VM
+  session (and the WebSocket tunnel re-check) is gated by ````can_manage_task````
+  (owner / tenant-admin / break-glass), NOT mere read visibility — live keyboard/
+  mouse/framebuffer control is a task action, so a read-only viewer of a public/
+  tenant task cannot tunnel into another user's or tenant's VM.
+
+Not yet supported (fail-closed — safe, but limited)
+---------------------------------------------------
+
+These modes do **not** carry tenant context correctly. Rather than leak, MT
+**fails closed** on them (data is stamped private / invisible, or the surface is
+admin-only), so enabling MT on these modes is safe but the affected analyses
+will simply not be visible. Adding real support is tracked as future work.
+
+* **Elasticsearch report store.** The visibility toggle syncs the tenant stamp
+  only to MongoDB; an ES-backed install would not update the ES stamp, and the ES
+  statistics aggregates cannot be per-record gated. **Run MT with MongoDB.** (An
+  ES bool-filter analogue of the scope predicate exists but is unexercised.)
+* **Legacy distributed (````utils/dist.py````).** The main→worker submission does not
+  forward tenant/user/visibility, so a distributed worker cannot stamp the shared
+  mongo document correctly. When a worker processes a distributed task
+  (````options.main_task_id```` set), the report is stamped **private/invisible**
+  (fail-closed) instead of world-visible. Use the broker/central path for
+  distributed multitenant analysis. (Our central path keys by ````job_id```` and never
+  sets ````main_task_id````, so it is unaffected.)
+
+Behavior notes
+--------------
+
+* **Statistics API shape (shared mode).** With MT enabled in ````shared```` mode, the
+  ````apiv2```` statistics endpoint returns **per-scope** results
+  (````data['public']````, ````data['tenant']````, ````data['mine']````) instead of the legacy flat
+  ````data['signatures']````. This is the correct scoped behavior; it is a breaking
+  change for API clients that assumed the flat shape on an MT-shared install.
+  Multitenancy-disabled installs and break-glass local-admins still receive the
+  flat dict.
+* **Direct VNC / VM operator console.** The task-less direct-console endpoints
+  (````task_id=0````: raw host:port VNC, plus VM console/start/shutdown/route/snapshot
+  by name) have no tenant scoping and mint sessions the per-task tunnel gate does
+  not cover, so **all** of them are restricted to break-glass admins
+  (````viewer_for(user).is_local_admin````) in addition to the existing config gate —
+  never a tenant user. (On an MT-disabled / no-auth install every principal is a
+  local-admin, so the operator console stays usable.)
+* **Threat-hunt facets.** ````hunt()```` scopes its aggregation by the viewer's entitled
+  scopes (````viewer_scope```` ````$match````); its facet ````task_ids```` rely on that stamp-based
+  ````$match```` with no per-id SQL backstop (a ````$facet```` count can't be post-filtered
+  per task). This is safe because the report tenant stamp is written fail-closed
+  on every path, so a doc can't carry a spoofed cross-tenant stamp.
+* **Modes:** ````shared```` (public pool + own tenant + own tasks) and ````locked````
+  (tenant-isolated). An unknown/typo ````mode```` fails closed to ````locked````.
+
+Architecture & Implementation Review
+------------------------------------
+
+A systematic security and architecture audit of CAPEv2's multi-tenancy implementation across the entire Django web layer (````web/analysis```` and ````web/apiv2````) confirms that the design is exceptionally mature, secure, and rigorously defended against cross-tenant data leaks. It operates on a robust, defense-in-depth model containing several layers:
+
+1. Core Logic Predicates
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+At the core layer, tenancy is decoupled from any specific database or web framework. It defines the foundational permission boundaries using pure Python dataclasses and pure functions:
+
+* **````Viewer```` Dataclass:** Captures the authenticated client's security context (e.g., ````user_id````, ````tenant_id````, and privilege markers ````is_superuser````, ````is_tenant_admin````, ````is_local_admin````).
+* **````Job```` Dataclass:** Represents the target task’s metadata (````owner_id````, ````tenant_id````, and ````visibility````).
+* **Pure Predicates:**
+  * ````can_read(Viewer, Job)````: Denies access to other tenants' private or tenant-level tasks.
+  * ````can_toggle(Viewer, Job)````: Controls general metadata updates.
+  * ````can_delete(Viewer, Job)````: Stricter than can_toggle; prevents tenant-admins from deleting public/shared tasks they do not own to avoid destructive actions on shared pools.
+  * ````can_set_visibility(Viewer, Job, new_visibility)````: Controls state transitions, blocking tenant-admins from converting non-owned public tasks into private/tenant tasks to bypass deletion restrictions.
+
+2. Django-to-Core Bridge & Fail-Closed Facade
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Bridges Django’s ````request.user```` into the core tenancy system cleanly and safely:
+
+* **````viewer_for(user)```` (````web/users/tenancy.py````):** Resolves the user context, strictly checking ````cuckoo.conf```` policy. If ````local_admins_manage_all_tenants```` is off, only superusers authenticated via an external IdP (with an Allauth SocialAccount) keep cross-tenant admin reach. Non-IdP superusers (like those created via ````createsuperuser````) are bound to their tenant, preventing local privilege escalation.
+* **````web/web/tenancy_optional.py````:** An import-optional facade acting as a safeguard. If an ````ImportError```` occurs or dependencies break, it queries ````_mt_enabled()```` to check if tenancy is enabled. If enabled, it **fails closed** (blocking permissions) rather than falling open to legacy wide-open (see-all) access.
+
+3. Endpoint Decorators & Access Guards
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Every task-scoped endpoint is guarded by either robust decorators or explicit rejection helpers:
+
+* **Decorators (````@require_task_visibility````, ````@require_task_manage````, ````@require_task_delete````):** Protect analysis views in ````web/analysis/views.py````. Unauthorized or non-existent tasks return the **exact same 403 Forbidden ("Not found") response**, completely preventing cross-tenant task ID enumeration.
+* **Helpers (````_deny_if_hidden````, ````_deny_task````, ````_deny_manage````, ````_deny_by_hash````):** Utilized by API endpoints in ````web/apiv2/views.py````.
+  * ````_deny_if_hidden```` returns an indistinguishable ````404 Task not found```` for both missing and hidden tasks.
+  * ````_deny_by_hash```` ensures payload/file downloads are restricted unless the requesting user has at least one visible task referencing that specific file hash.
+
+4. Data-Layer Query Scoping (Database Isolation)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Filters are injected directly into queries to prevent unauthorized data from ever leaving the database:
+
+* **PostgreSQL/MySQL (SQLAlchemy):** ````Database.list_tasks```` and ````count_matching_tasks```` inject explicit tenant restriction clauses directly into SQL statements based on the ````visible_to```` parameter.
+* **MongoDB:** All document-level lookups route through ````scoped_analysis_query```` (aliased as ````_analysis_filter````). In central mode, this queries unique ````info.job_id```` and strictly binds unstamped documents to the authorized ````task_id```` to prevent forged ````custom```` variable access.
+* **Elasticsearch:** ````viewer_scope_es_filter()```` produces boolean filter structures matching the same permission parameters.
+
+5. AST-Based Static Security Gates (Build-Time Verification)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To prevent regression or developer oversight when writing new views, CAPEv2 includes automated static analysis tests in ````web/apiv2/test_visibility.py```` that parse code at the Abstract Syntax Tree (AST) level:
+
+* **````test_routed_task_view_enforces_visibility````:** Automatically parses the AST of all view functions in ````apiv2.views````, ````analysis.views````, ````compare.views````, ````guac.views````, and ````web.urls```` that accept task identifiers (````task_id````, ````analysis_number````, etc.). It asserts that they **must** reference a visibility guard (such as ````_deny_if_hidden```` or decorators). Only strictly verified infrastructure-level helper views (like ````tasks_machine````) are allowlisted.
+* **````test_cross_task_mongo_pivots_are_reviewed````:** Scans the AST of all view modules and asserts that any function issuing multi-document operations (````mongo_find````, ````mongo_aggregate````) must be listed in ````REVIEWED_MONGO_PIVOTS```` along with its tenant-scoping justification.
+* **````test_every_perform_search_caller_passes_viewer````:** Guarantees that no ````perform_search()```` query is executed without explicitly passing ````viewer=````, preventing un-scoped searches.

--- a/web/users/tenancy.py
+++ b/web/users/tenancy.py
@@ -12,6 +12,7 @@ def viewer_for(user) -> Viewer:
     crosses tenants; when off, only IdP-provisioned superusers (those with a
     linked allauth SocialAccount) do — a local createsuperuser does not.
     """
+    from django.conf import settings
     cfg = multitenancy_config()
     is_super = bool(getattr(user, "is_superuser", False))
     if not cfg.enabled:
@@ -23,8 +24,9 @@ def viewer_for(user) -> Viewer:
         # is_authenticated check, or anonymous requests on a disabled install get
         # is_local_admin=False and every can_read/visible_to guard denies the
         # private-default tasks upstream served (back-compat regression).
+        is_local = not getattr(settings, "WEB_AUTHENTICATION", False) or is_super or bool(getattr(user, "is_staff", False))
         return Viewer(user_id=getattr(user, "id", None), tenant_id=None, is_superuser=is_super,
-                      is_tenant_admin=False, is_local_admin=True)
+                      is_tenant_admin=False, is_local_admin=is_local)
 
     if not getattr(user, "is_authenticated", False):
         # MT enabled: an anonymous request stays public-only (no break-glass).
@@ -63,10 +65,14 @@ def viewer_for(user) -> Viewer:
 
 
 def _job_for(task) -> Job:
+    cfg = multitenancy_config()
+    visibility = getattr(task, "visibility", "private")
+    if not cfg.enabled and getattr(task, "user_id", None) is None:
+        visibility = "public"
     return Job(
         owner_id=getattr(task, "user_id", None),
         tenant_id=getattr(task, "tenant_id", None),
-        visibility=getattr(task, "visibility", "private"),
+        visibility=visibility,
     )
 
 

--- a/web/users/test_tenancy.py
+++ b/web/users/test_tenancy.py
@@ -159,6 +159,54 @@ def test_disabled_anonymous_is_backcompat_see_all(monkeypatch):
 
 
 @pytest.mark.django_db
+def test_disabled_auth_enabled_enforces_ownership(monkeypatch, settings):
+    """If multitenancy is OFF but WEB_AUTHENTICATION is ON, non-staff users
+    should be denied access to other users' private tasks, but can access
+    legacy/ownerless tasks."""
+    from lib.cuckoo.common.tenancy import MTConfig
+    from users.tenancy import can_view_task, can_manage_task, can_delete_task, viewer_for
+    import users.tenancy as ut
+
+    monkeypatch.setattr(ut, "multitenancy_config", lambda: MTConfig(False, "shared", "", True))
+    settings.WEB_AUTHENTICATION = True
+
+    owner = User.objects.create_user("owner", "owner@x.com", "x")
+    nonowner = User.objects.create_user("nonowner", "nonowner@x.com", "x")
+    staff = User.objects.create_user("staff", "staff@x.com", "x")
+    staff.is_staff = True
+
+    class PrivateOwnedTask:
+        user_id = owner.id
+        tenant_id = None
+        visibility = "private"
+
+    class LegacyTask:
+        user_id = None
+        tenant_id = None
+        visibility = "private"
+
+    # Owner can view, manage, delete
+    assert can_view_task(owner, PrivateOwnedTask()) is True
+    assert can_manage_task(owner, PrivateOwnedTask()) is True
+    assert can_delete_task(owner, PrivateOwnedTask()) is True
+
+    # Staff can view, manage, delete
+    assert can_view_task(staff, PrivateOwnedTask()) is True
+    assert can_manage_task(staff, PrivateOwnedTask()) is True
+    assert can_delete_task(staff, PrivateOwnedTask()) is True
+
+    # Non-owner can NOT view, manage, or delete another user's task
+    assert can_view_task(nonowner, PrivateOwnedTask()) is False
+    assert can_manage_task(nonowner, PrivateOwnedTask()) is False
+    assert can_delete_task(nonowner, PrivateOwnedTask()) is False
+
+    # Non-owner CAN view, manage, and delete legacy (ownerless) task
+    assert can_view_task(nonowner, LegacyTask()) is True
+    assert can_manage_task(nonowner, LegacyTask()) is True
+    assert can_delete_task(nonowner, LegacyTask()) is True
+
+
+@pytest.mark.django_db
 def test_enabled_anonymous_stays_public_only(monkeypatch):
     """Counterpart to B0: when MT is ENABLED (locked), an anonymous viewer must
     remain public-only — the disabled short-circuit must NOT leak into enabled

--- a/web/users/test_tenancy.py
+++ b/web/users/test_tenancy.py
@@ -164,7 +164,7 @@ def test_disabled_auth_enabled_enforces_ownership(monkeypatch, settings):
     should be denied access to other users' private tasks, but can access
     legacy/ownerless tasks."""
     from lib.cuckoo.common.tenancy import MTConfig
-    from users.tenancy import can_view_task, can_manage_task, can_delete_task, viewer_for
+    from users.tenancy import can_view_task, can_manage_task, can_delete_task
     import users.tenancy as ut
 
     monkeypatch.setattr(ut, "multitenancy_config", lambda: MTConfig(False, "shared", "", True))

--- a/web/web/tenancy_optional.py
+++ b/web/web/tenancy_optional.py
@@ -54,11 +54,24 @@ def multitenancy_config():
     return real()
 
 
+def _is_owner_or_staff(user, task):
+    from django.conf import settings
+    if getattr(settings, "WEB_AUTHENTICATION", False):
+        is_staff = bool(getattr(user, "is_staff", False) or getattr(user, "is_superuser", False))
+        if not is_staff:
+            owner_id = getattr(task, "user_id", None)
+            if owner_id is not None and owner_id != getattr(user, "id", None):
+                return False
+    return True
+
+
 def can_view_task(user, task):
     try:
         from users.tenancy import can_view_task as real
     except ImportError:
-        return not _mt_enabled()  # MT enabled+broken -> deny; genuinely absent -> allow (single-tenant)
+        if _mt_enabled():
+            return False
+        return _is_owner_or_staff(user, task)
     return real(user, task)
 
 
@@ -66,7 +79,9 @@ def can_toggle_task(user, task):
     try:
         from users.tenancy import can_toggle_task as real
     except ImportError:
-        return not _mt_enabled()
+        if _mt_enabled():
+            return False
+        return _is_owner_or_staff(user, task)
     return real(user, task)
 
 
@@ -74,7 +89,9 @@ def can_manage_task(user, task):
     try:
         from users.tenancy import can_manage_task as real
     except ImportError:
-        return not _mt_enabled()
+        if _mt_enabled():
+            return False
+        return _is_owner_or_staff(user, task)
     return real(user, task)
 
 
@@ -85,7 +102,9 @@ def can_delete_task(user, task):
     try:
         from users.tenancy import can_delete_task as real
     except ImportError:
-        return not _mt_enabled()
+        if _mt_enabled():
+            return False
+        return _is_owner_or_staff(user, task)
     return real(user, task)
 
 
@@ -96,7 +115,17 @@ def can_delete_job(viewer, task):
     try:
         from users.tenancy import can_delete_job as real
     except ImportError:
-        return not _mt_enabled()
+        if _mt_enabled():
+            return False
+        # If we only have a Viewer, we check viewer.user_id
+        from django.conf import settings
+        if getattr(settings, "WEB_AUTHENTICATION", False):
+            is_staff = getattr(viewer, "is_superuser", False) or getattr(viewer, "is_local_admin", False)
+            if not is_staff:
+                owner_id = getattr(task, "user_id", None)
+                if owner_id is not None and owner_id != getattr(viewer, "user_id", None):
+                    return False
+        return True
     return real(viewer, task)
 
 
@@ -107,7 +136,9 @@ def can_set_visibility_task(user, task, new_visibility):
     try:
         from users.tenancy import can_set_visibility_task as real
     except ImportError:
-        return not _mt_enabled()
+        if _mt_enabled():
+            return False
+        return _is_owner_or_staff(user, task)
     return real(user, task, new_visibility)
 
 


### PR DESCRIPTION
When multitenancy is disabled but WEB_AUTHENTICATION is enabled, access checks now enforce owner/staff-only visibility and mutation rights for private tasks while preserving legacy ownerless tasks. Local admin handling was also corrected for disabled MT mode, and the fallback optional-tenancy helpers now deny access when MT is enabled instead of allowing broad access.