### PR TITLE
fix(web): Close span in process list in network overview

### DIFF
--- a/web/templates/analysis/network/_hosts_not_ajax.html
+++ b/web/templates/analysis/network/_hosts_not_ajax.html
@@ -44,7 +44,7 @@
                             {% if host.processes %}
                                 {% for p in host.processes %}
                                     <span class="badge bg-warning text-dark"
-                                          {% spaceless %}title="{% if p.source %}source: {{ p.source }}{% endif %}{% if p.resolved_hostname %}{% if p.source %} | {% endif %}resolved via {{ p.resolved_hostname }}{% endif %}{% if p.protocol %}{% if p.source or p.resolved_hostname %} | {% endif %}{{ p.protocol }}{% if p.dst_port %}:{{ p.dst_port }}{% endif %}{% endif %}"{% endspaceless %}
+                                          {% spaceless %}title="{% if p.source %}source: {{ p.source }}{% endif %}{% if p.resolved_hostname %}{% if p.source %} | {% endif %}resolved via {{ p.resolved_hostname }}{% endif %}{% if p.protocol %}{% if p.source or p.resolved_hostname %} | {% endif %}{{ p.protocol }}{% if p.dst_port %}:{{ p.dst_port }}{% endif %}{% endif %}"{% endspaceless %}>
                                         {% if p.process_name %}{{ p.process_name }}{% else %}(unknown){% endif %}{% if p.pid %} ({{ p.pid }}){% endif %}
                                     </span>
                                 {% endfor %}


### PR DESCRIPTION
Without this fix Network overview tab looks like this:
<img width="596" height="595" alt="image" src="https://github.com/user-attachments/assets/c343e9a6-10a4-4ec8-bfab-46749b37bd3a" />

and with this fix:

<img width="634" height="351" alt="image" src="https://github.com/user-attachments/assets/0929046e-16c6-45af-9975-e036696a7c8f" />
