### PR TITLE
Start Thread aux correctly and fix join warning

### DIFF
--- a/analyzer/linux/analyzer.py
+++ b/analyzer/linux/analyzer.py
@@ -278,7 +278,10 @@ class Analyzer:
                 log.debug('Initialized auxiliary module "%s"', module.__name__)
                 aux_avail.append(aux)
                 log.debug('Trying to start auxiliary module "%s"...', module.__name__)
-                aux.start()
+                if isinstance(aux, Thread):
+                    Thread.start(aux)
+                else:
+                    aux.start()
                 log.debug('Started auxiliary module "%s"', module.__name__)
                 aux_enabled.append(aux)
             except (NotImplementedError, AttributeError):

--- a/analyzer/windows/analyzer.py
+++ b/analyzer/windows/analyzer.py
@@ -602,7 +602,10 @@ class Analyzer:
                 aux_modules.append(aux)
                 configure_aux_from_data(aux)
                 log.debug('Trying to start auxiliary module "%s"...', module.__module__)
-                aux.start()
+                if isinstance(aux, Thread):
+                    Thread.start(aux)
+                else:
+                    aux.start()
             except (NotImplementedError, AttributeError) as e:
                 log.warning("Auxiliary module %s was not implemented: %s", module.__name__, e)
             except Exception as e:
@@ -874,7 +877,7 @@ class Analyzer:
                 if isinstance(aux, Thread):
                     aux.join(timeout=10)
                     if aux.is_alive():
-                        log.warning("Failed to join {aux} thread.")
+                        log.warning("Failed to join %s thread.", aux.__class__.__name__)
             except (NotImplementedError, AttributeError):
                 continue
             except Exception as e:


### PR DESCRIPTION
Handle auxiliary modules that are threading.Thread instances by calling Thread.start(aux) while preserving aux.start() for other types. Also correct the failed-join warning to include the auxiliary class name. Changes applied to analyzer/linux/analyzer.py and analyzer/windows/analyzer.py to improve thread startup reliability and logging clarity.